### PR TITLE
Feature/#43 @auth id 대신 @login member 사용

### DIFF
--- a/src/main/java/com/keeper/homepage/domain/auth/api/test/AuthTestController.java
+++ b/src/main/java/com/keeper/homepage/domain/auth/api/test/AuthTestController.java
@@ -1,6 +1,7 @@
 package com.keeper.homepage.domain.auth.api.test;
 
-import com.keeper.homepage.global.config.security.annotation.AuthId;
+import com.keeper.homepage.domain.member.entity.Member;
+import com.keeper.homepage.global.config.security.annotation.LoginMember;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -19,18 +20,18 @@ public class AuthTestController {
 
   @Secured("ROLE_회원")
   @GetMapping("/user")
-  public String userToken(@AuthId long myId) {
-    return String.valueOf(myId);
+  public String userToken(@LoginMember Member loginMember) {
+    return String.valueOf(loginMember.getId());
   }
 
   @Secured("ROLE_회장")
   @GetMapping("/admin")
-  public String adminToken(@AuthId long myId) {
-    return String.valueOf(myId);
+  public String adminToken(@LoginMember Member loginMember) {
+    return String.valueOf(loginMember.getId());
   }
 
   @GetMapping("/refresh")
-  public String refreshToken(@AuthId long myId) {
-    return String.valueOf(myId);
+  public String refreshToken(@LoginMember Member loginMember) {
+    return String.valueOf(loginMember.getId());
   }
 }

--- a/src/main/java/com/keeper/homepage/domain/auth/api/test/AuthTestController.java
+++ b/src/main/java/com/keeper/homepage/domain/auth/api/test/AuthTestController.java
@@ -31,7 +31,7 @@ public class AuthTestController {
   }
 
   @GetMapping("/refresh")
-  public String refreshToken(@LoginMember Member loginMember) {
-    return String.valueOf(loginMember.getId());
+  public String refreshToken() {
+    return "refresh!";
   }
 }

--- a/src/main/java/com/keeper/homepage/global/config/security/annotation/LoginMember.java
+++ b/src/main/java/com/keeper/homepage/global/config/security/annotation/LoginMember.java
@@ -7,7 +7,7 @@ import java.lang.annotation.Target;
 
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
-public @interface AuthId {
+public @interface LoginMember {
 
   boolean required() default true;
 }

--- a/src/main/java/com/keeper/homepage/global/config/security/annotation/LoginMemberArgumentResolver.java
+++ b/src/main/java/com/keeper/homepage/global/config/security/annotation/LoginMemberArgumentResolver.java
@@ -1,5 +1,8 @@
 package com.keeper.homepage.global.config.security.annotation;
 
+import com.keeper.homepage.domain.member.dao.MemberRepository;
+import com.keeper.homepage.global.error.BusinessException;
+import com.keeper.homepage.global.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.MethodParameter;
 import org.springframework.security.core.Authentication;
@@ -12,17 +15,21 @@ import org.springframework.web.method.support.ModelAndViewContainer;
 
 @Component
 @RequiredArgsConstructor
-public class AuthIdArgumentResolver implements HandlerMethodArgumentResolver {
+public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolver {
+
+  private final MemberRepository memberRepository;
 
   @Override
   public boolean supportsParameter(MethodParameter parameter) {
-    return parameter.hasParameterAnnotation(AuthId.class);
+    return parameter.hasParameterAnnotation(LoginMember.class);
   }
 
   @Override
   public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
       NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
     Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-    return Long.parseLong(authentication.getName());
+    long loginMemberId = Long.parseLong(authentication.getName());
+    return memberRepository.findById(loginMemberId)
+        .orElseThrow(() -> new BusinessException(loginMemberId, "JWT", ErrorCode.MEMBER_NOT_FOUND));
   }
 }

--- a/src/main/java/com/keeper/homepage/global/config/web/WebMvcConfiguration.java
+++ b/src/main/java/com/keeper/homepage/global/config/web/WebMvcConfiguration.java
@@ -2,7 +2,7 @@ package com.keeper.homepage.global.config.web;
 
 import static com.keeper.homepage.global.util.file.server.FileServerConstants.RESOURCE_PATH;
 
-import com.keeper.homepage.global.config.security.annotation.AuthIdArgumentResolver;
+import com.keeper.homepage.global.config.security.annotation.LoginMemberArgumentResolver;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
@@ -14,11 +14,11 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @RequiredArgsConstructor
 public class WebMvcConfiguration implements WebMvcConfigurer {
 
-  private final AuthIdArgumentResolver authIdArgumentResolver;
+  private final LoginMemberArgumentResolver loginMemberArgumentResolver;
 
   @Override
   public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
-    resolvers.add(authIdArgumentResolver);
+    resolvers.add(loginMemberArgumentResolver);
   }
 
   @Override

--- a/src/test/java/com/keeper/homepage/domain/auth/api/AuthTestControllerTest.java
+++ b/src/test/java/com/keeper/homepage/domain/auth/api/AuthTestControllerTest.java
@@ -24,13 +24,15 @@ import org.springframework.test.web.servlet.ResultActions;
 
 class AuthTestControllerTest extends IntegrationTest {
 
-  private final long adminId = 0L;
-  private final long userId = 1L;
+  private long adminId;
+  private long userId;
   private String adminToken;
   private String userToken;
 
   @BeforeEach
   void setup() {
+    adminId = memberTestHelper.builder().build().getId();
+    userId = memberTestHelper.builder().build().getId();
     adminToken = jwtTokenProvider.createAccessToken(ACCESS_TOKEN, adminId, ROLE_회원, ROLE_회장);
     userToken = jwtTokenProvider.createAccessToken(ACCESS_TOKEN, userId, ROLE_회원);
   }

--- a/src/test/java/com/keeper/homepage/domain/auth/api/AuthTestControllerTest.java
+++ b/src/test/java/com/keeper/homepage/domain/auth/api/AuthTestControllerTest.java
@@ -138,7 +138,7 @@ class AuthTestControllerTest extends IntegrationTest {
 
         callRefreshApi(accessCookie)
             .andExpect(status().isOk())
-            .andExpect(content().string(String.valueOf(adminId)));
+            .andExpect(content().string("refresh!"));
       }
 
       @Test


### PR DESCRIPTION
## 🔥 Related Issue

close: #43 

## 📝 Description

`@AuthId`로 로그인한 회원의 아이디를 가져오도록 되어 있었는데, 잘 사용하지 않을 것 같아 `@LoginMember` 어노테이션으로 변경 예정

AS-IS
```java
public void login(@AuthId long authId) {
  Member loginMember = memberRepository.findById(authId).orElseThrow();
}
```

TO-BE
```java
public void login(@LoginMember Member loginMember) { }
```

## ⭐️ Review

남기고 싶은 내용을 설명해주세요.