### PR TITLE
Feature/#31 이메일 인증 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/docs/auth/auth.adoc
+++ b/src/docs/auth/auth.adoc
@@ -1,0 +1,36 @@
+ifndef::snippets[]
+:snippets: ./build/generated-snippets
+endif::[]
+
+= USER API 문서
+:icons: font
+:source-highlighter: highlight.js
+:toc: left
+:toclevels: 1
+:sectlinks:
+
+== API 목록
+
+link:../keeper.html[API 목록으로 돌아가기]
+
+== *이메일 인증*
+
+=== 요청
+
+==== Request
+
+include::{snippets}/email-auth/http-request.adoc[]
+
+==== Request Fields
+
+include::{snippets}/email-auth/request-fields.adoc[]
+
+=== 응답
+
+==== Response
+
+include::{snippets}/email-auth/http-response.adoc[]
+
+==== Response Fields
+
+include::{snippets}/email-auth/response-fields.adoc[]

--- a/src/docs/keeper.adoc
+++ b/src/docs/keeper.adoc
@@ -1,0 +1,14 @@
+ifndef::snippets[]
+:snippets: ./build/generated-snippets
+endif::[]
+
+= FOODBOWL API 문서
+:icons: font
+:source-highlighter: highlight.js
+:toc: left
+:toclevels: 1
+:sectlinks:
+
+== *MEMBER API*
+
+link:auth/auth.html[API 문서 보기]

--- a/src/main/java/com/keeper/homepage/domain/auth/api/SignUpController.java
+++ b/src/main/java/com/keeper/homepage/domain/auth/api/SignUpController.java
@@ -1,0 +1,26 @@
+package com.keeper.homepage.domain.auth.api;
+
+import com.keeper.homepage.domain.auth.application.EmailAuthService;
+import com.keeper.homepage.domain.auth.dto.request.EmailAuthRequest;
+import com.keeper.homepage.domain.auth.dto.response.EmailAuthResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/sign-up")
+public class SignUpController {
+
+  private final EmailAuthService emailAuthService;
+
+  @PostMapping("/email-auth")
+  public ResponseEntity<EmailAuthResponse> emailAuth(@RequestBody @Valid EmailAuthRequest request) {
+    int expiredSeconds = emailAuthService.emailAuth(request.getEmail());
+    return ResponseEntity.ok(EmailAuthResponse.from(expiredSeconds));
+  }
+}

--- a/src/main/java/com/keeper/homepage/domain/auth/application/EmailAuthService.java
+++ b/src/main/java/com/keeper/homepage/domain/auth/application/EmailAuthService.java
@@ -1,5 +1,11 @@
 package com.keeper.homepage.domain.auth.application;
 
+import com.keeper.homepage.domain.auth.dao.redis.EmailAuthRedisRepository;
+import com.keeper.homepage.domain.auth.entity.redis.EmailAuthRedis;
+import com.keeper.homepage.global.util.mail.MailUtil;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -8,8 +14,39 @@ import org.springframework.stereotype.Service;
 public class EmailAuthService {
 
   public static final int EMAIL_EXPIRED_SECONDS = 300; // 5분
+  public static final int AUTH_CODE_LENGTH = 10;
+
+  private static final Random RANDOM = new Random();
+
+  private final MailUtil mailUtil;
+  private final EmailAuthRedisRepository emailAuthRedisRepository;
 
   public int emailAuth(String email) {
+    String authCode = generateRandomAuthCode();
+    setAuthCodeInRedis(email, authCode);
+    sendKeeperAuthCodeMail(email, authCode);
     return EMAIL_EXPIRED_SECONDS;
+  }
+
+  private static String generateRandomAuthCode() {
+    char leftLimit = '0';
+    char rightLimit = 'z';
+
+    return RANDOM.ints(leftLimit, rightLimit + 1)
+        .filter(i -> Character.isAlphabetic(i) || Character.isDigit(i))
+        .limit(EmailAuthService.AUTH_CODE_LENGTH)
+        .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
+        .toString();
+  }
+
+  private void setAuthCodeInRedis(String email, String authCode) {
+    emailAuthRedisRepository.save(EmailAuthRedis.of(email, authCode));
+  }
+
+  void sendKeeperAuthCodeMail(String email, String authCode) {
+    List<String> toUserList = new ArrayList<>(List.of(email));
+    String subject = "KEEPER 인증코드 발송 메일입니다.";
+    String text = "KEEPER 인증코드는 " + authCode + " 입니다.";
+    mailUtil.sendMail(toUserList, subject, text);
   }
 }

--- a/src/main/java/com/keeper/homepage/domain/auth/application/EmailAuthService.java
+++ b/src/main/java/com/keeper/homepage/domain/auth/application/EmailAuthService.java
@@ -1,0 +1,15 @@
+package com.keeper.homepage.domain.auth.application;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class EmailAuthService {
+
+  public static final int EMAIL_EXPIRED_SECONDS = 300; // 5분
+
+  public int emailAuth(String email) {
+    return EMAIL_EXPIRED_SECONDS;
+  }
+}

--- a/src/main/java/com/keeper/homepage/domain/auth/application/EmailAuthService.java
+++ b/src/main/java/com/keeper/homepage/domain/auth/application/EmailAuthService.java
@@ -2,6 +2,8 @@ package com.keeper.homepage.domain.auth.application;
 
 import com.keeper.homepage.domain.auth.dao.redis.EmailAuthRedisRepository;
 import com.keeper.homepage.domain.auth.entity.redis.EmailAuthRedis;
+import com.keeper.homepage.global.error.BusinessException;
+import com.keeper.homepage.global.error.ErrorCode;
 import com.keeper.homepage.global.util.mail.MailUtil;
 import java.util.ArrayList;
 import java.util.List;
@@ -22,6 +24,10 @@ public class EmailAuthService {
   private final EmailAuthRedisRepository emailAuthRedisRepository;
 
   public int emailAuth(String email) {
+    if (emailAuthRedisRepository.existsById(email)) {
+      throw new BusinessException(email, "email", ErrorCode.TOO_MANY_REQUEST_AUTH_CODE);
+    }
+
     String authCode = generateRandomAuthCode();
     setAuthCodeInRedis(email, authCode);
     sendKeeperAuthCodeMail(email, authCode);

--- a/src/main/java/com/keeper/homepage/domain/auth/dao/redis/EmailAuthRedisRepository.java
+++ b/src/main/java/com/keeper/homepage/domain/auth/dao/redis/EmailAuthRedisRepository.java
@@ -1,0 +1,8 @@
+package com.keeper.homepage.domain.auth.dao.redis;
+
+import com.keeper.homepage.domain.auth.entity.redis.EmailAuthRedis;
+import org.springframework.data.repository.CrudRepository;
+
+public interface EmailAuthRedisRepository extends CrudRepository<EmailAuthRedis, String> {
+
+}

--- a/src/main/java/com/keeper/homepage/domain/auth/dto/request/EmailAuthRequest.java
+++ b/src/main/java/com/keeper/homepage/domain/auth/dto/request/EmailAuthRequest.java
@@ -1,0 +1,21 @@
+package com.keeper.homepage.domain.auth.dto.request;
+
+import static lombok.AccessLevel.PRIVATE;
+
+import jakarta.validation.constraints.Email;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = PRIVATE)
+@AllArgsConstructor(access = PRIVATE)
+public class EmailAuthRequest {
+
+  @Email
+  private String email;
+
+  public static EmailAuthRequest from(String email) {
+    return new EmailAuthRequest(email);
+  }
+}

--- a/src/main/java/com/keeper/homepage/domain/auth/dto/response/EmailAuthResponse.java
+++ b/src/main/java/com/keeper/homepage/domain/auth/dto/response/EmailAuthResponse.java
@@ -1,0 +1,17 @@
+package com.keeper.homepage.domain.auth.dto.response;
+
+import static lombok.AccessLevel.PRIVATE;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = PRIVATE)
+public class EmailAuthResponse {
+
+  private int expiredSeconds;
+
+  public static EmailAuthResponse from(int expiredSeconds) {
+    return new EmailAuthResponse(expiredSeconds);
+  }
+}

--- a/src/main/java/com/keeper/homepage/domain/auth/entity/redis/EmailAuthRedis.java
+++ b/src/main/java/com/keeper/homepage/domain/auth/entity/redis/EmailAuthRedis.java
@@ -1,0 +1,23 @@
+package com.keeper.homepage.domain.auth.entity.redis;
+
+import static com.keeper.homepage.domain.auth.application.EmailAuthService.EMAIL_EXPIRED_SECONDS;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+
+@Getter
+@RedisHash(value = "emailAuth", timeToLive = EMAIL_EXPIRED_SECONDS)
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class EmailAuthRedis {
+
+  @Id
+  private final String email;
+  private final String authCode;
+
+  public static EmailAuthRedis of(String email, String authCode) {
+    return new EmailAuthRedis(email, authCode);
+  }
+}

--- a/src/main/java/com/keeper/homepage/global/config/security/SecurityConfiguration.java
+++ b/src/main/java/com/keeper/homepage/global/config/security/SecurityConfiguration.java
@@ -34,7 +34,7 @@ public class SecurityConfiguration {
   @Bean
   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
     http.authorizeHttpRequests()
-        .requestMatchers("/docs/*", "/keeper_files/**", "/auth-test").permitAll()
+        .requestMatchers("/docs/*", "/keeper_files/**", "/auth-test", "/sign-up/**").permitAll()
         .anyRequest().hasRole("회원")
         .and()
         .httpBasic().disable()

--- a/src/main/java/com/keeper/homepage/global/error/ErrorCode.java
+++ b/src/main/java/com/keeper/homepage/global/error/ErrorCode.java
@@ -11,6 +11,7 @@ public enum ErrorCode {
 
   // AUTH
   TOKEN_NOT_AVAILABLE("유효하지 않은 토큰입니다.", HttpStatus.UNAUTHORIZED),
+  TOO_MANY_REQUEST_AUTH_CODE("인증 코드가 만료되기 전에 다시 보내실 수 없습니다.", HttpStatus.BAD_REQUEST),
   // MEMBER
   MEMBER_NOT_FOUND("해당 회원을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
   ;

--- a/src/main/java/com/keeper/homepage/global/util/mail/MailUtil.java
+++ b/src/main/java/com/keeper/homepage/global/util/mail/MailUtil.java
@@ -1,0 +1,22 @@
+package com.keeper.homepage.global.util.mail;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MailUtil {
+
+  private final JavaMailSender javaMailSender;
+
+  public void sendMail(List<String> toUserList, String subject, String text) {
+    SimpleMailMessage simpleMessage = new SimpleMailMessage();
+    simpleMessage.setTo(toUserList.toArray(new String[toUserList.size()]));
+    simpleMessage.setSubject(subject);
+    simpleMessage.setText(text);
+    javaMailSender.send(simpleMessage);
+  }
+}

--- a/src/main/java/com/keeper/homepage/global/util/mail/MailUtil.java
+++ b/src/main/java/com/keeper/homepage/global/util/mail/MailUtil.java
@@ -4,9 +4,9 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
-import org.springframework.stereotype.Service;
+import org.springframework.stereotype.Component;
 
-@Service
+@Component
 @RequiredArgsConstructor
 public class MailUtil {
 

--- a/src/test/java/com/keeper/homepage/IntegrationTest.java
+++ b/src/test/java/com/keeper/homepage/IntegrationTest.java
@@ -13,6 +13,8 @@ import com.keeper.homepage.domain.about.dao.StaticWriteContentRepository;
 import com.keeper.homepage.domain.about.dao.StaticWriteSubtitleImageRepository;
 import com.keeper.homepage.domain.about.dao.StaticWriteTitleRepository;
 import com.keeper.homepage.domain.auth.application.EmailAuthService;
+import com.keeper.homepage.domain.auth.dao.redis.EmailAuthRedisRepository;
+import com.keeper.homepage.domain.auth.entity.redis.EmailAuthRedis;
 import com.keeper.homepage.domain.file.dao.FileRepository;
 import com.keeper.homepage.domain.member.dao.role.MemberJobRepository;
 import com.keeper.homepage.domain.thumbnail.dao.ThumbnailRepository;
@@ -59,6 +61,9 @@ public class IntegrationTest {
 
   @SpyBean
   protected StaticWriteContentRepository staticWriteContentRepository;
+
+  @Autowired
+  protected EmailAuthRedisRepository emailAuthRedisRepository;
 
   /******* Service *******/
   @SpyBean

--- a/src/test/java/com/keeper/homepage/IntegrationTest.java
+++ b/src/test/java/com/keeper/homepage/IntegrationTest.java
@@ -18,6 +18,7 @@ import com.keeper.homepage.domain.member.dao.role.MemberJobRepository;
 import com.keeper.homepage.domain.thumbnail.dao.ThumbnailRepository;
 import com.keeper.homepage.global.config.security.JwtTokenProvider;
 import com.keeper.homepage.global.util.file.FileUtil;
+import com.keeper.homepage.global.util.mail.MailUtil;
 import com.keeper.homepage.global.util.redis.RedisUtil;
 import com.keeper.homepage.global.util.thumbnail.ThumbnailTestHelper;
 import com.keeper.homepage.global.util.thumbnail.ThumbnailUtil;
@@ -62,6 +63,9 @@ public class IntegrationTest {
   /******* Service *******/
   @SpyBean
   protected EmailAuthService emailAuthService;
+
+  @Autowired
+  protected MailUtil mailUtil;
 
   /******* Helper *******/
 

--- a/src/test/java/com/keeper/homepage/IntegrationTest.java
+++ b/src/test/java/com/keeper/homepage/IntegrationTest.java
@@ -7,10 +7,12 @@ import static org.springframework.restdocs.operation.preprocess.Preprocessors.mo
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.keeper.homepage.domain.about.StaticWriteTestHelper;
 import com.keeper.homepage.domain.about.dao.StaticWriteContentRepository;
 import com.keeper.homepage.domain.about.dao.StaticWriteSubtitleImageRepository;
 import com.keeper.homepage.domain.about.dao.StaticWriteTitleRepository;
+import com.keeper.homepage.domain.auth.application.EmailAuthService;
 import com.keeper.homepage.domain.file.dao.FileRepository;
 import com.keeper.homepage.domain.member.dao.role.MemberJobRepository;
 import com.keeper.homepage.domain.thumbnail.dao.ThumbnailRepository;
@@ -56,6 +58,10 @@ public class IntegrationTest {
 
   @SpyBean
   protected StaticWriteContentRepository staticWriteContentRepository;
+
+  /******* Service *******/
+  @SpyBean
+  protected EmailAuthService emailAuthService;
 
   /******* Helper *******/
 
@@ -130,5 +136,14 @@ public class IntegrationTest {
 
   private static String getTodayThumbnailFilesPath() {
     return DEFAULT_THUMBNAIL_PATH + LocalDate.now();
+  }
+
+  protected String asJsonString(final Object obj) {
+    try {
+      final ObjectMapper objectMapper = new ObjectMapper();
+      return objectMapper.writeValueAsString(obj);
+    } catch (IOException e) {
+      throw new RuntimeException();
+    }
   }
 }

--- a/src/test/java/com/keeper/homepage/domain/auth/api/SignUpControllerTest.java
+++ b/src/test/java/com/keeper/homepage/domain/auth/api/SignUpControllerTest.java
@@ -1,0 +1,50 @@
+package com.keeper.homepage.domain.auth.api;
+
+import static com.keeper.homepage.domain.auth.application.EmailAuthService.EMAIL_EXPIRED_SECONDS;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.keeper.homepage.IntegrationTest;
+import com.keeper.homepage.domain.auth.dto.request.EmailAuthRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class SignUpControllerTest extends IntegrationTest {
+
+  @Nested
+  @DisplayName("이메일 인증 테스트")
+  class EmailAuth {
+
+    private static final String VALID_EMAIL = "email@email.com";
+
+    @Test
+    @DisplayName("유효한 요청이면 이메일 인증은 성공해야 한다.")
+    void should_successfully_when_validRequest() throws Exception {
+      EmailAuthRequest request = EmailAuthRequest.from(VALID_EMAIL);
+      when(emailAuthService.emailAuth(any())).thenReturn(EMAIL_EXPIRED_SECONDS);
+      mockMvc.perform(post("/sign-up/email-auth")
+              .contentType(APPLICATION_JSON)
+              .content(asJsonString(request)))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.expiredSeconds").value(EMAIL_EXPIRED_SECONDS))
+          .andDo(document("email-auth",
+              requestFields(
+                  fieldWithPath("email").description("인증을 보낼 이메일을 보내시면 됩니다.")
+              ),
+              responseFields(
+                  fieldWithPath("expiredSeconds").description("인증코드 유효 기간 입니다. (단위: 초)")
+              )));
+
+    }
+  }
+
+}

--- a/src/test/java/com/keeper/homepage/domain/auth/api/test/AuthTestControllerTest.java
+++ b/src/test/java/com/keeper/homepage/domain/auth/api/test/AuthTestControllerTest.java
@@ -1,4 +1,4 @@
-package com.keeper.homepage.domain.auth.api;
+package com.keeper.homepage.domain.auth.api.test;
 
 import static com.keeper.homepage.domain.member.entity.job.MemberJob.MemberJobType.ROLE_회원;
 import static com.keeper.homepage.domain.member.entity.job.MemberJob.MemberJobType.ROLE_회장;

--- a/src/test/java/com/keeper/homepage/domain/auth/application/EmailAuthServiceTest.java
+++ b/src/test/java/com/keeper/homepage/domain/auth/application/EmailAuthServiceTest.java
@@ -1,0 +1,42 @@
+package com.keeper.homepage.domain.auth.application;
+
+import static com.keeper.homepage.domain.auth.application.EmailAuthService.EMAIL_EXPIRED_SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+
+import com.keeper.homepage.IntegrationTest;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class EmailAuthServiceTest extends IntegrationTest {
+
+  @Test
+  @DisplayName("알파벳과 숫자로 이루어진 인증 코드가 잘 생성되어야 하고, Redis에 해당 내용이 들어있어야 한다.")
+  void should_generateSuccessfullyAndInRedis() {
+    doNothing().when(emailAuthService).sendKeeperAuthCodeMail(anyString(), anyString());
+    String validEmail = String.format("%s@%s.%s", getRandomUUIDLengthWith(5),
+        getRandomUUIDLengthWith(5), getRandomUUIDLengthWith(3));
+    assertThat(emailAuthRedisRepository.findById(validEmail)).isEmpty();
+
+    int result = emailAuthService.emailAuth(validEmail);
+
+    assertThat(result).isEqualTo(EMAIL_EXPIRED_SECONDS);
+    assertThat(emailAuthRedisRepository.findById(validEmail)).isNotEmpty();
+    String authCode = emailAuthRedisRepository.findById(validEmail).orElseThrow().getAuthCode();
+    assertThat(isEveryCharacterAlphabeticOrDigit(authCode)).isTrue();
+  }
+
+  private static boolean isEveryCharacterAlphabeticOrDigit(String authCode) {
+    return authCode.chars()
+        .allMatch(c -> Character.isAlphabetic(c) || Character.isDigit(c));
+  }
+
+  private static String getRandomUUIDLengthWith(int length) {
+    String randomString = UUID.randomUUID()
+        .toString();
+    length = Math.min(length, randomString.length());
+    return randomString.substring(0, length);
+  }
+}

--- a/src/test/java/com/keeper/homepage/global/util/mail/MailUtilTest.java
+++ b/src/test/java/com/keeper/homepage/global/util/mail/MailUtilTest.java
@@ -1,0 +1,15 @@
+package com.keeper.homepage.global.util.mail;
+
+import com.keeper.homepage.IntegrationTest;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class MailUtilTest extends IntegrationTest {
+
+  @Test
+  @DisplayName("메일을 보낼 때 에러가 발생하지 않아야 한다.")
+  void should_doesNotThrow_when_sendEmail() {
+    mailUtil.sendMail(List.of("test@test.com"), "제목", "내용");
+  }
+}


### PR DESCRIPTION
## 🔥 Related Issue

close: #31

## 📝 Description

이메일 인증 API 추가

**커밋 내역을 참고하시면 실제 기능 개발 전에 API 문서를 빠르게 뽑아내실 수 있습니다!**

1. **`Controller` & 필요한 껍데기 `Service` 구현 및 API 문서 작성** -> 
2. **급하다면 API 문서부터 프론트분에게 전달 후 다른 기능 개발 가능** -> 
3. **놓친 `Controller` TC 추가** -> 
4. **서비스 실제 로직 구현** -> 
5. **잘 동작할까 불안한 로직은 TC로 작성**
 
## ⭐️ Review

`application.yml`이 변경되었습니다.