### PR TITLE
Feature/#35 페이지블럭 리스트 조회 구현

### DIFF
--- a/src/docs/about/about.adoc
+++ b/src/docs/about/about.adoc
@@ -1,0 +1,32 @@
+ifndef::snippets[]
+:snippets: ./build/generated-snippets
+endif::[]
+
+= ABOUT API 문서
+:icons: font
+:source-highlighter: highlight.js
+:toc: left
+:toclevels: 1
+:sectlinks:
+
+== API 목록
+
+link:../keeper.html[API 목록으로 돌아가기]
+
+== *타이틀 타입 리스트 조회*
+
+=== 요청
+
+==== Request
+
+include::{snippets}/about-types/http-request.adoc[]
+
+=== 응답
+
+==== Response
+
+include::{snippets}/about-types/http-response.adoc[]
+
+==== Response Fields
+
+include::{snippets}/about-types/response-fields.adoc[]

--- a/src/docs/about/about.adoc
+++ b/src/docs/about/about.adoc
@@ -19,14 +19,36 @@ link:../keeper.html[API 목록으로 돌아가기]
 
 ==== Request
 
-include::{snippets}/about-types/http-request.adoc[]
+include::{snippets}/about-title-types/http-request.adoc[]
 
 === 응답
 
 ==== Response
 
-include::{snippets}/about-types/http-response.adoc[]
+include::{snippets}/about-title-types/http-response.adoc[]
 
 ==== Response Fields
 
-include::{snippets}/about-types/response-fields.adoc[]
+include::{snippets}/about-title-types/response-fields.adoc[]
+
+== *타입으로 페이지 블럭 리스트 조회*
+
+=== 요청
+
+==== Request
+
+include::{snippets}/about-title-by-type/http-request.adoc[]
+
+==== Path Parameters
+
+include::{snippets}/about-title-by-type/path-parameters.adoc[]
+
+=== 응답
+
+==== Response Body
+
+include::{snippets}/about-title-by-type/http-response.adoc[]
+
+==== Response Fields
+
+include::{snippets}/about-title-by-type/response-fields.adoc[]

--- a/src/main/java/com/keeper/homepage/domain/about/api/StaticWriteController.java
+++ b/src/main/java/com/keeper/homepage/domain/about/api/StaticWriteController.java
@@ -4,7 +4,6 @@ import com.keeper.homepage.domain.about.application.StaticWriteService;
 import com.keeper.homepage.domain.about.dto.response.StaticWriteTitleResponse;
 import com.keeper.homepage.domain.about.dto.response.StaticWriteTitleTypeResponse;
 import jakarta.validation.constraints.NotNull;
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -28,8 +27,8 @@ public class StaticWriteController {
   }
 
   @GetMapping("/titles/types/{type}")
-  public ResponseEntity<StaticWriteTitleResponse> getAllByType(@PathVariable @NotNull String type) {
-    StaticWriteTitleResponse response = staticWriteService.getAllByType(type);
+  public ResponseEntity<StaticWriteTitleResponse> getTitleByType(@PathVariable @NotNull String type) {
+    StaticWriteTitleResponse response = staticWriteService.getTitleByType(type);
     return ResponseEntity.status(HttpStatus.OK)
         .body(response);
   }

--- a/src/main/java/com/keeper/homepage/domain/about/api/StaticWriteController.java
+++ b/src/main/java/com/keeper/homepage/domain/about/api/StaticWriteController.java
@@ -2,10 +2,14 @@ package com.keeper.homepage.domain.about.api;
 
 import com.keeper.homepage.domain.about.application.StaticWriteService;
 import com.keeper.homepage.domain.about.dto.response.StaticWriteTitleResponse;
+import com.keeper.homepage.domain.about.dto.response.StaticWriteTitleTypeResponse;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -16,11 +20,18 @@ public class StaticWriteController {
 
   private final StaticWriteService staticWriteService;
 
-  @GetMapping("/types")
-  public ResponseEntity<StaticWriteTitleResponse> getAllTypes() {
-    StaticWriteTitleResponse staticWriteTitles = staticWriteService.getAllTypes();
+  @GetMapping("/titles/types")
+  public ResponseEntity<StaticWriteTitleTypeResponse> getAllTypes() {
+    StaticWriteTitleTypeResponse staticWriteTitles = staticWriteService.getAllTypes();
     return ResponseEntity.status(HttpStatus.OK)
         .body(staticWriteTitles);
+  }
+
+  @GetMapping("/titles/types/{type}")
+  public ResponseEntity<StaticWriteTitleResponse> getAllByType(@PathVariable @NotNull String type) {
+    StaticWriteTitleResponse response = staticWriteService.getAllByType(type);
+    return ResponseEntity.status(HttpStatus.OK)
+        .body(response);
   }
 
 }

--- a/src/main/java/com/keeper/homepage/domain/about/api/StaticWriteController.java
+++ b/src/main/java/com/keeper/homepage/domain/about/api/StaticWriteController.java
@@ -1,0 +1,26 @@
+package com.keeper.homepage.domain.about.api;
+
+import com.keeper.homepage.domain.about.application.StaticWriteService;
+import com.keeper.homepage.domain.about.dto.response.StaticWriteTitleResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/about")
+public class StaticWriteController {
+
+  private final StaticWriteService staticWriteService;
+
+  @GetMapping("/types")
+  public ResponseEntity<StaticWriteTitleResponse> getAllTypes() {
+    StaticWriteTitleResponse staticWriteTitles = staticWriteService.getAllTypes();
+    return ResponseEntity.status(HttpStatus.OK)
+        .body(staticWriteTitles);
+  }
+
+}

--- a/src/main/java/com/keeper/homepage/domain/about/application/StaticWriteService.java
+++ b/src/main/java/com/keeper/homepage/domain/about/application/StaticWriteService.java
@@ -2,8 +2,6 @@ package com.keeper.homepage.domain.about.application;
 
 import static com.keeper.homepage.global.error.ErrorCode.TITLE_TYPE_NOT_FOUND;
 
-import com.keeper.homepage.domain.about.dao.StaticWriteContentRepository;
-import com.keeper.homepage.domain.about.dao.StaticWriteSubtitleImageRepository;
 import com.keeper.homepage.domain.about.dao.StaticWriteTitleRepository;
 import com.keeper.homepage.domain.about.dto.response.StaticWriteTitleResponse;
 import com.keeper.homepage.domain.about.dto.response.StaticWriteTitleTypeResponse;
@@ -12,9 +10,11 @@ import com.keeper.homepage.domain.about.entity.StaticWriteTitle.StaticWriteTitle
 import com.keeper.homepage.global.error.BusinessException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class StaticWriteService {
 
   private final StaticWriteTitleRepository staticWriteTitleRepository;

--- a/src/main/java/com/keeper/homepage/domain/about/application/StaticWriteService.java
+++ b/src/main/java/com/keeper/homepage/domain/about/application/StaticWriteService.java
@@ -24,7 +24,7 @@ public class StaticWriteService {
   }
 
   public StaticWriteTitleResponse getAllByType(String type) {
-    StaticWriteTitle staticWriteTitle = staticWriteTitleRepository.findByType(StaticWriteTitleType.fromCode(type))
+    StaticWriteTitle staticWriteTitle = staticWriteTitleRepository.findByStaticWriteTitleType(StaticWriteTitleType.fromCode(type))
         .orElseThrow(() -> new BusinessException(type, "type", TITLE_TYPE_NOT_FOUND));
     return StaticWriteTitleResponse.from(staticWriteTitle);
   }

--- a/src/main/java/com/keeper/homepage/domain/about/application/StaticWriteService.java
+++ b/src/main/java/com/keeper/homepage/domain/about/application/StaticWriteService.java
@@ -1,0 +1,18 @@
+package com.keeper.homepage.domain.about.application;
+
+import com.keeper.homepage.domain.about.dao.StaticWriteContentRepository;
+import com.keeper.homepage.domain.about.dao.StaticWriteTitleRepository;
+import com.keeper.homepage.domain.about.dto.response.StaticWriteTitleResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class StaticWriteService {
+
+  private final StaticWriteTitleRepository staticWriteTitleRepository;
+
+  public StaticWriteTitleResponse getAllTypes() {
+    return StaticWriteTitleResponse.from(staticWriteTitleRepository.findAll());
+  }
+}

--- a/src/main/java/com/keeper/homepage/domain/about/application/StaticWriteService.java
+++ b/src/main/java/com/keeper/homepage/domain/about/application/StaticWriteService.java
@@ -23,7 +23,7 @@ public class StaticWriteService {
     return StaticWriteTitleTypeResponse.from(staticWriteTitleRepository.findAll());
   }
 
-  public StaticWriteTitleResponse getAllByType(String type) {
+  public StaticWriteTitleResponse getTitleByType(String type) {
     StaticWriteTitle staticWriteTitle = staticWriteTitleRepository.findByStaticWriteTitleType(StaticWriteTitleType.fromCode(type))
         .orElseThrow(() -> new BusinessException(type, "type", TITLE_TYPE_NOT_FOUND));
     return StaticWriteTitleResponse.from(staticWriteTitle);

--- a/src/main/java/com/keeper/homepage/domain/about/application/StaticWriteService.java
+++ b/src/main/java/com/keeper/homepage/domain/about/application/StaticWriteService.java
@@ -1,8 +1,15 @@
 package com.keeper.homepage.domain.about.application;
 
+import static com.keeper.homepage.global.error.ErrorCode.TITLE_TYPE_NOT_FOUND;
+
 import com.keeper.homepage.domain.about.dao.StaticWriteContentRepository;
+import com.keeper.homepage.domain.about.dao.StaticWriteSubtitleImageRepository;
 import com.keeper.homepage.domain.about.dao.StaticWriteTitleRepository;
 import com.keeper.homepage.domain.about.dto.response.StaticWriteTitleResponse;
+import com.keeper.homepage.domain.about.dto.response.StaticWriteTitleTypeResponse;
+import com.keeper.homepage.domain.about.entity.StaticWriteTitle;
+import com.keeper.homepage.domain.about.entity.StaticWriteTitle.StaticWriteTitleType;
+import com.keeper.homepage.global.error.BusinessException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -12,7 +19,13 @@ public class StaticWriteService {
 
   private final StaticWriteTitleRepository staticWriteTitleRepository;
 
-  public StaticWriteTitleResponse getAllTypes() {
-    return StaticWriteTitleResponse.from(staticWriteTitleRepository.findAll());
+  public StaticWriteTitleTypeResponse getAllTypes() {
+    return StaticWriteTitleTypeResponse.from(staticWriteTitleRepository.findAll());
+  }
+
+  public StaticWriteTitleResponse getAllByType(String type) {
+    StaticWriteTitle staticWriteTitle = staticWriteTitleRepository.findByType(StaticWriteTitleType.fromCode(type))
+        .orElseThrow(() -> new BusinessException(type, "type", TITLE_TYPE_NOT_FOUND));
+    return StaticWriteTitleResponse.from(staticWriteTitle);
   }
 }

--- a/src/main/java/com/keeper/homepage/domain/about/converter/StaticWriteTitleTypeConverter.java
+++ b/src/main/java/com/keeper/homepage/domain/about/converter/StaticWriteTitleTypeConverter.java
@@ -1,6 +1,7 @@
 package com.keeper.homepage.domain.about.converter;
 
 import com.keeper.homepage.domain.about.entity.StaticWriteTitle.StaticWriteTitleType;
+import com.keeper.homepage.global.error.BusinessException;
 import jakarta.persistence.AttributeConverter;
 import jakarta.persistence.Converter;
 import lombok.extern.slf4j.Slf4j;
@@ -22,7 +23,7 @@ public class StaticWriteTitleTypeConverter implements
     }
     try {
       return StaticWriteTitleType.fromCode(dbData);
-    } catch (IllegalArgumentException e) {
+    } catch (BusinessException e) {
       log.error("failure to convert cause unexpected code [{}]", dbData, e);
       throw e;
     }

--- a/src/main/java/com/keeper/homepage/domain/about/dao/StaticWriteContentRepository.java
+++ b/src/main/java/com/keeper/homepage/domain/about/dao/StaticWriteContentRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface StaticWriteContentRepository extends JpaRepository<StaticWriteContent, Long> {
 
-  List<StaticWriteContent> findAllByStaticWriteSubtitleImage_StaticWriteTitle_Type(
-      StaticWriteTitleType type);
+  List<StaticWriteContent> findAllByStaticWriteSubtitleImage_StaticWriteTitle_StaticWriteTitleType(
+      StaticWriteTitleType staticWriteTitleType);
 
 }

--- a/src/main/java/com/keeper/homepage/domain/about/dao/StaticWriteContentRepository.java
+++ b/src/main/java/com/keeper/homepage/domain/about/dao/StaticWriteContentRepository.java
@@ -3,7 +3,6 @@ package com.keeper.homepage.domain.about.dao;
 import com.keeper.homepage.domain.about.entity.StaticWriteContent;
 import com.keeper.homepage.domain.about.entity.StaticWriteTitle.StaticWriteTitleType;
 import java.util.List;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface StaticWriteContentRepository extends JpaRepository<StaticWriteContent, Long> {

--- a/src/main/java/com/keeper/homepage/domain/about/dao/StaticWriteTitleRepository.java
+++ b/src/main/java/com/keeper/homepage/domain/about/dao/StaticWriteTitleRepository.java
@@ -1,8 +1,12 @@
 package com.keeper.homepage.domain.about.dao;
 
 import com.keeper.homepage.domain.about.entity.StaticWriteTitle;
+import com.keeper.homepage.domain.about.entity.StaticWriteTitle.StaticWriteTitleType;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface StaticWriteTitleRepository extends JpaRepository<StaticWriteTitle, Long> {
+
+  Optional<StaticWriteTitle> findByType(StaticWriteTitleType type);
 
 }

--- a/src/main/java/com/keeper/homepage/domain/about/dao/StaticWriteTitleRepository.java
+++ b/src/main/java/com/keeper/homepage/domain/about/dao/StaticWriteTitleRepository.java
@@ -7,6 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface StaticWriteTitleRepository extends JpaRepository<StaticWriteTitle, Long> {
 
-  Optional<StaticWriteTitle> findByType(StaticWriteTitleType type);
+  Optional<StaticWriteTitle> findByStaticWriteTitleType(StaticWriteTitleType staticWriteTitleType);
 
 }

--- a/src/main/java/com/keeper/homepage/domain/about/dto/response/StaticWriteContentResponse.java
+++ b/src/main/java/com/keeper/homepage/domain/about/dto/response/StaticWriteContentResponse.java
@@ -3,15 +3,18 @@ package com.keeper.homepage.domain.about.dto.response;
 import static lombok.AccessLevel.PRIVATE;
 
 import com.keeper.homepage.domain.about.entity.StaticWriteContent;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
+@Builder
+@AllArgsConstructor(access = PRIVATE)
 public class StaticWriteContentResponse {
 
-  private final Long id;
-  private final String content;
-  private final Integer displayOrder;
+  private Long id;
+  private String content;
+  private Integer displayOrder;
 
   public static StaticWriteContentResponse from(StaticWriteContent staticWriteContent) {
     return StaticWriteContentResponse.builder()
@@ -19,12 +22,5 @@ public class StaticWriteContentResponse {
         .content(staticWriteContent.getContent())
         .displayOrder(staticWriteContent.getDisplayOrder())
         .build();
-  }
-
-  @Builder
-  private StaticWriteContentResponse(Long id, String content, Integer displayOrder) {
-    this.id = id;
-    this.content = content;
-    this.displayOrder = displayOrder;
   }
 }

--- a/src/main/java/com/keeper/homepage/domain/about/dto/response/StaticWriteContentResponse.java
+++ b/src/main/java/com/keeper/homepage/domain/about/dto/response/StaticWriteContentResponse.java
@@ -3,7 +3,6 @@ package com.keeper.homepage.domain.about.dto.response;
 import static lombok.AccessLevel.PRIVATE;
 
 import com.keeper.homepage.domain.about.entity.StaticWriteContent;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -11,9 +10,7 @@ import lombok.Getter;
 public class StaticWriteContentResponse {
 
   private final Long id;
-
   private final String content;
-
   private final Integer displayOrder;
 
   public static StaticWriteContentResponse from(StaticWriteContent staticWriteContent) {

--- a/src/main/java/com/keeper/homepage/domain/about/dto/response/StaticWriteContentResponse.java
+++ b/src/main/java/com/keeper/homepage/domain/about/dto/response/StaticWriteContentResponse.java
@@ -4,20 +4,30 @@ import static lombok.AccessLevel.PRIVATE;
 
 import com.keeper.homepage.domain.about.entity.StaticWriteContent;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-@AllArgsConstructor(access = PRIVATE)
 public class StaticWriteContentResponse {
 
-  private Long id;
+  private final Long id;
 
-  private String content;
+  private final String content;
 
-  private Integer displayOrder;
+  private final Integer displayOrder;
 
   public static StaticWriteContentResponse from(StaticWriteContent staticWriteContent) {
-    return new StaticWriteContentResponse(staticWriteContent.getId(),
-        staticWriteContent.getContent(), staticWriteContent.getDisplayOrder());
+    return StaticWriteContentResponse.builder()
+        .id(staticWriteContent.getId())
+        .content(staticWriteContent.getContent())
+        .displayOrder(staticWriteContent.getDisplayOrder())
+        .build();
+  }
+
+  @Builder
+  private StaticWriteContentResponse(Long id, String content, Integer displayOrder) {
+    this.id = id;
+    this.content = content;
+    this.displayOrder = displayOrder;
   }
 }

--- a/src/main/java/com/keeper/homepage/domain/about/dto/response/StaticWriteContentResponse.java
+++ b/src/main/java/com/keeper/homepage/domain/about/dto/response/StaticWriteContentResponse.java
@@ -1,0 +1,23 @@
+package com.keeper.homepage.domain.about.dto.response;
+
+import static lombok.AccessLevel.PRIVATE;
+
+import com.keeper.homepage.domain.about.entity.StaticWriteContent;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = PRIVATE)
+public class StaticWriteContentResponse {
+
+  private Long id;
+
+  private String content;
+
+  private Integer displayOrder;
+
+  public static StaticWriteContentResponse from(StaticWriteContent staticWriteContent) {
+    return new StaticWriteContentResponse(staticWriteContent.getId(),
+        staticWriteContent.getContent(), staticWriteContent.getDisplayOrder());
+  }
+}

--- a/src/main/java/com/keeper/homepage/domain/about/dto/response/StaticWriteSubTitleImageResponse.java
+++ b/src/main/java/com/keeper/homepage/domain/about/dto/response/StaticWriteSubTitleImageResponse.java
@@ -15,11 +15,11 @@ import lombok.Getter;
 @AllArgsConstructor(access = PRIVATE)
 public class StaticWriteSubTitleImageResponse {
 
-  private final Long id;
-  private final String subtitle;
-  private final String thumbnailPath;
-  private final Integer displayOrder;
-  private final List<StaticWriteContentResponse> staticWriteContents;
+  private Long id;
+  private String subtitle;
+  private String thumbnailPath;
+  private Integer displayOrder;
+  private List<StaticWriteContentResponse> staticWriteContents;
 
   public static StaticWriteSubTitleImageResponse from(StaticWriteSubtitleImage subtitleImage) {
     return StaticWriteSubTitleImageResponse.builder()

--- a/src/main/java/com/keeper/homepage/domain/about/dto/response/StaticWriteSubTitleImageResponse.java
+++ b/src/main/java/com/keeper/homepage/domain/about/dto/response/StaticWriteSubTitleImageResponse.java
@@ -4,31 +4,44 @@ import static java.util.stream.Collectors.toList;
 import static lombok.AccessLevel.PRIVATE;
 
 import com.keeper.homepage.domain.about.entity.StaticWriteSubtitleImage;
+import com.keeper.homepage.domain.about.entity.StaticWriteTitle;
 import java.util.List;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-@AllArgsConstructor(access = PRIVATE)
 public class StaticWriteSubTitleImageResponse {
 
-  private Long id;
+  private final Long id;
 
-  private String subtitle;
+  private final String subtitle;
 
-  private String thumbnailPath;
+  private final String thumbnailPath;
 
-  private Integer displayOrder;
+  private final Integer displayOrder;
 
-  private List<StaticWriteContentResponse> staticWriteContents;
+  private final List<StaticWriteContentResponse> staticWriteContents;
 
   public static StaticWriteSubTitleImageResponse from(StaticWriteSubtitleImage subtitleImage) {
-    return new StaticWriteSubTitleImageResponse(subtitleImage.getId(),
-        subtitleImage.getSubtitle(),
-        subtitleImage.getThumbnail() != null ? subtitleImage.getThumbnail().getPath() : null,
-        subtitleImage.getDisplayOrder(),
-        subtitleImage.getStaticWriteContents().stream()
+    return StaticWriteSubTitleImageResponse.builder()
+        .id(subtitleImage.getId())
+        .subtitle(subtitleImage.getSubtitle())
+        .thumbnailPath(subtitleImage.getThumbnail() != null ? subtitleImage.getThumbnail().getPath() : null)
+        .displayOrder(subtitleImage.getDisplayOrder())
+        .staticWriteContents(subtitleImage.getStaticWriteContents().stream()
             .map(StaticWriteContentResponse::from)
-            .collect(toList()));
+            .collect(toList()))
+        .build();
+  }
+
+  @Builder
+  private StaticWriteSubTitleImageResponse(Long id, String subtitle, String thumbnailPath,
+      Integer displayOrder, List<StaticWriteContentResponse> staticWriteContents) {
+    this.id = id;
+    this.subtitle = subtitle;
+    this.thumbnailPath = thumbnailPath;
+    this.displayOrder = displayOrder;
+    this.staticWriteContents = staticWriteContents;
   }
 }

--- a/src/main/java/com/keeper/homepage/domain/about/dto/response/StaticWriteSubTitleImageResponse.java
+++ b/src/main/java/com/keeper/homepage/domain/about/dto/response/StaticWriteSubTitleImageResponse.java
@@ -1,0 +1,34 @@
+package com.keeper.homepage.domain.about.dto.response;
+
+import static java.util.stream.Collectors.toList;
+import static lombok.AccessLevel.PRIVATE;
+
+import com.keeper.homepage.domain.about.entity.StaticWriteSubtitleImage;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = PRIVATE)
+public class StaticWriteSubTitleImageResponse {
+
+  private Long id;
+
+  private String subtitle;
+
+  private String thumbnailPath;
+
+  private Integer displayOrder;
+
+  private List<StaticWriteContentResponse> staticWriteContents;
+
+  public static StaticWriteSubTitleImageResponse from(StaticWriteSubtitleImage subtitleImage) {
+    return new StaticWriteSubTitleImageResponse(subtitleImage.getId(),
+        subtitleImage.getSubtitle(),
+        subtitleImage.getThumbnail() != null ? subtitleImage.getThumbnail().getPath() : null,
+        subtitleImage.getDisplayOrder(),
+        subtitleImage.getStaticWriteContents().stream()
+            .map(StaticWriteContentResponse::from)
+            .collect(toList()));
+  }
+}

--- a/src/main/java/com/keeper/homepage/domain/about/dto/response/StaticWriteSubTitleImageResponse.java
+++ b/src/main/java/com/keeper/homepage/domain/about/dto/response/StaticWriteSubTitleImageResponse.java
@@ -11,6 +11,8 @@ import lombok.Builder;
 import lombok.Getter;
 
 @Getter
+@Builder
+@AllArgsConstructor(access = PRIVATE)
 public class StaticWriteSubTitleImageResponse {
 
   private final Long id;
@@ -29,15 +31,5 @@ public class StaticWriteSubTitleImageResponse {
             .map(StaticWriteContentResponse::from)
             .collect(toList()))
         .build();
-  }
-
-  @Builder
-  private StaticWriteSubTitleImageResponse(Long id, String subtitle, String thumbnailPath,
-      Integer displayOrder, List<StaticWriteContentResponse> staticWriteContents) {
-    this.id = id;
-    this.subtitle = subtitle;
-    this.thumbnailPath = thumbnailPath;
-    this.displayOrder = displayOrder;
-    this.staticWriteContents = staticWriteContents;
   }
 }

--- a/src/main/java/com/keeper/homepage/domain/about/dto/response/StaticWriteSubTitleImageResponse.java
+++ b/src/main/java/com/keeper/homepage/domain/about/dto/response/StaticWriteSubTitleImageResponse.java
@@ -14,13 +14,9 @@ import lombok.Getter;
 public class StaticWriteSubTitleImageResponse {
 
   private final Long id;
-
   private final String subtitle;
-
   private final String thumbnailPath;
-
   private final Integer displayOrder;
-
   private final List<StaticWriteContentResponse> staticWriteContents;
 
   public static StaticWriteSubTitleImageResponse from(StaticWriteSubtitleImage subtitleImage) {

--- a/src/main/java/com/keeper/homepage/domain/about/dto/response/StaticWriteTitleResponse.java
+++ b/src/main/java/com/keeper/homepage/domain/about/dto/response/StaticWriteTitleResponse.java
@@ -14,10 +14,10 @@ import lombok.Getter;
 @AllArgsConstructor(access = PRIVATE)
 public class StaticWriteTitleResponse {
 
-  private final Long id;
-  private final String title;
-  private final String type;
-  private final List<StaticWriteSubTitleImageResponse> subtitleImages;
+  private Long id;
+  private String title;
+  private String type;
+  private List<StaticWriteSubTitleImageResponse> subtitleImages;
 
   public static StaticWriteTitleResponse from(StaticWriteTitle title) {
     return StaticWriteTitleResponse.builder()

--- a/src/main/java/com/keeper/homepage/domain/about/dto/response/StaticWriteTitleResponse.java
+++ b/src/main/java/com/keeper/homepage/domain/about/dto/response/StaticWriteTitleResponse.java
@@ -5,28 +5,38 @@ import static lombok.AccessLevel.PRIVATE;
 
 import com.keeper.homepage.domain.about.entity.StaticWriteTitle;
 import java.util.List;
-import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-@AllArgsConstructor(access = PRIVATE)
 public class StaticWriteTitleResponse {
 
-  private Long id;
+  private final Long id;
 
-  private String title;
+  private final String title;
 
-  private String type;
+  private final String type;
 
-  private List<StaticWriteSubTitleImageResponse> subtitleImages;
+  private final List<StaticWriteSubTitleImageResponse> subtitleImages;
 
   public static StaticWriteTitleResponse from(StaticWriteTitle title) {
-    return new StaticWriteTitleResponse(title.getId(),
-        title.getTitle(),
-        title.getType().getType(),
-        title.getStaticWriteSubtitleImages().stream()
+    return StaticWriteTitleResponse.builder()
+        .id(title.getId())
+        .title(title.getTitle())
+        .type(title.getType().getType())
+        .subtitleImages(title.getStaticWriteSubtitleImages().stream()
             .map(StaticWriteSubTitleImageResponse::from)
-            .collect(toList()));
+            .collect(toList()))
+        .build();
+  }
+
+  @Builder
+  private StaticWriteTitleResponse(Long id, String title, String type,
+      List<StaticWriteSubTitleImageResponse> subtitleImages) {
+    this.id = id;
+    this.title = title;
+    this.type = type;
+    this.subtitleImages = subtitleImages;
   }
 }

--- a/src/main/java/com/keeper/homepage/domain/about/dto/response/StaticWriteTitleResponse.java
+++ b/src/main/java/com/keeper/homepage/domain/about/dto/response/StaticWriteTitleResponse.java
@@ -11,11 +11,8 @@ import lombok.Getter;
 public class StaticWriteTitleResponse {
 
   private final Long id;
-
   private final String title;
-
   private final String type;
-
   private final List<StaticWriteSubTitleImageResponse> subtitleImages;
 
   public static StaticWriteTitleResponse from(StaticWriteTitle title) {

--- a/src/main/java/com/keeper/homepage/domain/about/dto/response/StaticWriteTitleResponse.java
+++ b/src/main/java/com/keeper/homepage/domain/about/dto/response/StaticWriteTitleResponse.java
@@ -1,0 +1,22 @@
+package com.keeper.homepage.domain.about.dto.response;
+
+import static java.util.stream.Collectors.toList;
+import static lombok.AccessLevel.PRIVATE;
+
+import com.keeper.homepage.domain.about.entity.StaticWriteTitle;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = PRIVATE)
+public class StaticWriteTitleResponse {
+
+  private List<String> list;
+
+  public static StaticWriteTitleResponse from(List<StaticWriteTitle> staticWriteTitles) {
+    return new StaticWriteTitleResponse(staticWriteTitles.stream()
+        .map(staticWriteTitle -> staticWriteTitle.getType().getType())
+        .collect(toList()));
+  }
+}

--- a/src/main/java/com/keeper/homepage/domain/about/dto/response/StaticWriteTitleResponse.java
+++ b/src/main/java/com/keeper/homepage/domain/about/dto/response/StaticWriteTitleResponse.java
@@ -5,6 +5,7 @@ import static lombok.AccessLevel.PRIVATE;
 
 import com.keeper.homepage.domain.about.entity.StaticWriteTitle;
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -12,11 +13,20 @@ import lombok.Getter;
 @AllArgsConstructor(access = PRIVATE)
 public class StaticWriteTitleResponse {
 
-  private List<String> list;
+  private Long id;
 
-  public static StaticWriteTitleResponse from(List<StaticWriteTitle> staticWriteTitles) {
-    return new StaticWriteTitleResponse(staticWriteTitles.stream()
-        .map(staticWriteTitle -> staticWriteTitle.getType().getType())
-        .collect(toList()));
+  private String title;
+
+  private String type;
+
+  private List<StaticWriteSubTitleImageResponse> subtitleImages;
+
+  public static StaticWriteTitleResponse from(StaticWriteTitle title) {
+    return new StaticWriteTitleResponse(title.getId(),
+        title.getTitle(),
+        title.getType().getType(),
+        title.getStaticWriteSubtitleImages().stream()
+            .map(StaticWriteSubTitleImageResponse::from)
+            .collect(toList()));
   }
 }

--- a/src/main/java/com/keeper/homepage/domain/about/dto/response/StaticWriteTitleResponse.java
+++ b/src/main/java/com/keeper/homepage/domain/about/dto/response/StaticWriteTitleResponse.java
@@ -1,11 +1,9 @@
 package com.keeper.homepage.domain.about.dto.response;
 
 import static java.util.stream.Collectors.toList;
-import static lombok.AccessLevel.PRIVATE;
 
 import com.keeper.homepage.domain.about.entity.StaticWriteTitle;
 import java.util.List;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -24,7 +22,7 @@ public class StaticWriteTitleResponse {
     return StaticWriteTitleResponse.builder()
         .id(title.getId())
         .title(title.getTitle())
-        .type(title.getType().getType())
+        .type(title.getStaticWriteTitleType().getType())
         .subtitleImages(title.getStaticWriteSubtitleImages().stream()
             .map(StaticWriteSubTitleImageResponse::from)
             .collect(toList()))

--- a/src/main/java/com/keeper/homepage/domain/about/dto/response/StaticWriteTitleResponse.java
+++ b/src/main/java/com/keeper/homepage/domain/about/dto/response/StaticWriteTitleResponse.java
@@ -1,13 +1,17 @@
 package com.keeper.homepage.domain.about.dto.response;
 
 import static java.util.stream.Collectors.toList;
+import static lombok.AccessLevel.PRIVATE;
 
 import com.keeper.homepage.domain.about.entity.StaticWriteTitle;
 import java.util.List;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
+@Builder
+@AllArgsConstructor(access = PRIVATE)
 public class StaticWriteTitleResponse {
 
   private final Long id;
@@ -24,14 +28,5 @@ public class StaticWriteTitleResponse {
             .map(StaticWriteSubTitleImageResponse::from)
             .collect(toList()))
         .build();
-  }
-
-  @Builder
-  private StaticWriteTitleResponse(Long id, String title, String type,
-      List<StaticWriteSubTitleImageResponse> subtitleImages) {
-    this.id = id;
-    this.title = title;
-    this.type = type;
-    this.subtitleImages = subtitleImages;
   }
 }

--- a/src/main/java/com/keeper/homepage/domain/about/dto/response/StaticWriteTitleTypeResponse.java
+++ b/src/main/java/com/keeper/homepage/domain/about/dto/response/StaticWriteTitleTypeResponse.java
@@ -1,0 +1,22 @@
+package com.keeper.homepage.domain.about.dto.response;
+
+import static java.util.stream.Collectors.toList;
+import static lombok.AccessLevel.PRIVATE;
+
+import com.keeper.homepage.domain.about.entity.StaticWriteTitle;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = PRIVATE)
+public class StaticWriteTitleTypeResponse {
+
+  private List<String> list;
+
+  public static StaticWriteTitleTypeResponse from(List<StaticWriteTitle> staticWriteTitles) {
+    return new StaticWriteTitleTypeResponse(staticWriteTitles.stream()
+        .map(staticWriteTitle -> staticWriteTitle.getType().getType())
+        .collect(toList()));
+  }
+}

--- a/src/main/java/com/keeper/homepage/domain/about/dto/response/StaticWriteTitleTypeResponse.java
+++ b/src/main/java/com/keeper/homepage/domain/about/dto/response/StaticWriteTitleTypeResponse.java
@@ -16,7 +16,7 @@ public class StaticWriteTitleTypeResponse {
 
   public static StaticWriteTitleTypeResponse from(List<StaticWriteTitle> staticWriteTitles) {
     return new StaticWriteTitleTypeResponse(staticWriteTitles.stream()
-        .map(staticWriteTitle -> staticWriteTitle.getType().getType())
+        .map(staticWriteTitle -> staticWriteTitle.getStaticWriteTitleType().getType())
         .collect(toList()));
   }
 }

--- a/src/main/java/com/keeper/homepage/domain/about/entity/StaticWriteSubtitleImage.java
+++ b/src/main/java/com/keeper/homepage/domain/about/entity/StaticWriteSubtitleImage.java
@@ -11,7 +11,10 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -41,6 +44,9 @@ public class StaticWriteSubtitleImage {
 
   @Column(name = "display_order", nullable = false)
   private int displayOrder;
+
+  @OneToMany(mappedBy = "staticWriteSubtitleImage", cascade = REMOVE)
+  private final List<StaticWriteContent> staticWriteContents = new ArrayList<>();
 
   public void updateStaticWriteSubtitleImage(String subtitle, StaticWriteTitle staticWriteTitle,
       Thumbnail thumbnail, int displayOrder) {

--- a/src/main/java/com/keeper/homepage/domain/about/entity/StaticWriteTitle.java
+++ b/src/main/java/com/keeper/homepage/domain/about/entity/StaticWriteTitle.java
@@ -1,16 +1,22 @@
 package com.keeper.homepage.domain.about.entity;
 
+import static com.keeper.homepage.global.error.ErrorCode.TITLE_TYPE_NOT_FOUND;
+import static jakarta.persistence.CascadeType.REMOVE;
 import static jakarta.persistence.GenerationType.IDENTITY;
 import static java.lang.String.format;
 
 import com.keeper.homepage.domain.about.converter.StaticWriteTitleTypeConverter;
+import com.keeper.homepage.global.error.BusinessException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -34,6 +40,9 @@ public class StaticWriteTitle {
   @Convert(converter = StaticWriteTitleTypeConverter.class)
   @Column(name = "type", nullable = false)
   private StaticWriteTitleType type;
+
+  @OneToMany(mappedBy = "staticWriteTitle", cascade = REMOVE)
+  private final List<StaticWriteSubtitleImage> staticWriteSubtitleImages = new ArrayList<>();
 
   public static StaticWriteTitle getStaticWriteTitleBy(StaticWriteTitleType type) {
     return StaticWriteTitle.builder()

--- a/src/main/java/com/keeper/homepage/domain/about/entity/StaticWriteTitle.java
+++ b/src/main/java/com/keeper/homepage/domain/about/entity/StaticWriteTitle.java
@@ -39,24 +39,24 @@ public class StaticWriteTitle {
 
   @Convert(converter = StaticWriteTitleTypeConverter.class)
   @Column(name = "type", nullable = false)
-  private StaticWriteTitleType type;
+  private StaticWriteTitleType staticWriteTitleType;
 
   @OneToMany(mappedBy = "staticWriteTitle", cascade = REMOVE)
   private final List<StaticWriteSubtitleImage> staticWriteSubtitleImages = new ArrayList<>();
 
   public static StaticWriteTitle getStaticWriteTitleBy(StaticWriteTitleType type) {
     return StaticWriteTitle.builder()
-        .id(type.id)
-        .title(type.title)
-        .type(type)
+        .id(type.getId())
+        .title(type.getTitle())
+        .staticWriteTitleType(type)
         .build();
   }
 
   @Builder
-  private StaticWriteTitle(Long id, String title, StaticWriteTitleType type) {
+  private StaticWriteTitle(Long id, String title, StaticWriteTitleType staticWriteTitleType) {
     this.id = id;
     this.title = title;
-    this.type = type;
+    this.staticWriteTitleType = staticWriteTitleType;
   }
 
   @Getter

--- a/src/main/java/com/keeper/homepage/domain/about/entity/StaticWriteTitle.java
+++ b/src/main/java/com/keeper/homepage/domain/about/entity/StaticWriteTitle.java
@@ -71,11 +71,11 @@ public class StaticWriteTitle {
     private final String title;
     private final String type;
 
-    public static StaticWriteTitleType fromCode(String dbData) {
+    public static StaticWriteTitleType fromCode(String type) {
       return Arrays.stream(StaticWriteTitleType.values())
-          .filter(type -> type.getType().equals(dbData))
+          .filter(staticWriteTitleType -> staticWriteTitleType.getType().equals(type))
           .findAny()
-          .orElseThrow(() -> new IllegalArgumentException(format("%s 타입이 DB에 존재하지 않습니다.", dbData)));
+          .orElseThrow(() -> new BusinessException(type, "type", TITLE_TYPE_NOT_FOUND));
     }
   }
 

--- a/src/main/java/com/keeper/homepage/global/config/security/SecurityConfiguration.java
+++ b/src/main/java/com/keeper/homepage/global/config/security/SecurityConfiguration.java
@@ -34,7 +34,7 @@ public class SecurityConfiguration {
   @Bean
   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
     http.authorizeHttpRequests()
-        .requestMatchers("/docs/*", "/keeper_files/**", "/auth-test", "/sign-up/**", "/error")
+        .requestMatchers("/docs/*", "/keeper_files/**", "/auth-test", "/sign-up/**", "/error", "/about/**")
         .permitAll()
         .anyRequest().hasRole("회원")
         .and()

--- a/src/main/java/com/keeper/homepage/global/error/ErrorCode.java
+++ b/src/main/java/com/keeper/homepage/global/error/ErrorCode.java
@@ -19,6 +19,8 @@ public enum ErrorCode {
   MEMBER_EMAIL_DUPLICATE("회원 이메일이 중복됩니다.", HttpStatus.CONFLICT),
   MEMBER_LOGIN_ID_DUPLICATE("회원의 로그인 아이디가 중복됩니다.", HttpStatus.CONFLICT),
   MEMBER_STUDENT_ID_DUPLICATE("회원의 학번이 중복됩니다.", HttpStatus.CONFLICT),
+  // ABOUT
+  TITLE_TYPE_NOT_FOUND("해당 타입의 타이틀을 찾을 수 없습니다.", HttpStatus.NOT_FOUND)
   ;
 
   private final String message;

--- a/src/test/java/com/keeper/homepage/IntegrationTest.java
+++ b/src/test/java/com/keeper/homepage/IntegrationTest.java
@@ -9,6 +9,7 @@ import static org.springframework.security.test.web.servlet.setup.SecurityMockMv
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.keeper.homepage.domain.about.StaticWriteTestHelper;
+import com.keeper.homepage.domain.about.application.StaticWriteService;
 import com.keeper.homepage.domain.about.dao.StaticWriteContentRepository;
 import com.keeper.homepage.domain.about.dao.StaticWriteSubtitleImageRepository;
 import com.keeper.homepage.domain.about.dao.StaticWriteTitleRepository;
@@ -104,6 +105,9 @@ public class IntegrationTest {
 
   @Autowired
   protected MailUtil mailUtil;
+
+  @Autowired
+  protected StaticWriteService staticWriteService;
 
   /******* Helper *******/
 

--- a/src/test/java/com/keeper/homepage/domain/about/StaticWriteTestHelper.java
+++ b/src/test/java/com/keeper/homepage/domain/about/StaticWriteTestHelper.java
@@ -26,7 +26,7 @@ public class StaticWriteTestHelper {
   public StaticWriteTitle generateStaticWriteTitle() {
     return staticWriteTitleRepository.save(StaticWriteTitle.builder()
         .title("테스트 타이틀")
-        .type(ACTIVITY)
+        .staticWriteTitleType(ACTIVITY)
         .build());
   }
 

--- a/src/test/java/com/keeper/homepage/domain/about/api/StaticWriteControllerTest.java
+++ b/src/test/java/com/keeper/homepage/domain/about/api/StaticWriteControllerTest.java
@@ -40,7 +40,7 @@ public class StaticWriteControllerTest extends IntegrationTest {
 
     @Test
     @DisplayName("타이틀 타입으로 페이지 블럭 조회시 해당 타이틀의 페이지 블럭이 성공적으로 조회되어야 한다.")
-    void should_getAllTitlesSuccessfully_when_getTitlesByType() throws Exception {
+    void should_getTitleSuccessfully_when_getTitleByType() throws Exception {
       String activity = ACTIVITY.getType();
       mockMvc.perform(get("/about/titles/types/{type}", activity))
           .andExpect(status().isOk())

--- a/src/test/java/com/keeper/homepage/domain/about/api/StaticWriteControllerTest.java
+++ b/src/test/java/com/keeper/homepage/domain/about/api/StaticWriteControllerTest.java
@@ -1,0 +1,37 @@
+package com.keeper.homepage.domain.about.api;
+
+import static com.keeper.homepage.domain.auth.application.EmailAuthService.EMAIL_EXPIRED_SECONDS;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.keeper.homepage.IntegrationTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+public class StaticWriteControllerTest extends IntegrationTest {
+
+  @Nested
+  @DisplayName("타이틀 타입 조회 테스트")
+  class StaticWriteTitleTest {
+
+    @Test
+    @DisplayName("타이틀 타입 조회 시 모든 값이 성공적으로 조회되어야 한다.")
+    void should_getAllTypesSuccessfully_when_getAllTypes() throws Exception {
+      mockMvc.perform(get("/about/types"))
+          .andExpect(status().isOk())
+          .andDo(document("about-types",
+              responseFields(
+                  fieldWithPath("list").description("타이틀 타입의 리스트 입니다.")
+              )));
+    }
+  }
+
+}

--- a/src/test/java/com/keeper/homepage/domain/about/api/StaticWriteControllerTest.java
+++ b/src/test/java/com/keeper/homepage/domain/about/api/StaticWriteControllerTest.java
@@ -1,13 +1,18 @@
 package com.keeper.homepage.domain.about.api;
 
-import static com.keeper.homepage.domain.auth.application.EmailAuthService.EMAIL_EXPIRED_SECONDS;
-import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static com.keeper.homepage.domain.about.entity.StaticWriteTitle.StaticWriteTitleType.ACTIVITY;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.hamcrest.Matchers.containsString;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.subsectionWithPath;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -19,18 +24,59 @@ import org.junit.jupiter.api.Test;
 public class StaticWriteControllerTest extends IntegrationTest {
 
   @Nested
-  @DisplayName("타이틀 타입 조회 테스트")
+  @DisplayName("타이틀 조회 테스트")
   class StaticWriteTitleTest {
 
     @Test
     @DisplayName("타이틀 타입 조회 시 모든 값이 성공적으로 조회되어야 한다.")
     void should_getAllTypesSuccessfully_when_getAllTypes() throws Exception {
-      mockMvc.perform(get("/about/types"))
+      mockMvc.perform(get("/about/titles/types"))
           .andExpect(status().isOk())
-          .andDo(document("about-types",
+          .andDo(document("about-title-types",
               responseFields(
                   fieldWithPath("list").description("타이틀 타입의 리스트 입니다.")
               )));
+    }
+
+    @Test
+    @DisplayName("타이틀 타입으로 페이지 블럭 조회시 해당 타이틀의 페이지 블럭이 성공적으로 조회되어야 한다.")
+    void should_getAllTitlesSuccessfully_when_getTitlesByType() throws Exception {
+      String activity = ACTIVITY.getType();
+      mockMvc.perform(get("/about/titles/types/{type}", activity))
+          .andExpect(status().isOk())
+          .andDo(document("about-title-by-type",
+              pathParameters(
+                  parameterWithName("type").description("찾고자 하는 페이지 블럭 타이틀의 타입")
+              ),
+              responseFields(
+                  fieldWithPath("id").description("해당 타입과 일치하는 페이지 블럭 타이틀 ID"),
+                  fieldWithPath("title").description("해당 타입과 일치하는 페이지 블럭 타이틀 제목"),
+                  fieldWithPath("type").description("해당 타입과 일치하는 페이지 블럭 타이틀 타입"),
+                  subsectionWithPath("subtitleImages")
+                      .description("페이지 블럭 타이틀과 연결된 페이지 블럭 서브 타이틀 데이터 리스트"),
+                  subsectionWithPath("subtitleImages[].id").description("페이지 블럭 서브 타이틀 ID"),
+                  subsectionWithPath("subtitleImages[].subtitle").description("페이지 블럭 서브 타이틀 이름"),
+                  subsectionWithPath("subtitleImages[].thumbnailPath")
+                      .description("페이지 블럭 서브 타이틀 썸네일 경로"),
+                  subsectionWithPath("subtitleImages[].displayOrder")
+                      .description("페이지 블럭 서브 타이틀 우선순위"),
+                  subsectionWithPath("subtitleImages[].staticWriteContents")
+                      .description("페이지 블럭 서브 타이틀과 연결된 페이지 블럭 컨텐츠 리스트"),
+                  subsectionWithPath("subtitleImages[].staticWriteContents[].id")
+                      .description("페이지 블럭 컨텐츠 ID"),
+                  subsectionWithPath("subtitleImages[].staticWriteContents[].content")
+                      .description("페이지 블럭 컨텐츠 이름"),
+                  subsectionWithPath("subtitleImages[].staticWriteContents[].displayOrder")
+                      .description("페이지 블럭 컨텐츠 우선순위")
+              )));
+    }
+
+    @Test
+    @DisplayName("DB에서 찾을 수 없는 타입으로 타이틀 조회 시 404 Not Found를 반환해야 한다.")
+    void should_404NotFound_when_getTitlesByNotFoundType() throws Exception {
+      mockMvc.perform(get("/about/titles/types/{type}", "null"))
+          .andExpect(status().isNotFound())
+          .andExpect(content().string(containsString("해당 타입의 타이틀을 찾을 수 없습니다.")));
     }
   }
 

--- a/src/test/java/com/keeper/homepage/domain/about/application/StaticWriteServiceTest.java
+++ b/src/test/java/com/keeper/homepage/domain/about/application/StaticWriteServiceTest.java
@@ -34,9 +34,9 @@ public class StaticWriteServiceTest extends IntegrationTest {
 
   @Test
   @DisplayName("각 타이틀 타입으로 페이지 블럭 조회 시 성공적으로 조회되어야 한다.")
-  void should_getTitlesSuccessfully_when_getTitlesByType() {
+  void should_getTitleSuccessfully_when_getTitleByType() {
     StaticWriteTitleType type = ACTIVITY;
-    StaticWriteTitleResponse response = staticWriteService.getAllByType(type.getType());
+    StaticWriteTitleResponse response = staticWriteService.getTitleByType(type.getType());
 
     assertThat(response.getId()).isEqualTo(type.getId());
     assertThat(response.getTitle()).isEqualTo(type.getTitle());
@@ -46,7 +46,7 @@ public class StaticWriteServiceTest extends IntegrationTest {
   @Test
   @DisplayName("DB에서 찾을 수 없는 타입으로 타이틀 조회 시 Exception을 발생시킨다.")
   void should_throwException_when_getTitlesByNotFoundType() {
-    assertThatThrownBy(() -> staticWriteService.getAllByType("null"))
+    assertThatThrownBy(() -> staticWriteService.getTitleByType("null"))
         .isInstanceOf(BusinessException.class)
         .hasMessageContaining("해당 타입의 타이틀을 찾을 수 없습니다.");
   }

--- a/src/test/java/com/keeper/homepage/domain/about/application/StaticWriteServiceTest.java
+++ b/src/test/java/com/keeper/homepage/domain/about/application/StaticWriteServiceTest.java
@@ -1,11 +1,15 @@
 package com.keeper.homepage.domain.about.application;
 
+import static com.keeper.homepage.domain.about.entity.StaticWriteTitle.StaticWriteTitleType.ACTIVITY;
 import static java.util.Arrays.stream;
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.keeper.homepage.IntegrationTest;
+import com.keeper.homepage.domain.about.dto.response.StaticWriteTitleResponse;
 import com.keeper.homepage.domain.about.entity.StaticWriteTitle.StaticWriteTitleType;
+import com.keeper.homepage.global.error.BusinessException;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -26,5 +30,24 @@ public class StaticWriteServiceTest extends IntegrationTest {
     for (int i = 0; i < staticWriteTitleTypes.size(); ++i) {
       assertThat(response.get(i)).isEqualTo(staticWriteTitleTypes.get(i));
     }
+  }
+
+  @Test
+  @DisplayName("각 타이틀 타입으로 페이지 블럭 조회 시 성공적으로 조회되어야 한다.")
+  void should_getTitlesSuccessfully_when_getTitlesByType() {
+    StaticWriteTitleType type = ACTIVITY;
+    StaticWriteTitleResponse response = staticWriteService.getAllByType(type.getType());
+
+    assertThat(response.getId()).isEqualTo(type.getId());
+    assertThat(response.getTitle()).isEqualTo(type.getTitle());
+    assertThat(response.getType()).isEqualTo(type.getType());
+  }
+
+  @Test
+  @DisplayName("DB에서 찾을 수 없는 타입으로 타이틀 조회 시 Exception을 발생시킨다.")
+  void should_throwException_when_getTitlesByNotFoundType() {
+    assertThatThrownBy(() -> staticWriteService.getAllByType("null"))
+        .isInstanceOf(BusinessException.class)
+        .hasMessageContaining("해당 타입의 타이틀을 찾을 수 없습니다.");
   }
 }

--- a/src/test/java/com/keeper/homepage/domain/about/application/StaticWriteServiceTest.java
+++ b/src/test/java/com/keeper/homepage/domain/about/application/StaticWriteServiceTest.java
@@ -1,0 +1,30 @@
+package com.keeper.homepage.domain.about.application;
+
+import static java.util.Arrays.stream;
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.keeper.homepage.IntegrationTest;
+import com.keeper.homepage.domain.about.entity.StaticWriteTitle.StaticWriteTitleType;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class StaticWriteServiceTest extends IntegrationTest {
+
+  @Test
+  @DisplayName("타이틀 타입 조회 시 모든 값이 성공적으로 조회되어야 한다.")
+  void should_getAllTypesSuccessfully_when_getAllTypes() {
+    List<String> staticWriteTitleTypes = stream(StaticWriteTitleType.values())
+        .map(StaticWriteTitleType::getType)
+        .collect(toList());
+    List<String> response = staticWriteService.getAllTypes()
+        .getList();
+
+    assertThat(response.size()).isEqualTo(staticWriteTitleTypes.size());
+    assertThat(response).containsAll(staticWriteTitleTypes);
+    for (int i = 0; i < staticWriteTitleTypes.size(); ++i) {
+      assertThat(response.get(i)).isEqualTo(staticWriteTitleTypes.get(i));
+    }
+  }
+}

--- a/src/test/java/com/keeper/homepage/domain/about/dao/StaticWriteRepositoryTest.java
+++ b/src/test/java/com/keeper/homepage/domain/about/dao/StaticWriteRepositoryTest.java
@@ -179,11 +179,11 @@ public class StaticWriteRepositoryTest extends IntegrationTest {
 
       // when
       List<StaticWriteContent> staticWriteContents = staticWriteContentRepository
-          .findAllByStaticWriteSubtitleImage_StaticWriteTitle_Type(type);
+          .findAllByStaticWriteSubtitleImage_StaticWriteTitle_StaticWriteTitleType(type);
 
       List<StaticWriteTitleType> contentTypes = staticWriteContents
           .stream()
-          .map(s -> s.getStaticWriteSubtitleImage().getStaticWriteTitle().getType())
+          .map(s -> s.getStaticWriteSubtitleImage().getStaticWriteTitle().getStaticWriteTitleType())
           .toList();
 
       // then


### PR DESCRIPTION
## 🔥 Related Issue

close: #35

## 📝 Description

페이지 블럭 타입의 리스트 조회, 타입으로 페이지 블럭 리스트 조회 API 개발을 했습니다.

## ⭐️ Review

간단한 조회 API 구현임에도, 이것 저것 생각할 게 많았습니다!
아직 부족한 점이 많네요! 코드리뷰 해주시면 감사합니다.