### PR TITLE
Feature/#30 회원가입 구현

### DIFF
--- a/src/docs/auth/auth.adoc
+++ b/src/docs/auth/auth.adoc
@@ -13,6 +13,28 @@ endif::[]
 
 link:../keeper.html[API 목록으로 돌아가기]
 
+== *회원 가입*
+
+=== 요청
+
+==== Request
+
+include::{snippets}/sign-up/http-request.adoc[]
+
+==== Request Fields
+
+include::{snippets}/sign-up/request-fields.adoc[]
+
+=== 응답
+
+==== Response
+
+include::{snippets}/sign-up/http-response.adoc[]
+
+==== Response Headers
+
+include::{snippets}/sign-up/response-headers.adoc[]
+
 == *이메일 인증*
 
 === 요청

--- a/src/main/java/com/keeper/homepage/domain/auth/api/SignUpController.java
+++ b/src/main/java/com/keeper/homepage/domain/auth/api/SignUpController.java
@@ -1,9 +1,12 @@
 package com.keeper.homepage.domain.auth.api;
 
 import com.keeper.homepage.domain.auth.application.EmailAuthService;
+import com.keeper.homepage.domain.auth.application.SignUpService;
 import com.keeper.homepage.domain.auth.dto.request.EmailAuthRequest;
+import com.keeper.homepage.domain.auth.dto.request.SignUpRequest;
 import com.keeper.homepage.domain.auth.dto.response.EmailAuthResponse;
 import jakarta.validation.Valid;
+import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -16,7 +19,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/sign-up")
 public class SignUpController {
 
+  private final SignUpService signUpService;
   private final EmailAuthService emailAuthService;
+
+  @PostMapping
+  public ResponseEntity<Void> signUp(@RequestBody @Valid SignUpRequest request) {
+  long memberId = signUpService.signUp(request);
+    return ResponseEntity.created(URI.create("/members/" + memberId)).build();
+  }
 
   @PostMapping("/email-auth")
   public ResponseEntity<EmailAuthResponse> emailAuth(@RequestBody @Valid EmailAuthRequest request) {

--- a/src/main/java/com/keeper/homepage/domain/auth/application/CheckDuplicateService.java
+++ b/src/main/java/com/keeper/homepage/domain/auth/application/CheckDuplicateService.java
@@ -1,0 +1,26 @@
+package com.keeper.homepage.domain.auth.application;
+
+import com.keeper.homepage.domain.member.dao.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CheckDuplicateService {
+
+  private final MemberRepository memberRepository;
+
+  public boolean isDuplicateEmail(String email) {
+    return memberRepository.existsByProfileEmailAddress(email);
+  }
+
+  public boolean isDuplicateLoginId(String loginId) {
+    return memberRepository.existsByProfileLoginId(loginId);
+  }
+
+  public boolean isDuplicateStudentID(String studentId) {
+    return memberRepository.existsByProfileStudentId(studentId);
+  }
+}

--- a/src/main/java/com/keeper/homepage/domain/auth/application/SignUpService.java
+++ b/src/main/java/com/keeper/homepage/domain/auth/application/SignUpService.java
@@ -1,6 +1,14 @@
 package com.keeper.homepage.domain.auth.application;
 
+import static com.keeper.homepage.global.error.ErrorCode.AUTH_CODE_EXPIRED;
+import static com.keeper.homepage.global.error.ErrorCode.AUTH_CODE_MISMATCH;
+
+import com.keeper.homepage.domain.auth.dao.redis.EmailAuthRedisRepository;
 import com.keeper.homepage.domain.auth.dto.request.SignUpRequest;
+import com.keeper.homepage.domain.member.dao.MemberRepository;
+import com.keeper.homepage.domain.member.entity.Member;
+import com.keeper.homepage.global.error.BusinessException;
+import jakarta.validation.constraints.Email;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -9,8 +17,28 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class SignUpService {
 
+  private final MemberRepository memberRepository;
+  private final EmailAuthRedisRepository emailAuthRedisRepository;
+
   @Transactional
   public long signUp(SignUpRequest request) {
-    return 0;
+    String actualAuthCode = getActualAuthCode(request.getEmail());
+    checkAuthCodeMatch(request.getAuthCode(), actualAuthCode);
+    return memberRepository.save(Member.builder()
+            .profile(request.toMemberProfile())
+            .build())
+        .getId();
+  }
+
+  private static void checkAuthCodeMatch(String requestAuthCode, String actualAuthCode) {
+    if (!actualAuthCode.equals(requestAuthCode)) {
+      throw new BusinessException(requestAuthCode, "authCode", AUTH_CODE_MISMATCH);
+    }
+  }
+
+  private String getActualAuthCode(@Email String email) {
+    return emailAuthRedisRepository.findById(email)
+        .orElseThrow(() -> new BusinessException(email, "email", AUTH_CODE_EXPIRED))
+        .getAuthCode();
   }
 }

--- a/src/main/java/com/keeper/homepage/domain/auth/application/SignUpService.java
+++ b/src/main/java/com/keeper/homepage/domain/auth/application/SignUpService.java
@@ -28,7 +28,9 @@ public class SignUpService {
 
   @Transactional
   public long signUp(SignUpRequest request) {
-    checkIsDuplicate(request.getEmail(), request.getLoginId(), request.getStudentId());
+    checkIsDuplicateEmail(request.getEmail());
+    checkIsDuplicateLoginId(request.getLoginId());
+    checkIsDuplicateStudentId(request.getStudentId());
 
     String actualAuthCode = getActualAuthCode(request.getEmail());
     checkAuthCodeMatch(request.getAuthCode(), actualAuthCode);
@@ -38,13 +40,19 @@ public class SignUpService {
         .getId();
   }
 
-  private void checkIsDuplicate(String email, String loginId, String studentId) {
+  private void checkIsDuplicateEmail(String email) {
     if (checkDuplicateService.isDuplicateEmail(email)) {
       throw new BusinessException(email, "email", MEMBER_EMAIL_DUPLICATE);
     }
+  }
+
+  private void checkIsDuplicateLoginId(String loginId) {
     if (checkDuplicateService.isDuplicateLoginId(loginId)) {
       throw new BusinessException(loginId, "loginId", MEMBER_LOGIN_ID_DUPLICATE);
     }
+  }
+
+  private void checkIsDuplicateStudentId(String studentId) {
     if (checkDuplicateService.isDuplicateStudentID(studentId)) {
       throw new BusinessException(studentId, "studentId", MEMBER_STUDENT_ID_DUPLICATE);
     }

--- a/src/main/java/com/keeper/homepage/domain/auth/application/SignUpService.java
+++ b/src/main/java/com/keeper/homepage/domain/auth/application/SignUpService.java
@@ -2,6 +2,9 @@ package com.keeper.homepage.domain.auth.application;
 
 import static com.keeper.homepage.global.error.ErrorCode.AUTH_CODE_EXPIRED;
 import static com.keeper.homepage.global.error.ErrorCode.AUTH_CODE_MISMATCH;
+import static com.keeper.homepage.global.error.ErrorCode.MEMBER_EMAIL_DUPLICATE;
+import static com.keeper.homepage.global.error.ErrorCode.MEMBER_LOGIN_ID_DUPLICATE;
+import static com.keeper.homepage.global.error.ErrorCode.MEMBER_STUDENT_ID_DUPLICATE;
 
 import com.keeper.homepage.domain.auth.dao.redis.EmailAuthRedisRepository;
 import com.keeper.homepage.domain.auth.dto.request.SignUpRequest;
@@ -19,15 +22,30 @@ public class SignUpService {
 
   private final MemberRepository memberRepository;
   private final EmailAuthRedisRepository emailAuthRedisRepository;
+  private final CheckDuplicateService checkDuplicateService;
 
   @Transactional
   public long signUp(SignUpRequest request) {
+    checkIsDuplicate(request.getEmail(), request.getLoginId(), request.getStudentId());
+
     String actualAuthCode = getActualAuthCode(request.getEmail());
     checkAuthCodeMatch(request.getAuthCode(), actualAuthCode);
     return memberRepository.save(Member.builder()
             .profile(request.toMemberProfile())
             .build())
         .getId();
+  }
+
+  private void checkIsDuplicate(String email, String loginId, String studentId) {
+    if (checkDuplicateService.isDuplicateEmail(email)) {
+      throw new BusinessException(email, "email", MEMBER_EMAIL_DUPLICATE);
+    }
+    if (checkDuplicateService.isDuplicateLoginId(loginId)) {
+      throw new BusinessException(loginId, "loginId", MEMBER_LOGIN_ID_DUPLICATE);
+    }
+    if (checkDuplicateService.isDuplicateStudentID(studentId)) {
+      throw new BusinessException(studentId, "studentId", MEMBER_STUDENT_ID_DUPLICATE);
+    }
   }
 
   private static void checkAuthCodeMatch(String requestAuthCode, String actualAuthCode) {

--- a/src/main/java/com/keeper/homepage/domain/auth/application/SignUpService.java
+++ b/src/main/java/com/keeper/homepage/domain/auth/application/SignUpService.java
@@ -1,0 +1,16 @@
+package com.keeper.homepage.domain.auth.application;
+
+import com.keeper.homepage.domain.auth.dto.request.SignUpRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class SignUpService {
+
+  @Transactional
+  public long signUp(SignUpRequest request) {
+    return 0;
+  }
+}

--- a/src/main/java/com/keeper/homepage/domain/auth/dto/request/SignUpRequest.java
+++ b/src/main/java/com/keeper/homepage/domain/auth/dto/request/SignUpRequest.java
@@ -13,7 +13,9 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.hibernate.validator.constraints.Length;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Getter
 @NoArgsConstructor(access = PRIVATE)
@@ -32,6 +34,7 @@ public class SignUpRequest {
   @Email
   private String email;
   @Pattern(regexp = "^(?=.*?[A-Za-z])(?=.*?\\d).{8,20}$", message = PASSWORD_INVALID)
+  @Setter
   private String password;
   @Pattern(regexp = "^[a-zA-Z가-힣]{1,20}", message = REAL_NAME_INVALID)
   private String realName;
@@ -44,11 +47,11 @@ public class SignUpRequest {
   @Pattern(regexp = "^[0-9]*$", message = NICKNAME_INVALID)
   private String studentId;
 
-  public Profile toMemberProfile() {
+  public Profile toMemberProfile(PasswordEncoder passwordEncoder) {
     return Profile.builder()
         .loginId(this.loginId)
         .emailAddress(this.email)
-        .password(this.password)
+        .password(passwordEncoder.encode(this.password))
         .realName(this.realName)
         .nickname(this.nickname)
         .birthday(this.birthday)

--- a/src/main/java/com/keeper/homepage/domain/auth/dto/request/SignUpRequest.java
+++ b/src/main/java/com/keeper/homepage/domain/auth/dto/request/SignUpRequest.java
@@ -1,0 +1,45 @@
+package com.keeper.homepage.domain.auth.dto.request;
+
+import static com.keeper.homepage.domain.auth.application.EmailAuthService.AUTH_CODE_LENGTH;
+import static lombok.AccessLevel.PACKAGE;
+import static lombok.AccessLevel.PRIVATE;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Pattern;
+import java.time.LocalDate;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.Length;
+
+@Getter
+@NoArgsConstructor(access = PRIVATE)
+@AllArgsConstructor(access = PACKAGE)
+@Builder
+public class SignUpRequest {
+
+  public static final String LOGIN_ID_INVALID = "로그인 아이디는 4~12자 영어, 숫자, '_'만 가능합니다.";
+  public static final String PASSWORD_INVALID = "비밀번호는 8~20자여야 하고 영어, 숫자가 포함되어야 합니다.";
+  public static final String REAL_NAME_INVALID = "실명은 1~20자 한글, 영어만 가능합니다.";
+  public static final String NICKNAME_INVALID = "닉네임은 1~16자 한글, 영어, 숫자만 가능합니다.";
+  public static final String STUDENT_ID_INVALID = "학번은 숫자만 가능합니다.";
+
+  @Pattern(regexp = "^[a-zA-Z0-9_]{4,12}", message = LOGIN_ID_INVALID)
+  private String loginId;
+  @Email
+  private String email;
+  @Pattern(regexp = "^(?=.*?[A-Za-z])(?=.*?\\d).{8,20}$", message = PASSWORD_INVALID)
+  private String password;
+  @Pattern(regexp = "^[a-zA-Z가-힣]{1,20}", message = REAL_NAME_INVALID)
+  private String realName;
+  @Pattern(regexp = "^[a-zA-Z0-9가-힣ㄱ-ㅎㅏ-ㅣ]{1,16}", message = NICKNAME_INVALID)
+  private String nickname;
+  @Length(min = AUTH_CODE_LENGTH, max = AUTH_CODE_LENGTH)
+  private String authCode;
+  @JsonFormat(pattern = "yyyy.MM.dd")
+  private LocalDate birthday;
+  @Pattern(regexp = "^[0-9]*$", message = NICKNAME_INVALID)
+  private String studentId;
+}

--- a/src/main/java/com/keeper/homepage/domain/auth/dto/request/SignUpRequest.java
+++ b/src/main/java/com/keeper/homepage/domain/auth/dto/request/SignUpRequest.java
@@ -5,6 +5,7 @@ import static lombok.AccessLevel.PACKAGE;
 import static lombok.AccessLevel.PRIVATE;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.keeper.homepage.domain.member.entity.embedded.Profile;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.Pattern;
 import java.time.LocalDate;
@@ -42,4 +43,16 @@ public class SignUpRequest {
   private LocalDate birthday;
   @Pattern(regexp = "^[0-9]*$", message = NICKNAME_INVALID)
   private String studentId;
+
+  public Profile toMemberProfile() {
+    return Profile.builder()
+        .loginId(this.loginId)
+        .emailAddress(this.email)
+        .password(this.password)
+        .realName(this.realName)
+        .nickname(this.nickname)
+        .birthday(this.birthday)
+        .studentId(this.studentId)
+        .build();
+  }
 }

--- a/src/main/java/com/keeper/homepage/domain/member/dao/MemberRepository.java
+++ b/src/main/java/com/keeper/homepage/domain/member/dao/MemberRepository.java
@@ -5,4 +5,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
+  boolean existsByProfileEmailAddress(String emailAddress);
+
+  boolean existsByProfileLoginId(String loginId);
+
+  boolean existsByProfileStudentId(String studentId);
 }

--- a/src/main/java/com/keeper/homepage/domain/member/entity/Member.java
+++ b/src/main/java/com/keeper/homepage/domain/member/entity/Member.java
@@ -4,6 +4,7 @@ import static jakarta.persistence.CascadeType.ALL;
 import static jakarta.persistence.CascadeType.REMOVE;
 
 import com.keeper.homepage.domain.attendance.entity.Attendance;
+import com.keeper.homepage.domain.member.entity.embedded.Generation;
 import com.keeper.homepage.domain.member.entity.embedded.MeritDemerit;
 import com.keeper.homepage.domain.member.entity.embedded.Profile;
 import com.keeper.homepage.domain.member.entity.job.MemberHasMemberJob;
@@ -17,6 +18,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -44,6 +46,9 @@ public class Member {
   @Embedded
   private Profile profile;
 
+  @Embedded
+  private Generation generation;
+
   @Column(name = "point", nullable = false)
   private Integer point;
 
@@ -66,6 +71,7 @@ public class Member {
   private Member(Profile profile, Integer point, Integer level, Integer merit, Integer demerit,
       Integer totalAttendance) {
     this.profile = profile;
+    this.generation = Generation.generateGeneration(LocalDate.now());
     this.point = point;
     this.level = level;
     this.meritDemerit = MeritDemerit.builder()

--- a/src/main/java/com/keeper/homepage/domain/member/entity/Member.java
+++ b/src/main/java/com/keeper/homepage/domain/member/entity/Member.java
@@ -9,7 +9,6 @@ import com.keeper.homepage.domain.member.entity.embedded.Profile;
 import com.keeper.homepage.domain.member.entity.job.MemberHasMemberJob;
 import com.keeper.homepage.domain.member.entity.job.MemberJob;
 import com.keeper.homepage.domain.member.entity.job.MemberJob.MemberJobType;
-import com.keeper.homepage.domain.thumbnail.entity.Thumbnail;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -18,7 +17,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
-import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -65,21 +63,9 @@ public class Member {
   private final Set<MemberHasMemberJob> memberJob = new HashSet<>();
 
   @Builder
-  private Member(String loginId, String emailAddress, String password, String realName,
-      String nickname, LocalDate birthday, String studentId, Integer point, Integer level,
-      Thumbnail thumbnail, Integer merit, Integer demerit, Float generation,
+  private Member(Profile profile, Integer point, Integer level, Integer merit, Integer demerit,
       Integer totalAttendance) {
-    this.profile = Profile.builder()
-        .loginId(loginId)
-        .emailAddress(emailAddress)
-        .password(password)
-        .realName(realName)
-        .nickname(nickname)
-        .birthday(birthday)
-        .studentId(studentId)
-        .thumbnail(thumbnail)
-        .generation(generation)
-        .build();
+    this.profile = profile;
     this.point = point;
     this.level = level;
     this.meritDemerit = MeritDemerit.builder()

--- a/src/main/java/com/keeper/homepage/domain/member/entity/Member.java
+++ b/src/main/java/com/keeper/homepage/domain/member/entity/Member.java
@@ -1,5 +1,7 @@
 package com.keeper.homepage.domain.member.entity;
 
+import static com.keeper.homepage.domain.member.entity.rank.MemberRank.MemberRankType.일반회원;
+import static com.keeper.homepage.domain.member.entity.type.MemberType.MemberTypeEnum.정회원;
 import static jakarta.persistence.CascadeType.ALL;
 import static jakarta.persistence.CascadeType.REMOVE;
 
@@ -10,12 +12,17 @@ import com.keeper.homepage.domain.member.entity.embedded.Profile;
 import com.keeper.homepage.domain.member.entity.job.MemberHasMemberJob;
 import com.keeper.homepage.domain.member.entity.job.MemberJob;
 import com.keeper.homepage.domain.member.entity.job.MemberJob.MemberJobType;
+import com.keeper.homepage.domain.member.entity.rank.MemberRank;
+import com.keeper.homepage.domain.member.entity.type.MemberType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import java.time.LocalDate;
@@ -61,6 +68,14 @@ public class Member {
   @Column(name = "total_attendance", nullable = false)
   private Integer totalAttendance;
 
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "member_type_id")
+  private MemberType memberType;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "member_rank_id")
+  private MemberRank memberRank;
+
   @OneToMany(mappedBy = "member", cascade = REMOVE)
   private final List<Attendance> memberAttendance = new ArrayList<>();
 
@@ -79,6 +94,8 @@ public class Member {
         .demerit(demerit == null ? 0 : demerit)
         .build();
     this.totalAttendance = totalAttendance;
+    this.memberType = MemberType.getMemberTypeBy(정회원);
+    this.memberRank = MemberRank.getMemberRankBy(일반회원);
     this.assignJob(MemberJobType.ROLE_회원);
   }
 

--- a/src/main/java/com/keeper/homepage/domain/member/entity/embedded/Generation.java
+++ b/src/main/java/com/keeper/homepage/domain/member/entity/embedded/Generation.java
@@ -1,0 +1,40 @@
+package com.keeper.homepage.domain.member.entity.embedded;
+
+import static java.time.Month.DECEMBER;
+import static java.time.Month.FEBRUARY;
+import static java.time.Month.JANUARY;
+import static java.time.Month.NOVEMBER;
+import static java.time.Month.OCTOBER;
+import static java.time.Month.SEPTEMBER;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class Generation {
+
+  private static final int KEEPER_FOUNDING_YEAR = 2009;
+  private static final List<Month> SECOND_SEMESTER = List.of(SEPTEMBER, OCTOBER, NOVEMBER, DECEMBER,
+      JANUARY, FEBRUARY);
+
+  @Column(name = "generation")
+  private Float generation;
+
+  public static Generation generateGeneration(LocalDate now) {
+    float generation = now.getYear() - KEEPER_FOUNDING_YEAR;
+    if (SECOND_SEMESTER.contains(now.getMonth())) {
+      generation += 0.5;
+    }
+    return new Generation(generation);
+  }
+}

--- a/src/main/java/com/keeper/homepage/domain/member/entity/embedded/Profile.java
+++ b/src/main/java/com/keeper/homepage/domain/member/entity/embedded/Profile.java
@@ -1,5 +1,12 @@
 package com.keeper.homepage.domain.member.entity.embedded;
 
+import static java.time.Month.DECEMBER;
+import static java.time.Month.FEBRUARY;
+import static java.time.Month.JANUARY;
+import static java.time.Month.NOVEMBER;
+import static java.time.Month.OCTOBER;
+import static java.time.Month.SEPTEMBER;
+
 import com.keeper.homepage.domain.thumbnail.entity.Thumbnail;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -8,17 +15,16 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
 import java.time.LocalDate;
+import java.time.Month;
+import java.util.List;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @Embeddable
-@Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class Profile {
 
   public static final int MAX_LOGIN_ID_LENGTH = 80;
@@ -26,6 +32,9 @@ public class Profile {
   public static final int MAX_REAL_NAME_LENGTH = 40;
   public static final int MAX_NICKNAME_LENGTH = 40;
   public static final int MAX_STUDENT_ID_LENGTH = 45;
+  private static final int KEEPER_FOUNDING_YEAR = 2009;
+  private static final List<Month> SECOND_SEMESTER = List.of(SEPTEMBER, OCTOBER, NOVEMBER, DECEMBER,
+      JANUARY, FEBRUARY);
 
   @Column(name = "login_id", nullable = false, unique = true, length = MAX_LOGIN_ID_LENGTH)
   private String loginId;
@@ -54,4 +63,26 @@ public class Profile {
 
   @Column(name = "generation")
   private Float generation;
+
+  @Builder
+  private Profile(String loginId, String emailAddress, String password, String realName,
+      String nickname, LocalDate birthday, String studentId, Thumbnail thumbnail) {
+    this.loginId = loginId;
+    this.emailAddress = emailAddress;
+    this.password = password;
+    this.realName = realName;
+    this.nickname = nickname;
+    this.birthday = birthday;
+    this.studentId = studentId;
+    this.thumbnail = thumbnail;
+    this.generation = generateGeneration(LocalDate.now());
+  }
+
+  private float generateGeneration(LocalDate now) {
+    float generation = now.getYear() - KEEPER_FOUNDING_YEAR;
+    if (SECOND_SEMESTER.contains(now.getMonth())) {
+      generation += 0.5;
+    }
+    return generation;
+  }
 }

--- a/src/main/java/com/keeper/homepage/domain/member/entity/embedded/Profile.java
+++ b/src/main/java/com/keeper/homepage/domain/member/entity/embedded/Profile.java
@@ -1,12 +1,5 @@
 package com.keeper.homepage.domain.member.entity.embedded;
 
-import static java.time.Month.DECEMBER;
-import static java.time.Month.FEBRUARY;
-import static java.time.Month.JANUARY;
-import static java.time.Month.NOVEMBER;
-import static java.time.Month.OCTOBER;
-import static java.time.Month.SEPTEMBER;
-
 import com.keeper.homepage.domain.thumbnail.entity.Thumbnail;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -15,8 +8,6 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
 import java.time.LocalDate;
-import java.time.Month;
-import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -32,9 +23,6 @@ public class Profile {
   public static final int MAX_REAL_NAME_LENGTH = 40;
   public static final int MAX_NICKNAME_LENGTH = 40;
   public static final int MAX_STUDENT_ID_LENGTH = 45;
-  private static final int KEEPER_FOUNDING_YEAR = 2009;
-  private static final List<Month> SECOND_SEMESTER = List.of(SEPTEMBER, OCTOBER, NOVEMBER, DECEMBER,
-      JANUARY, FEBRUARY);
 
   @Column(name = "login_id", nullable = false, unique = true, length = MAX_LOGIN_ID_LENGTH)
   private String loginId;
@@ -61,9 +49,6 @@ public class Profile {
   @JoinColumn(name = "thumbnail_id")
   private Thumbnail thumbnail;
 
-  @Column(name = "generation")
-  private Float generation;
-
   @Builder
   private Profile(String loginId, String emailAddress, String password, String realName,
       String nickname, LocalDate birthday, String studentId, Thumbnail thumbnail) {
@@ -75,14 +60,5 @@ public class Profile {
     this.birthday = birthday;
     this.studentId = studentId;
     this.thumbnail = thumbnail;
-    this.generation = generateGeneration(LocalDate.now());
-  }
-
-  private float generateGeneration(LocalDate now) {
-    float generation = now.getYear() - KEEPER_FOUNDING_YEAR;
-    if (SECOND_SEMESTER.contains(now.getMonth())) {
-      generation += 0.5;
-    }
-    return generation;
   }
 }

--- a/src/main/java/com/keeper/homepage/global/config/password/PasswordConfiguration.java
+++ b/src/main/java/com/keeper/homepage/global/config/password/PasswordConfiguration.java
@@ -1,0 +1,96 @@
+package com.keeper.homepage.global.config.password;
+
+import static org.springframework.security.crypto.factory.PasswordEncoderFactories.createDelegatingPasswordEncoder;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.KeySpec;
+import java.util.Base64;
+import javax.crypto.SecretKey;
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.PBEKeySpec;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class PasswordConfiguration {
+
+  @Bean
+  public PasswordEncoder passwordEncoder() {
+    return new PasswordEncoder() {
+      @Override
+      public String encode(CharSequence rawPassword) {
+        return createDelegatingPasswordEncoder().encode(rawPassword);
+      }
+
+      @Override
+      public boolean matches(CharSequence rawPassword, String encodedPassword) {
+        return createDelegatingPasswordEncoder().matches(rawPassword, encodedPassword)
+            || matchesWithPBKDF2SHA256(rawPassword.toString(), encodedPassword)
+            || matchesWithMD5(rawPassword.toString(), encodedPassword);
+      }
+    };
+  }
+
+  private boolean matchesWithPBKDF2SHA256(String password, String hashedPassword) {
+    try {
+      String[] parts = hashedPassword.split(":");
+      if (parts.length != 4) {
+        return false;
+      }
+      int iterations = Integer.parseInt(parts[1]);
+      String salt = parts[2];
+      String hash = encodeWithPBKDF2SHA256(password, salt, iterations);
+      String[] passwordParts = hash.split(":");
+      return passwordParts[3].substring(0, 32).equals(parts[3]);
+    } catch (Exception ignore) {
+      return false;
+    }
+  }
+
+  private String encodeWithPBKDF2SHA256(String password, String salt, int iterations)
+      throws NoSuchAlgorithmException, InvalidKeySpecException {
+    String hash = getEncodedHashWithPBKDF2SHA256(password, salt, iterations);
+    return String.format("%s:%d:%s:%s", "pbkdf2_sha256", iterations, salt, hash);
+  }
+
+  private String getEncodedHashWithPBKDF2SHA256(String password, String salt, int iterations)
+      throws NoSuchAlgorithmException, InvalidKeySpecException {
+    SecretKeyFactory keyFactory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA256");
+    KeySpec keySpec = new PBEKeySpec(password.toCharArray(), salt.getBytes(StandardCharsets.UTF_8),
+        iterations, 256);
+    SecretKey secret = keyFactory.generateSecret(keySpec);
+
+    assert secret != null;
+    byte[] rawHash = secret.getEncoded();
+    byte[] hashBase64 = Base64.getEncoder().encode(rawHash);
+
+    return new String(hashBase64);
+  }
+
+  private boolean matchesWithMD5(String password, String hashedPassword) {
+    try {
+      return hashedPassword.equals(encodeWithMD5(password));
+    } catch (Exception ignore) {
+      return false;
+    }
+  }
+
+  private String encodeWithMD5(String password) throws NoSuchAlgorithmException {
+    return getEncodedHashWithMD5(password);
+  }
+
+  private String getEncodedHashWithMD5(String pwd) throws NoSuchAlgorithmException {
+    MessageDigest md = MessageDigest.getInstance("MD5");
+    md.update(pwd.getBytes());
+    byte[] byteData = md.digest();
+    StringBuilder sb = new StringBuilder();
+    for (byte byteDatum : byteData) {
+      sb.append(Integer.toString((byteDatum & 0xff) + 0x100, 16).substring(1));
+    }
+    return sb.toString();
+  }
+}

--- a/src/main/java/com/keeper/homepage/global/config/security/SecurityConfiguration.java
+++ b/src/main/java/com/keeper/homepage/global/config/security/SecurityConfiguration.java
@@ -34,7 +34,8 @@ public class SecurityConfiguration {
   @Bean
   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
     http.authorizeHttpRequests()
-        .requestMatchers("/docs/*", "/keeper_files/**", "/auth-test", "/sign-up/**").permitAll()
+        .requestMatchers("/docs/*", "/keeper_files/**", "/auth-test", "/sign-up/**", "/error")
+        .permitAll()
         .anyRequest().hasRole("회원")
         .and()
         .httpBasic().disable()

--- a/src/main/java/com/keeper/homepage/global/config/security/SecurityConfiguration.java
+++ b/src/main/java/com/keeper/homepage/global/config/security/SecurityConfiguration.java
@@ -56,11 +56,6 @@ public class SecurityConfiguration {
   }
 
   @Bean
-  public PasswordEncoder passwordEncoder() {
-    return PasswordEncoderFactories.createDelegatingPasswordEncoder();
-  }
-
-  @Bean
   public CorsConfigurationSource corsConfigurationSource() {
     CorsConfiguration configuration = new CorsConfiguration();
 

--- a/src/main/java/com/keeper/homepage/global/error/ErrorCode.java
+++ b/src/main/java/com/keeper/homepage/global/error/ErrorCode.java
@@ -11,8 +11,8 @@ public enum ErrorCode {
 
   // AUTH
   TOKEN_NOT_AVAILABLE("유효하지 않은 토큰입니다.", HttpStatus.UNAUTHORIZED),
-  AUTH_CODE_EXPIRED("인증 코드가 만료되었습니다.", HttpStatus.UNAUTHORIZED),
-  AUTH_CODE_MISMATCH("인증 코드가 일치하지 않습니다.", HttpStatus.UNAUTHORIZED),
+  AUTH_CODE_EXPIRED("인증 코드가 없거나 만료되었습니다.", HttpStatus.NOT_FOUND),
+  AUTH_CODE_MISMATCH("인증 코드가 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
   // MEMBER
   MEMBER_NOT_FOUND("해당 회원을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
   MEMBER_EMAIL_DUPLICATE("회원 이메일이 중복됩니다.", HttpStatus.CONFLICT),

--- a/src/main/java/com/keeper/homepage/global/error/ErrorCode.java
+++ b/src/main/java/com/keeper/homepage/global/error/ErrorCode.java
@@ -11,6 +11,8 @@ public enum ErrorCode {
 
   // AUTH
   TOKEN_NOT_AVAILABLE("유효하지 않은 토큰입니다.", HttpStatus.UNAUTHORIZED),
+  AUTH_CODE_EXPIRED("인증 코드가 만료되었습니다.", HttpStatus.UNAUTHORIZED),
+  AUTH_CODE_MISMATCH("인증 코드가 일치하지 않습니다.", HttpStatus.UNAUTHORIZED),
   // MEMBER
   MEMBER_NOT_FOUND("해당 회원을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
   ;

--- a/src/main/java/com/keeper/homepage/global/error/ErrorCode.java
+++ b/src/main/java/com/keeper/homepage/global/error/ErrorCode.java
@@ -15,6 +15,9 @@ public enum ErrorCode {
   AUTH_CODE_MISMATCH("인증 코드가 일치하지 않습니다.", HttpStatus.UNAUTHORIZED),
   // MEMBER
   MEMBER_NOT_FOUND("해당 회원을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+  MEMBER_EMAIL_DUPLICATE("회원 이메일이 중복됩니다.", HttpStatus.CONFLICT),
+  MEMBER_LOGIN_ID_DUPLICATE("회원의 로그인 아이디가 중복됩니다.", HttpStatus.CONFLICT),
+  MEMBER_STUDENT_ID_DUPLICATE("회원의 학번이 중복됩니다.", HttpStatus.CONFLICT),
   ;
 
   private final String message;

--- a/src/main/java/com/keeper/homepage/global/error/ExceptionAdvice.java
+++ b/src/main/java/com/keeper/homepage/global/error/ExceptionAdvice.java
@@ -2,16 +2,39 @@ package com.keeper.homepage.global.error;
 
 import java.util.stream.Collectors;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.BindException;
 import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
 public class ExceptionAdvice {
 
+  @ExceptionHandler(RuntimeException.class)
+  public ResponseEntity<ErrorResponse> runtimeException() {
+    return ResponseEntity.internalServerError()
+        .body(ErrorResponse.from("서버에 문제가 생겼습니다."));
+  }
+
+  @ExceptionHandler(HttpMessageNotReadableException.class)
+  public ResponseEntity<ErrorResponse> httpMessageNotReadableException(
+      HttpMessageNotReadableException e) {
+    return ResponseEntity.badRequest()
+        .body(ErrorResponse.from(e.getMessage()));
+  }
+
   @ExceptionHandler(BindException.class)
   public ResponseEntity<ErrorResponse> bindException(BindException e) {
+    String errorMessage = getErrorMessage(e);
+    return ResponseEntity.badRequest()
+        .body(ErrorResponse.from(errorMessage));
+  }
+
+  @ExceptionHandler(MethodArgumentNotValidException.class)
+  public ResponseEntity<ErrorResponse> methodArgumentNotValidException(
+      MethodArgumentNotValidException e) {
     String errorMessage = getErrorMessage(e);
     return ResponseEntity.badRequest()
         .body(ErrorResponse.from(errorMessage));

--- a/src/main/java/com/keeper/homepage/global/error/ExceptionAdvice.java
+++ b/src/main/java/com/keeper/homepage/global/error/ExceptionAdvice.java
@@ -1,8 +1,10 @@
 package com.keeper.homepage.global.error;
 
 import java.util.stream.Collectors;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.validation.BindException;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -16,6 +18,12 @@ public class ExceptionAdvice {
   public ResponseEntity<ErrorResponse> runtimeException() {
     return ResponseEntity.internalServerError()
         .body(ErrorResponse.from("서버에 문제가 생겼습니다."));
+  }
+
+  @ExceptionHandler(AccessDeniedException.class)
+  public ResponseEntity<ErrorResponse> accessDeniedException(AccessDeniedException e) {
+    return ResponseEntity.status(HttpStatus.FORBIDDEN)
+        .body(ErrorResponse.from("권한이 없습니다."));
   }
 
   @ExceptionHandler(HttpMessageNotReadableException.class)

--- a/src/test/java/com/keeper/homepage/IntegrationTest.java
+++ b/src/test/java/com/keeper/homepage/IntegrationTest.java
@@ -15,6 +15,7 @@ import com.keeper.homepage.domain.about.dao.StaticWriteTitleRepository;
 import com.keeper.homepage.domain.attendance.AttendanceTestHelper;
 import com.keeper.homepage.domain.attendance.dao.AttendanceRepository;
 import com.keeper.homepage.domain.auth.application.EmailAuthService;
+import com.keeper.homepage.domain.auth.application.SignUpService;
 import com.keeper.homepage.domain.auth.dao.redis.EmailAuthRedisRepository;
 import com.keeper.homepage.domain.file.dao.FileRepository;
 import com.keeper.homepage.domain.member.MemberTestHelper;
@@ -89,6 +90,9 @@ public class IntegrationTest {
   /******* Service *******/
   @SpyBean
   protected EmailAuthService emailAuthService;
+
+  @SpyBean
+  protected SignUpService signUpService;
 
   @Autowired
   protected MailUtil mailUtil;

--- a/src/test/java/com/keeper/homepage/IntegrationTest.java
+++ b/src/test/java/com/keeper/homepage/IntegrationTest.java
@@ -131,6 +131,9 @@ public class IntegrationTest {
   @Autowired
   protected JwtTokenProvider jwtTokenProvider;
 
+  @Autowired
+  protected ObjectMapper objectMapper;
+
   @PersistenceContext
   protected EntityManager em;
 
@@ -176,10 +179,9 @@ public class IntegrationTest {
 
   protected String asJsonString(final Object obj) {
     try {
-      final ObjectMapper objectMapper = new ObjectMapper();
       return objectMapper.writeValueAsString(obj);
     } catch (IOException e) {
-      throw new RuntimeException();
+      throw new RuntimeException(e);
     }
   }
 }

--- a/src/test/java/com/keeper/homepage/IntegrationTest.java
+++ b/src/test/java/com/keeper/homepage/IntegrationTest.java
@@ -46,6 +46,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.transaction.annotation.Transactional;
@@ -141,6 +142,9 @@ public class IntegrationTest {
 
   @Autowired
   protected ObjectMapper objectMapper;
+
+  @Autowired
+  protected PasswordEncoder passwordEncoder;
 
   @PersistenceContext
   protected EntityManager em;

--- a/src/test/java/com/keeper/homepage/IntegrationTest.java
+++ b/src/test/java/com/keeper/homepage/IntegrationTest.java
@@ -14,6 +14,7 @@ import com.keeper.homepage.domain.about.dao.StaticWriteSubtitleImageRepository;
 import com.keeper.homepage.domain.about.dao.StaticWriteTitleRepository;
 import com.keeper.homepage.domain.attendance.AttendanceTestHelper;
 import com.keeper.homepage.domain.attendance.dao.AttendanceRepository;
+import com.keeper.homepage.domain.auth.application.CheckDuplicateService;
 import com.keeper.homepage.domain.auth.application.EmailAuthService;
 import com.keeper.homepage.domain.auth.application.SignUpService;
 import com.keeper.homepage.domain.auth.dao.redis.EmailAuthRedisRepository;
@@ -93,6 +94,9 @@ public class IntegrationTest {
 
   @SpyBean
   protected SignUpService signUpService;
+
+  @SpyBean
+  protected CheckDuplicateService checkDuplicateService;
 
   @Autowired
   protected MailUtil mailUtil;

--- a/src/test/java/com/keeper/homepage/domain/auth/api/SignUpControllerTest.java
+++ b/src/test/java/com/keeper/homepage/domain/auth/api/SignUpControllerTest.java
@@ -2,9 +2,9 @@ package com.keeper.homepage.domain.auth.api;
 
 import static com.keeper.homepage.domain.auth.application.EmailAuthService.AUTH_CODE_LENGTH;
 import static com.keeper.homepage.domain.auth.application.EmailAuthService.EMAIL_EXPIRED_SECONDS;
+import static org.hamcrest.Matchers.containsString;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.when;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
@@ -14,6 +14,7 @@ import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuild
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -22,12 +23,16 @@ import com.keeper.homepage.IntegrationTest;
 import com.keeper.homepage.domain.auth.dto.request.EmailAuthRequest;
 import com.keeper.homepage.domain.auth.dto.request.SignUpRequest;
 import java.time.LocalDate;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.http.HttpHeaders;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.ResultActions;
 
 class SignUpControllerTest extends IntegrationTest {
@@ -91,7 +96,7 @@ class SignUpControllerTest extends IntegrationTest {
     @DisplayName("유효한 요청일 경우 회원가입은 성공해야 한다.")
     void should_successfully_when_validRequest() throws Exception {
       long createdMemberId = 1L;
-      when(signUpService.signUp(any())).thenReturn(createdMemberId);
+      doReturn(createdMemberId).when(signUpService).signUp(any());
       callSignUpApi(validRequest)
           .andExpect(status().isCreated())
           .andExpect(header().string(HttpHeaders.LOCATION, "/members/" + createdMemberId))
@@ -111,6 +116,49 @@ class SignUpControllerTest extends IntegrationTest {
               responseHeaders(
                   headerWithName(HttpHeaders.LOCATION).description("생성된 회원의 URI입니다.")
               )));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    @DisplayName("잘못된 형식의 요청일 경우 400 Bad Request를 반환해야 한다.")
+    void should_400BadRequest_when_invalidRequest(String field, String invalidValue)
+        throws Exception {
+      Object validValue = ReflectionTestUtils.getField(validRequest, field);
+      ReflectionTestUtils.setField(validRequest, field, invalidValue);
+      callSignUpApi(validRequest)
+          .andExpect(status().isBadRequest())
+          .andExpect(content().string(containsString(field)))
+          .andExpect(content().string(containsString(invalidValue)));
+      ReflectionTestUtils.setField(validRequest, field, validValue);
+    }
+
+    static Stream<Arguments> should_400BadRequest_when_invalidRequest() {
+      return Stream.of(
+          Arguments.arguments("loginId", "a_0"),
+          Arguments.arguments("loginId", "a".repeat(13)),
+          Arguments.arguments("loginId", "abcd#"),
+          Arguments.arguments("loginId", "no-dash-haha"),
+          Arguments.arguments("email", "a@a."),
+          Arguments.arguments("email", "notEmail"),
+          Arguments.arguments("password", "a".repeat(6) + "0"),
+          Arguments.arguments("password", "a".repeat(20) + "0"),
+          Arguments.arguments("password", "abcdefghij"),
+          Arguments.arguments("password", "0123456789"),
+          Arguments.arguments("password", "noNumber###"),
+          Arguments.arguments("password", "0123456!@#$"),
+          Arguments.arguments("realName", "a".repeat(21)),
+          Arguments.arguments("realName", ""),
+          Arguments.arguments("realName", "  "),
+          Arguments.arguments("realName", "noNumber00"),
+          Arguments.arguments("nickname", "0_0"),
+          Arguments.arguments("nickname", "0-0"),
+          Arguments.arguments("nickname", "noSpecial!@#$"),
+          Arguments.arguments("nickname", "공백은 안됩니다."),
+          Arguments.arguments("authCode", "a".repeat(AUTH_CODE_LENGTH - 1)),
+          Arguments.arguments("authCode", "a".repeat(AUTH_CODE_LENGTH + 1)),
+          Arguments.arguments("studentId", "noNumber!"),
+          Arguments.arguments("studentId", "12345_6789")
+      );
     }
 
     private ResultActions callSignUpApi(SignUpRequest request) throws Exception {

--- a/src/test/java/com/keeper/homepage/domain/auth/api/SignUpControllerTest.java
+++ b/src/test/java/com/keeper/homepage/domain/auth/api/SignUpControllerTest.java
@@ -1,25 +1,33 @@
 package com.keeper.homepage.domain.auth.api;
 
+import static com.keeper.homepage.domain.auth.application.EmailAuthService.AUTH_CODE_LENGTH;
 import static com.keeper.homepage.domain.auth.application.EmailAuthService.EMAIL_EXPIRED_SECONDS;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.responseHeaders;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.keeper.homepage.IntegrationTest;
 import com.keeper.homepage.domain.auth.dto.request.EmailAuthRequest;
+import com.keeper.homepage.domain.auth.dto.request.SignUpRequest;
+import java.time.LocalDate;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.http.HttpHeaders;
 import org.springframework.test.web.servlet.ResultActions;
 
 class SignUpControllerTest extends IntegrationTest {
@@ -60,6 +68,54 @@ class SignUpControllerTest extends IntegrationTest {
     private ResultActions callEmailAuthApi(EmailAuthRequest request) throws Exception {
       return mockMvc.perform(post("/sign-up/email-auth")
           .contentType(APPLICATION_JSON)
+          .content(asJsonString(request)));
+    }
+  }
+
+  @Nested
+  @DisplayName("회원가입 테스트")
+  class SignUp {
+
+    private final SignUpRequest validRequest = SignUpRequest.builder()
+        .loginId("loginId_1337")
+        .email("keeper@keeper.or.kr")
+        .password("password123!@#$")
+        .realName("정현모minion")
+        .nickname("0v0zㅣ존")
+        .authCode("0123456789")
+        .birthday(LocalDate.of(1970, 1, 1))
+        .studentId("197012345")
+        .build();
+
+    @Test
+    @DisplayName("유효한 요청일 경우 회원가입은 성공해야 한다.")
+    void should_successfully_when_validRequest() throws Exception {
+      long createdMemberId = 1L;
+      when(signUpService.signUp(any())).thenReturn(createdMemberId);
+      callSignUpApi(validRequest)
+          .andExpect(status().isCreated())
+          .andExpect(header().string(HttpHeaders.LOCATION, "/members/" + createdMemberId))
+          .andDo(document("sign-up",
+              requestFields(
+                  fieldWithPath("loginId").description("로그인 아이디는 4~12자 영어, 숫자, '_'만 가능합니다."),
+                  fieldWithPath("email").description("이메일은 이메일 형식을 따라야 합니다."),
+                  fieldWithPath("password").description("비밀번호는 8~20자여야 하고 영어, 숫자가 포함되어야 합니다."),
+                  fieldWithPath("realName").description("실명은 1~20자 한글, 영어만 가능합니다."),
+                  fieldWithPath("nickname").description("닉네임은 1~16자 한글, 영어, 숫자만 가능합니다."),
+                  fieldWithPath("authCode")
+                      .description("길이가 " + AUTH_CODE_LENGTH + "인 인증 코드를 입력해야 합니다."),
+                  fieldWithPath("birthday").description("생일 형식은 yyyy.MM.dd 입니다.")
+                      .optional(),
+                  fieldWithPath("studentId").description("학번은 숫자만 가능합니다.")
+              ),
+              responseHeaders(
+                  headerWithName(HttpHeaders.LOCATION).description("생성된 회원의 URI입니다.")
+              )));
+    }
+
+    private ResultActions callSignUpApi(SignUpRequest request) throws Exception {
+      return mockMvc.perform(post("/sign-up")
+          .contentType(APPLICATION_JSON_VALUE)
           .content(asJsonString(request)));
     }
   }

--- a/src/test/java/com/keeper/homepage/domain/auth/api/SignUpControllerTest.java
+++ b/src/test/java/com/keeper/homepage/domain/auth/api/SignUpControllerTest.java
@@ -2,6 +2,7 @@ package com.keeper.homepage.domain.auth.api;
 
 import static com.keeper.homepage.domain.auth.application.EmailAuthService.EMAIL_EXPIRED_SECONDS;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
@@ -33,7 +34,7 @@ class SignUpControllerTest extends IntegrationTest {
     @DisplayName("유효한 요청이면 이메일 인증은 성공해야 한다.")
     void should_successfully_when_validRequest() throws Exception {
       EmailAuthRequest request = EmailAuthRequest.from(VALID_EMAIL);
-      when(emailAuthService.emailAuth(any())).thenReturn(EMAIL_EXPIRED_SECONDS);
+      doReturn(EMAIL_EXPIRED_SECONDS).when(emailAuthService).emailAuth(any());
       callEmailAuthApi(request)
           .andExpect(status().isOk())
           .andExpect(jsonPath("$.expiredSeconds").value(EMAIL_EXPIRED_SECONDS))
@@ -51,7 +52,7 @@ class SignUpControllerTest extends IntegrationTest {
     @DisplayName("이메일 형식에 맞지 않으면 400 Bad Request를 응답한다.")
     void should_throwException_when_invalidRequest(String invalidEmail) throws Exception {
       EmailAuthRequest request = EmailAuthRequest.from(invalidEmail);
-      when(emailAuthService.emailAuth(any())).thenReturn(EMAIL_EXPIRED_SECONDS);
+      doReturn(EMAIL_EXPIRED_SECONDS).when(emailAuthService).emailAuth(any());
       callEmailAuthApi(request)
           .andExpect(status().isBadRequest());
     }

--- a/src/test/java/com/keeper/homepage/domain/auth/application/CheckDuplicateServiceTest.java
+++ b/src/test/java/com/keeper/homepage/domain/auth/application/CheckDuplicateServiceTest.java
@@ -1,0 +1,41 @@
+package com.keeper.homepage.domain.auth.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.keeper.homepage.IntegrationTest;
+import com.keeper.homepage.domain.member.entity.Member;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class CheckDuplicateServiceTest extends IntegrationTest {
+
+  @Test
+  @DisplayName("중복되는 일 경우 true를 반환해야 한다.")
+  void should_returnTrue_whenIsDuplicateEmail() {
+    Member member = memberTestHelper.generate();
+
+    boolean result = checkDuplicateService.isDuplicateEmail(member.getProfile().getEmailAddress());
+
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  @DisplayName("중복되는 일 경우 true를 반환해야 한다.")
+  void should_returnTrue_whenIsDuplicateLoginId() {
+    Member member = memberTestHelper.generate();
+
+    boolean result = checkDuplicateService.isDuplicateLoginId(member.getProfile().getLoginId());
+
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  @DisplayName("중복되는 일 경우 true를 반환해야 한다.")
+  void should_returnTrue_whenIsDuplicateStudentID() {
+    Member member = memberTestHelper.generate();
+
+    boolean result = checkDuplicateService.isDuplicateStudentID(member.getProfile().getStudentId());
+
+    assertThat(result).isTrue();
+  }
+}

--- a/src/test/java/com/keeper/homepage/domain/auth/application/SignUpServiceTest.java
+++ b/src/test/java/com/keeper/homepage/domain/auth/application/SignUpServiceTest.java
@@ -1,0 +1,40 @@
+package com.keeper.homepage.domain.auth.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+
+import com.keeper.homepage.IntegrationTest;
+import com.keeper.homepage.domain.auth.dto.request.SignUpRequest;
+import com.keeper.homepage.domain.member.entity.Member;
+import java.time.LocalDate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class SignUpServiceTest extends IntegrationTest {
+
+  private final SignUpRequest validRequest = SignUpRequest.builder()
+      .loginId("loginId_1337")
+      .email("keeper@keeper.or.kr")
+      .password("password123!@#$")
+      .realName("정현모minion")
+      .nickname("0v0zㅣ존")
+      .authCode("0123456789")
+      .birthday(LocalDate.of(1970, 1, 1))
+      .studentId("197012345")
+      .build();
+
+  @Test
+  @DisplayName("회원가입 시 비밀번호는 암호화되어야 한다.")
+  void should_encrypted_when_signUp() {
+    doReturn("").when(signUpService).getActualAuthCode(any());
+    doNothing().when(signUpService).checkAuthCodeMatch(any(), any());
+    long savedMemberId = signUpService.signUp(validRequest);
+
+    Member savedMember = memberRepository.findById(savedMemberId).orElseThrow();
+    String hashedPassword = savedMember.getProfile().getPassword();
+    assertThat(hashedPassword).isNotEqualTo(validRequest.getPassword());
+    assertThat(passwordEncoder.matches(validRequest.getPassword(), hashedPassword)).isTrue();
+  }
+}

--- a/src/test/java/com/keeper/homepage/domain/member/MemberTestHelper.java
+++ b/src/test/java/com/keeper/homepage/domain/member/MemberTestHelper.java
@@ -8,6 +8,7 @@ import static com.keeper.homepage.domain.member.entity.embedded.Profile.MAX_STUD
 
 import com.keeper.homepage.domain.member.dao.MemberRepository;
 import com.keeper.homepage.domain.member.entity.Member;
+import com.keeper.homepage.domain.member.entity.embedded.Profile;
 import com.keeper.homepage.domain.thumbnail.entity.Thumbnail;
 import com.keeper.homepage.global.util.thumbnail.ThumbnailTestHelper;
 import java.time.LocalDate;
@@ -124,19 +125,21 @@ public class MemberTestHelper {
 
     public Member build() {
       return memberRepository.save(Member.builder()
-          .loginId(loginId != null ? loginId : getRandomUUIDLengthWith(MAX_LOGIN_ID_LENGTH))
-          .emailAddress(email != null ? email : getRandomUUIDLengthWith(MAX_EMAIL_LENGTH))
-          .password(password != null ? password : getRandomUUIDLengthWith(100))
-          .realName(realName != null ? realName : getRandomUUIDLengthWith(MAX_REAL_NAME_LENGTH))
-          .nickname(nickname != null ? nickname : getRandomUUIDLengthWith(MAX_NICKNAME_LENGTH))
-          .birthday(birthday != null ? birthday : LocalDate.of(1970, 1, 1))
-          .studentId(studentId != null ? studentId : getRandomUUIDLengthWith(MAX_STUDENT_ID_LENGTH))
+          .profile(Profile.builder()
+              .loginId(loginId != null ? loginId : getRandomUUIDLengthWith(MAX_LOGIN_ID_LENGTH))
+              .emailAddress(email != null ? email : getRandomUUIDLengthWith(MAX_EMAIL_LENGTH))
+              .password(password != null ? password : getRandomUUIDLengthWith(100))
+              .realName(realName != null ? realName : getRandomUUIDLengthWith(MAX_REAL_NAME_LENGTH))
+              .nickname(nickname != null ? nickname : getRandomUUIDLengthWith(MAX_NICKNAME_LENGTH))
+              .birthday(birthday != null ? birthday : LocalDate.of(1970, 1, 1))
+              .studentId(studentId != null ? studentId
+                  : getRandomUUIDLengthWith(MAX_STUDENT_ID_LENGTH))
+              .thumbnail(thumbnail != null ? thumbnail : thumbnailTestHelper.generateThumbnail())
+              .build())
           .point(point != null ? point : 0)
           .level(level != null ? level : 0)
-          .thumbnail(thumbnail != null ? thumbnail : thumbnailTestHelper.generateThumbnail())
           .merit(merit != null ? merit : 0)
           .demerit(demerit != null ? demerit : 0)
-          .generation(generation != null ? generation : 8.0F)
           .totalAttendance(totalAttendance != null ? totalAttendance : 0)
           .build());
     }

--- a/src/test/java/com/keeper/homepage/domain/member/dao/MemberRepositoryTest.java
+++ b/src/test/java/com/keeper/homepage/domain/member/dao/MemberRepositoryTest.java
@@ -8,6 +8,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.keeper.homepage.IntegrationTest;
 import com.keeper.homepage.domain.member.entity.Member;
+import com.keeper.homepage.domain.member.entity.embedded.Profile;
 import com.keeper.homepage.domain.member.entity.job.MemberHasMemberJob;
 import com.keeper.homepage.domain.member.entity.job.MemberJob;
 import java.util.List;
@@ -34,11 +35,13 @@ class MemberRepositoryTest extends IntegrationTest {
     @DisplayName("default 값이 있는 컬럼은 null로 저장해도 저장에 성공한다.")
     void should_saveSuccessfully_when_defaultColumnIsNull() {
       Member memberBeforeSave = Member.builder()
-          .loginId("ABC")
-          .emailAddress("ABC@keeper.com")
-          .password("password")
-          .realName("realName")
-          .nickname("nickname")
+          .profile(Profile.builder()
+              .loginId("ABC")
+              .emailAddress("ABC@keeper.com")
+              .password("password")
+              .realName("realName")
+              .nickname("nickname")
+              .build())
           .build();
 
       assertThat(memberBeforeSave.getPoint()).isNull();


### PR DESCRIPTION
## 🔥 Related Issue

close: #30

## 📝 Description

- 회원가입 API 제작
    - `로그인 아이디`, `이메일`, `학번` 중복 체크
    - 회원가입시 인증코드 확인
    - 비밀번호 저장 시 암호화
    - 회원 생성 시 기본적으로 [일반회원], [정회원] 역할 부여
    - 회원 생성 시 기수를 계산해서 적용
- `ExceptionAdvice`에 `RuntimeException`, `AccessDeniedException`, `HttpMessageNotReadableException` 추가
- `passwordEncoder` config 파일 분리
    - 이관 전 비밀번호 암호화 방식도 적용하기 위해 레거시 코드 들어가있음 (언젠간 다른 사람들이 고쳐주길...)
- 에러 발생 시 리다이렉트 되는 `/error` URL에 권한 없어도 접근 가능하도록 변경

---
- **[test]** `objectMapper` `Autowired`로 주입하도록 변경
- **[test]** `@SpyBean`은 모킹 시 `when` 대신 `doReturn` 사용

## ⭐️ Review

다들 화이팅입니다!