### PR TITLE
Feature/feature/#52 회원의 각 컬럼을 객체로 분리

### DIFF
--- a/src/main/java/com/keeper/homepage/domain/auth/api/SignUpController.java
+++ b/src/main/java/com/keeper/homepage/domain/auth/api/SignUpController.java
@@ -7,6 +7,7 @@ import com.keeper.homepage.domain.auth.dto.request.EmailAuthRequest;
 import com.keeper.homepage.domain.auth.dto.request.SignUpRequest;
 import com.keeper.homepage.domain.auth.dto.response.CheckDuplicateResponse;
 import com.keeper.homepage.domain.auth.dto.response.EmailAuthResponse;
+import com.keeper.homepage.domain.member.entity.embedded.EmailAddress;
 import com.keeper.homepage.domain.member.entity.embedded.LoginId;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
@@ -50,7 +51,7 @@ public class SignUpController {
 
   @GetMapping("/exists/email")
   public ResponseEntity<CheckDuplicateResponse> checkDuplicateEmail(
-      @RequestParam @NotNull String email) {
+      @RequestParam @NotNull EmailAddress email) {
     boolean isDuplicate = checkDuplicateService.isDuplicateEmail(email);
     return ResponseEntity.ok(CheckDuplicateResponse.from(isDuplicate));
   }

--- a/src/main/java/com/keeper/homepage/domain/auth/api/SignUpController.java
+++ b/src/main/java/com/keeper/homepage/domain/auth/api/SignUpController.java
@@ -13,7 +13,6 @@ import jakarta.validation.constraints.NotNull;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -29,11 +28,10 @@ public class SignUpController {
   private final SignUpService signUpService;
   private final EmailAuthService emailAuthService;
   private final CheckDuplicateService checkDuplicateService;
-  private final PasswordEncoder passwordEncoder;
 
   @PostMapping
   public ResponseEntity<Void> signUp(@RequestBody @Valid SignUpRequest request) {
-    long memberId = signUpService.signUp(request.toMemberProfile(passwordEncoder), request.getAuthCode());
+    long memberId = signUpService.signUp(request.toMemberProfile(), request.getAuthCode());
     return ResponseEntity.created(URI.create("/members/" + memberId)).build();
   }
 

--- a/src/main/java/com/keeper/homepage/domain/auth/api/SignUpController.java
+++ b/src/main/java/com/keeper/homepage/domain/auth/api/SignUpController.java
@@ -7,11 +7,13 @@ import com.keeper.homepage.domain.auth.dto.request.EmailAuthRequest;
 import com.keeper.homepage.domain.auth.dto.request.SignUpRequest;
 import com.keeper.homepage.domain.auth.dto.response.CheckDuplicateResponse;
 import com.keeper.homepage.domain.auth.dto.response.EmailAuthResponse;
+import com.keeper.homepage.domain.member.entity.embedded.LoginId;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -27,10 +29,11 @@ public class SignUpController {
   private final SignUpService signUpService;
   private final EmailAuthService emailAuthService;
   private final CheckDuplicateService checkDuplicateService;
+  private final PasswordEncoder passwordEncoder;
 
   @PostMapping
   public ResponseEntity<Void> signUp(@RequestBody @Valid SignUpRequest request) {
-    long memberId = signUpService.signUp(request);
+    long memberId = signUpService.signUp(request.toMemberProfile(passwordEncoder), request.getAuthCode());
     return ResponseEntity.created(URI.create("/members/" + memberId)).build();
   }
 
@@ -42,7 +45,7 @@ public class SignUpController {
 
   @GetMapping("/exists/login-id")
   public ResponseEntity<CheckDuplicateResponse> checkDuplicateLoginId(
-      @RequestParam @NotNull String loginId) {
+      @RequestParam @NotNull LoginId loginId) {
     boolean isDuplicate = checkDuplicateService.isDuplicateLoginId(loginId);
     return ResponseEntity.ok(CheckDuplicateResponse.from(isDuplicate));
   }

--- a/src/main/java/com/keeper/homepage/domain/auth/api/SignUpController.java
+++ b/src/main/java/com/keeper/homepage/domain/auth/api/SignUpController.java
@@ -9,6 +9,7 @@ import com.keeper.homepage.domain.auth.dto.response.CheckDuplicateResponse;
 import com.keeper.homepage.domain.auth.dto.response.EmailAuthResponse;
 import com.keeper.homepage.domain.member.entity.embedded.EmailAddress;
 import com.keeper.homepage.domain.member.entity.embedded.LoginId;
+import com.keeper.homepage.domain.member.entity.embedded.StudentId;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import java.net.URI;
@@ -58,7 +59,7 @@ public class SignUpController {
 
   @GetMapping("/exists/student-id")
   public ResponseEntity<CheckDuplicateResponse> checkDuplicateStudentId(
-      @RequestParam @NotNull String studentId) {
+      @RequestParam @NotNull StudentId studentId) {
     boolean isDuplicate = checkDuplicateService.isDuplicateStudentID(studentId);
     return ResponseEntity.ok(CheckDuplicateResponse.from(isDuplicate));
   }

--- a/src/main/java/com/keeper/homepage/domain/auth/application/CheckDuplicateService.java
+++ b/src/main/java/com/keeper/homepage/domain/auth/application/CheckDuplicateService.java
@@ -3,6 +3,7 @@ package com.keeper.homepage.domain.auth.application;
 import com.keeper.homepage.domain.member.dao.MemberRepository;
 import com.keeper.homepage.domain.member.entity.embedded.EmailAddress;
 import com.keeper.homepage.domain.member.entity.embedded.LoginId;
+import com.keeper.homepage.domain.member.entity.embedded.StudentId;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,7 +23,7 @@ public class CheckDuplicateService {
     return memberRepository.existsByProfileLoginId(loginId);
   }
 
-  public boolean isDuplicateStudentID(String studentId) {
+  public boolean isDuplicateStudentID(StudentId studentId) {
     return memberRepository.existsByProfileStudentId(studentId);
   }
 }

--- a/src/main/java/com/keeper/homepage/domain/auth/application/CheckDuplicateService.java
+++ b/src/main/java/com/keeper/homepage/domain/auth/application/CheckDuplicateService.java
@@ -1,6 +1,7 @@
 package com.keeper.homepage.domain.auth.application;
 
 import com.keeper.homepage.domain.member.dao.MemberRepository;
+import com.keeper.homepage.domain.member.entity.embedded.EmailAddress;
 import com.keeper.homepage.domain.member.entity.embedded.LoginId;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -13,7 +14,7 @@ public class CheckDuplicateService {
 
   private final MemberRepository memberRepository;
 
-  public boolean isDuplicateEmail(String email) {
+  public boolean isDuplicateEmail(EmailAddress email) {
     return memberRepository.existsByProfileEmailAddress(email);
   }
 

--- a/src/main/java/com/keeper/homepage/domain/auth/application/CheckDuplicateService.java
+++ b/src/main/java/com/keeper/homepage/domain/auth/application/CheckDuplicateService.java
@@ -1,6 +1,7 @@
 package com.keeper.homepage.domain.auth.application;
 
 import com.keeper.homepage.domain.member.dao.MemberRepository;
+import com.keeper.homepage.domain.member.entity.embedded.LoginId;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,7 +17,7 @@ public class CheckDuplicateService {
     return memberRepository.existsByProfileEmailAddress(email);
   }
 
-  public boolean isDuplicateLoginId(String loginId) {
+  public boolean isDuplicateLoginId(LoginId loginId) {
     return memberRepository.existsByProfileLoginId(loginId);
   }
 

--- a/src/main/java/com/keeper/homepage/domain/auth/application/SignUpService.java
+++ b/src/main/java/com/keeper/homepage/domain/auth/application/SignUpService.java
@@ -12,6 +12,7 @@ import com.keeper.homepage.domain.member.entity.Member;
 import com.keeper.homepage.domain.member.entity.embedded.EmailAddress;
 import com.keeper.homepage.domain.member.entity.embedded.LoginId;
 import com.keeper.homepage.domain.member.entity.embedded.Profile;
+import com.keeper.homepage.domain.member.entity.embedded.StudentId;
 import com.keeper.homepage.global.error.BusinessException;
 import jakarta.validation.constraints.Email;
 import lombok.RequiredArgsConstructor;
@@ -52,7 +53,7 @@ public class SignUpService {
     }
   }
 
-  private void checkIsDuplicateStudentId(String studentId) {
+  private void checkIsDuplicateStudentId(StudentId studentId) {
     if (checkDuplicateService.isDuplicateStudentID(studentId)) {
       throw new BusinessException(studentId, "studentId", MEMBER_STUDENT_ID_DUPLICATE);
     }

--- a/src/main/java/com/keeper/homepage/domain/auth/application/SignUpService.java
+++ b/src/main/java/com/keeper/homepage/domain/auth/application/SignUpService.java
@@ -9,6 +9,7 @@ import static com.keeper.homepage.global.error.ErrorCode.MEMBER_STUDENT_ID_DUPLI
 import com.keeper.homepage.domain.auth.dao.redis.EmailAuthRedisRepository;
 import com.keeper.homepage.domain.member.dao.MemberRepository;
 import com.keeper.homepage.domain.member.entity.Member;
+import com.keeper.homepage.domain.member.entity.embedded.EmailAddress;
 import com.keeper.homepage.domain.member.entity.embedded.LoginId;
 import com.keeper.homepage.domain.member.entity.embedded.Profile;
 import com.keeper.homepage.global.error.BusinessException;
@@ -31,7 +32,7 @@ public class SignUpService {
     checkIsDuplicateLoginId(profile.getLoginId());
     checkIsDuplicateStudentId(profile.getStudentId());
 
-    String actualAuthCode = getActualAuthCode(profile.getEmailAddress());
+    String actualAuthCode = getActualAuthCode(profile.getEmailAddress().get());
     checkAuthCodeMatch(authCode, actualAuthCode);
     return memberRepository.save(Member.builder()
             .profile(profile)
@@ -39,7 +40,7 @@ public class SignUpService {
         .getId();
   }
 
-  private void checkIsDuplicateEmail(String email) {
+  private void checkIsDuplicateEmail(EmailAddress email) {
     if (checkDuplicateService.isDuplicateEmail(email)) {
       throw new BusinessException(email, "email", MEMBER_EMAIL_DUPLICATE);
     }

--- a/src/main/java/com/keeper/homepage/domain/auth/dto/request/SignUpRequest.java
+++ b/src/main/java/com/keeper/homepage/domain/auth/dto/request/SignUpRequest.java
@@ -2,11 +2,14 @@ package com.keeper.homepage.domain.auth.dto.request;
 
 import static com.keeper.homepage.domain.auth.application.EmailAuthService.AUTH_CODE_LENGTH;
 import static com.keeper.homepage.domain.member.entity.embedded.LoginId.LOGIN_ID_REGEX;
+import static com.keeper.homepage.domain.member.entity.embedded.Password.PASSWORD_REGEX;
 import static lombok.AccessLevel.PACKAGE;
 import static lombok.AccessLevel.PRIVATE;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.keeper.homepage.domain.member.entity.embedded.LoginId;
+import com.keeper.homepage.domain.member.entity.embedded.Password;
 import com.keeper.homepage.domain.member.entity.embedded.Profile;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.Pattern;
@@ -15,9 +18,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import org.hibernate.validator.constraints.Length;
-import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Getter
 @NoArgsConstructor(access = PRIVATE)
@@ -25,7 +26,6 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 @Builder
 public class SignUpRequest {
 
-  public static final String PASSWORD_INVALID = "비밀번호는 8~20자여야 하고 영어, 숫자가 포함되어야 합니다.";
   public static final String REAL_NAME_INVALID = "실명은 1~20자 한글, 영어만 가능합니다.";
   public static final String NICKNAME_INVALID = "닉네임은 1~16자 한글, 영어, 숫자만 가능합니다.";
   public static final String STUDENT_ID_INVALID = "학번은 숫자만 가능합니다.";
@@ -34,9 +34,9 @@ public class SignUpRequest {
   private String loginId;
   @Email
   private String email;
-  @Pattern(regexp = "^(?=.*?[A-Za-z])(?=.*?\\d).{8,20}$", message = PASSWORD_INVALID)
-  @Setter
-  private String password;
+  @Pattern(regexp = PASSWORD_REGEX, message = Password.PASSWORD_INVALID)
+  @JsonProperty("password")
+  private String rawPassword;
   @Pattern(regexp = "^[a-zA-Z가-힣]{1,20}", message = REAL_NAME_INVALID)
   private String realName;
   @Pattern(regexp = "^[a-zA-Z0-9가-힣ㄱ-ㅎㅏ-ㅣ]{1,16}", message = NICKNAME_INVALID)
@@ -48,12 +48,11 @@ public class SignUpRequest {
   @Pattern(regexp = "^[0-9]*$", message = NICKNAME_INVALID)
   private String studentId;
 
-  public Profile toMemberProfile(PasswordEncoder passwordEncoder) {
-    System.out.println("password = " + passwordEncoder.encode(this.password));
+  public Profile toMemberProfile() {
     return Profile.builder()
         .loginId(LoginId.from(this.loginId))
         .emailAddress(this.email)
-        .password(passwordEncoder.encode(this.password))
+        .password(Password.from(this.rawPassword))
         .realName(this.realName)
         .nickname(this.nickname)
         .birthday(this.birthday)

--- a/src/main/java/com/keeper/homepage/domain/auth/dto/request/SignUpRequest.java
+++ b/src/main/java/com/keeper/homepage/domain/auth/dto/request/SignUpRequest.java
@@ -2,10 +2,11 @@ package com.keeper.homepage.domain.auth.dto.request;
 
 import static com.keeper.homepage.domain.auth.application.EmailAuthService.AUTH_CODE_LENGTH;
 import static com.keeper.homepage.domain.member.entity.embedded.LoginId.LOGIN_ID_REGEX;
-import static com.keeper.homepage.domain.member.entity.embedded.Nickname.NICKNAME_INVALID;
 import static com.keeper.homepage.domain.member.entity.embedded.Nickname.NICKNAME_REGEX;
 import static com.keeper.homepage.domain.member.entity.embedded.Password.PASSWORD_REGEX;
 import static com.keeper.homepage.domain.member.entity.embedded.RealName.REAL_NAME_REGEX;
+import static com.keeper.homepage.domain.member.entity.embedded.StudentId.STUDENT_ID_INVALID;
+import static com.keeper.homepage.domain.member.entity.embedded.StudentId.STUDENT_ID_REGEX;
 import static lombok.AccessLevel.PACKAGE;
 import static lombok.AccessLevel.PRIVATE;
 
@@ -17,6 +18,7 @@ import com.keeper.homepage.domain.member.entity.embedded.Nickname;
 import com.keeper.homepage.domain.member.entity.embedded.Password;
 import com.keeper.homepage.domain.member.entity.embedded.Profile;
 import com.keeper.homepage.domain.member.entity.embedded.RealName;
+import com.keeper.homepage.domain.member.entity.embedded.StudentId;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.Pattern;
 import java.time.LocalDate;
@@ -31,8 +33,6 @@ import org.hibernate.validator.constraints.Length;
 @AllArgsConstructor(access = PACKAGE)
 @Builder
 public class SignUpRequest {
-
-  public static final String STUDENT_ID_INVALID = "학번은 숫자만 가능합니다.";
 
   @Pattern(regexp = LOGIN_ID_REGEX, message = LoginId.LOGIN_ID_INVALID)
   private String loginId;
@@ -49,7 +49,7 @@ public class SignUpRequest {
   private String authCode;
   @JsonFormat(pattern = "yyyy.MM.dd")
   private LocalDate birthday;
-  @Pattern(regexp = "^[0-9]*$", message = NICKNAME_INVALID)
+  @Pattern(regexp = STUDENT_ID_REGEX, message = STUDENT_ID_INVALID)
   private String studentId;
 
   public Profile toMemberProfile() {
@@ -60,7 +60,7 @@ public class SignUpRequest {
         .realName(RealName.from(this.realName))
         .nickname(Nickname.from(this.nickname))
         .birthday(this.birthday)
-        .studentId(this.studentId)
+        .studentId(StudentId.from(this.studentId))
         .build();
   }
 }

--- a/src/main/java/com/keeper/homepage/domain/auth/dto/request/SignUpRequest.java
+++ b/src/main/java/com/keeper/homepage/domain/auth/dto/request/SignUpRequest.java
@@ -3,6 +3,7 @@ package com.keeper.homepage.domain.auth.dto.request;
 import static com.keeper.homepage.domain.auth.application.EmailAuthService.AUTH_CODE_LENGTH;
 import static com.keeper.homepage.domain.member.entity.embedded.LoginId.LOGIN_ID_REGEX;
 import static com.keeper.homepage.domain.member.entity.embedded.Password.PASSWORD_REGEX;
+import static com.keeper.homepage.domain.member.entity.embedded.RealName.REAL_NAME_REGEX;
 import static lombok.AccessLevel.PACKAGE;
 import static lombok.AccessLevel.PRIVATE;
 
@@ -12,6 +13,7 @@ import com.keeper.homepage.domain.member.entity.embedded.EmailAddress;
 import com.keeper.homepage.domain.member.entity.embedded.LoginId;
 import com.keeper.homepage.domain.member.entity.embedded.Password;
 import com.keeper.homepage.domain.member.entity.embedded.Profile;
+import com.keeper.homepage.domain.member.entity.embedded.RealName;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.Pattern;
 import java.time.LocalDate;
@@ -27,7 +29,6 @@ import org.hibernate.validator.constraints.Length;
 @Builder
 public class SignUpRequest {
 
-  public static final String REAL_NAME_INVALID = "실명은 1~20자 한글, 영어만 가능합니다.";
   public static final String NICKNAME_INVALID = "닉네임은 1~16자 한글, 영어, 숫자만 가능합니다.";
   public static final String STUDENT_ID_INVALID = "학번은 숫자만 가능합니다.";
 
@@ -38,7 +39,7 @@ public class SignUpRequest {
   @Pattern(regexp = PASSWORD_REGEX, message = Password.PASSWORD_INVALID)
   @JsonProperty("password")
   private String rawPassword;
-  @Pattern(regexp = "^[a-zA-Z가-힣]{1,20}", message = REAL_NAME_INVALID)
+  @Pattern(regexp = REAL_NAME_REGEX, message = RealName.REAL_NAME_INVALID)
   private String realName;
   @Pattern(regexp = "^[a-zA-Z0-9가-힣ㄱ-ㅎㅏ-ㅣ]{1,16}", message = NICKNAME_INVALID)
   private String nickname;
@@ -54,7 +55,7 @@ public class SignUpRequest {
         .loginId(LoginId.from(this.loginId))
         .emailAddress(EmailAddress.from(this.email))
         .password(Password.from(this.rawPassword))
-        .realName(this.realName)
+        .realName(RealName.from(this.realName))
         .nickname(this.nickname)
         .birthday(this.birthday)
         .studentId(this.studentId)

--- a/src/main/java/com/keeper/homepage/domain/auth/dto/request/SignUpRequest.java
+++ b/src/main/java/com/keeper/homepage/domain/auth/dto/request/SignUpRequest.java
@@ -8,6 +8,7 @@ import static lombok.AccessLevel.PRIVATE;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.keeper.homepage.domain.member.entity.embedded.EmailAddress;
 import com.keeper.homepage.domain.member.entity.embedded.LoginId;
 import com.keeper.homepage.domain.member.entity.embedded.Password;
 import com.keeper.homepage.domain.member.entity.embedded.Profile;
@@ -51,7 +52,7 @@ public class SignUpRequest {
   public Profile toMemberProfile() {
     return Profile.builder()
         .loginId(LoginId.from(this.loginId))
-        .emailAddress(this.email)
+        .emailAddress(EmailAddress.from(this.email))
         .password(Password.from(this.rawPassword))
         .realName(this.realName)
         .nickname(this.nickname)

--- a/src/main/java/com/keeper/homepage/domain/auth/dto/request/SignUpRequest.java
+++ b/src/main/java/com/keeper/homepage/domain/auth/dto/request/SignUpRequest.java
@@ -2,6 +2,8 @@ package com.keeper.homepage.domain.auth.dto.request;
 
 import static com.keeper.homepage.domain.auth.application.EmailAuthService.AUTH_CODE_LENGTH;
 import static com.keeper.homepage.domain.member.entity.embedded.LoginId.LOGIN_ID_REGEX;
+import static com.keeper.homepage.domain.member.entity.embedded.Nickname.NICKNAME_INVALID;
+import static com.keeper.homepage.domain.member.entity.embedded.Nickname.NICKNAME_REGEX;
 import static com.keeper.homepage.domain.member.entity.embedded.Password.PASSWORD_REGEX;
 import static com.keeper.homepage.domain.member.entity.embedded.RealName.REAL_NAME_REGEX;
 import static lombok.AccessLevel.PACKAGE;
@@ -11,6 +13,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.keeper.homepage.domain.member.entity.embedded.EmailAddress;
 import com.keeper.homepage.domain.member.entity.embedded.LoginId;
+import com.keeper.homepage.domain.member.entity.embedded.Nickname;
 import com.keeper.homepage.domain.member.entity.embedded.Password;
 import com.keeper.homepage.domain.member.entity.embedded.Profile;
 import com.keeper.homepage.domain.member.entity.embedded.RealName;
@@ -29,7 +32,6 @@ import org.hibernate.validator.constraints.Length;
 @Builder
 public class SignUpRequest {
 
-  public static final String NICKNAME_INVALID = "닉네임은 1~16자 한글, 영어, 숫자만 가능합니다.";
   public static final String STUDENT_ID_INVALID = "학번은 숫자만 가능합니다.";
 
   @Pattern(regexp = LOGIN_ID_REGEX, message = LoginId.LOGIN_ID_INVALID)
@@ -41,7 +43,7 @@ public class SignUpRequest {
   private String rawPassword;
   @Pattern(regexp = REAL_NAME_REGEX, message = RealName.REAL_NAME_INVALID)
   private String realName;
-  @Pattern(regexp = "^[a-zA-Z0-9가-힣ㄱ-ㅎㅏ-ㅣ]{1,16}", message = NICKNAME_INVALID)
+  @Pattern(regexp = NICKNAME_REGEX, message = Nickname.NICKNAME_INVALID)
   private String nickname;
   @Length(min = AUTH_CODE_LENGTH, max = AUTH_CODE_LENGTH)
   private String authCode;
@@ -56,7 +58,7 @@ public class SignUpRequest {
         .emailAddress(EmailAddress.from(this.email))
         .password(Password.from(this.rawPassword))
         .realName(RealName.from(this.realName))
-        .nickname(this.nickname)
+        .nickname(Nickname.from(this.nickname))
         .birthday(this.birthday)
         .studentId(this.studentId)
         .build();

--- a/src/main/java/com/keeper/homepage/domain/auth/dto/request/SignUpRequest.java
+++ b/src/main/java/com/keeper/homepage/domain/auth/dto/request/SignUpRequest.java
@@ -1,10 +1,12 @@
 package com.keeper.homepage.domain.auth.dto.request;
 
 import static com.keeper.homepage.domain.auth.application.EmailAuthService.AUTH_CODE_LENGTH;
+import static com.keeper.homepage.domain.member.entity.embedded.LoginId.LOGIN_ID_REGEX;
 import static lombok.AccessLevel.PACKAGE;
 import static lombok.AccessLevel.PRIVATE;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.keeper.homepage.domain.member.entity.embedded.LoginId;
 import com.keeper.homepage.domain.member.entity.embedded.Profile;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.Pattern;
@@ -23,13 +25,12 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 @Builder
 public class SignUpRequest {
 
-  public static final String LOGIN_ID_INVALID = "로그인 아이디는 4~12자 영어, 숫자, '_'만 가능합니다.";
   public static final String PASSWORD_INVALID = "비밀번호는 8~20자여야 하고 영어, 숫자가 포함되어야 합니다.";
   public static final String REAL_NAME_INVALID = "실명은 1~20자 한글, 영어만 가능합니다.";
   public static final String NICKNAME_INVALID = "닉네임은 1~16자 한글, 영어, 숫자만 가능합니다.";
   public static final String STUDENT_ID_INVALID = "학번은 숫자만 가능합니다.";
 
-  @Pattern(regexp = "^[a-zA-Z0-9_]{4,12}", message = LOGIN_ID_INVALID)
+  @Pattern(regexp = LOGIN_ID_REGEX, message = LoginId.LOGIN_ID_INVALID)
   private String loginId;
   @Email
   private String email;
@@ -48,8 +49,9 @@ public class SignUpRequest {
   private String studentId;
 
   public Profile toMemberProfile(PasswordEncoder passwordEncoder) {
+    System.out.println("password = " + passwordEncoder.encode(this.password));
     return Profile.builder()
-        .loginId(this.loginId)
+        .loginId(LoginId.from(this.loginId))
         .emailAddress(this.email)
         .password(passwordEncoder.encode(this.password))
         .realName(this.realName)

--- a/src/main/java/com/keeper/homepage/domain/member/dao/MemberRepository.java
+++ b/src/main/java/com/keeper/homepage/domain/member/dao/MemberRepository.java
@@ -1,13 +1,14 @@
 package com.keeper.homepage.domain.member.dao;
 
 import com.keeper.homepage.domain.member.entity.Member;
+import com.keeper.homepage.domain.member.entity.embedded.LoginId;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
   boolean existsByProfileEmailAddress(String emailAddress);
 
-  boolean existsByProfileLoginId(String loginId);
+  boolean existsByProfileLoginId(LoginId profileLoginId);
 
   boolean existsByProfileStudentId(String studentId);
 }

--- a/src/main/java/com/keeper/homepage/domain/member/dao/MemberRepository.java
+++ b/src/main/java/com/keeper/homepage/domain/member/dao/MemberRepository.java
@@ -1,12 +1,13 @@
 package com.keeper.homepage.domain.member.dao;
 
 import com.keeper.homepage.domain.member.entity.Member;
+import com.keeper.homepage.domain.member.entity.embedded.EmailAddress;
 import com.keeper.homepage.domain.member.entity.embedded.LoginId;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
-  boolean existsByProfileEmailAddress(String emailAddress);
+  boolean existsByProfileEmailAddress(EmailAddress profileEmailAddress);
 
   boolean existsByProfileLoginId(LoginId profileLoginId);
 

--- a/src/main/java/com/keeper/homepage/domain/member/dao/MemberRepository.java
+++ b/src/main/java/com/keeper/homepage/domain/member/dao/MemberRepository.java
@@ -3,6 +3,7 @@ package com.keeper.homepage.domain.member.dao;
 import com.keeper.homepage.domain.member.entity.Member;
 import com.keeper.homepage.domain.member.entity.embedded.EmailAddress;
 import com.keeper.homepage.domain.member.entity.embedded.LoginId;
+import com.keeper.homepage.domain.member.entity.embedded.StudentId;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
@@ -11,5 +12,5 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
   boolean existsByProfileLoginId(LoginId profileLoginId);
 
-  boolean existsByProfileStudentId(String studentId);
+  boolean existsByProfileStudentId(StudentId profileStudentId);
 }

--- a/src/main/java/com/keeper/homepage/domain/member/entity/Member.java
+++ b/src/main/java/com/keeper/homepage/domain/member/entity/Member.java
@@ -1,5 +1,6 @@
 package com.keeper.homepage.domain.member.entity;
 
+import static com.keeper.homepage.domain.member.entity.embedded.LoginId.MAX_LOGIN_ID_LENGTH;
 import static com.keeper.homepage.domain.member.entity.rank.MemberRank.MemberRankType.일반회원;
 import static com.keeper.homepage.domain.member.entity.type.MemberType.MemberTypeEnum.정회원;
 import static jakarta.persistence.CascadeType.ALL;
@@ -15,6 +16,8 @@ import com.keeper.homepage.domain.member.entity.job.MemberJob;
 import com.keeper.homepage.domain.member.entity.job.MemberJob.MemberJobType;
 import com.keeper.homepage.domain.member.entity.rank.MemberRank;
 import com.keeper.homepage.domain.member.entity.type.MemberType;
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.AttributeOverrides;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -54,6 +57,9 @@ public class Member {
   private Long id;
 
   @Embedded
+  @AttributeOverrides({
+      @AttributeOverride(name = "loginId", column = @Column(name = "login_id", nullable = false, unique = true, length = MAX_LOGIN_ID_LENGTH)),
+  })
   private Profile profile;
 
   @Embedded

--- a/src/main/java/com/keeper/homepage/domain/member/entity/Member.java
+++ b/src/main/java/com/keeper/homepage/domain/member/entity/Member.java
@@ -3,6 +3,7 @@ package com.keeper.homepage.domain.member.entity;
 import static com.keeper.homepage.domain.member.entity.embedded.EmailAddress.MAX_EMAIL_LENGTH;
 import static com.keeper.homepage.domain.member.entity.embedded.LoginId.MAX_LOGIN_ID_LENGTH;
 import static com.keeper.homepage.domain.member.entity.embedded.Nickname.MAX_NICKNAME_LENGTH;
+import static com.keeper.homepage.domain.member.entity.embedded.RealName.*;
 import static com.keeper.homepage.domain.member.entity.embedded.StudentId.MAX_STUDENT_ID_LENGTH;
 import static com.keeper.homepage.domain.member.entity.rank.MemberRank.MemberRankType.일반회원;
 import static com.keeper.homepage.domain.member.entity.type.MemberType.MemberTypeEnum.정회원;
@@ -65,7 +66,7 @@ public class Member {
       @AttributeOverride(name = "loginId", column = @Column(name = "login_id", nullable = false, unique = true, length = MAX_LOGIN_ID_LENGTH)),
       @AttributeOverride(name = "password", column = @Column(name = "password", nullable = false, length = 512)),
       @AttributeOverride(name = "emailAddress", column = @Column(name = "email_address", nullable = false, unique = true, length = MAX_EMAIL_LENGTH)),
-      @AttributeOverride(name = "realName", column = @Column(name = "real_name", nullable = false, length = RealName.MAX_REAL_NAME_LENGTH)),
+      @AttributeOverride(name = "realName", column = @Column(name = "real_name", nullable = false, length = MAX_REAL_NAME_LENGTH)),
       @AttributeOverride(name = "nickName", column = @Column(name = "nick_name", nullable = false, length = MAX_NICKNAME_LENGTH)),
       @AttributeOverride(name = "studentId", column = @Column(name = "student_id", unique = true, length = MAX_STUDENT_ID_LENGTH))
   })

--- a/src/main/java/com/keeper/homepage/domain/member/entity/Member.java
+++ b/src/main/java/com/keeper/homepage/domain/member/entity/Member.java
@@ -11,6 +11,7 @@ import com.keeper.homepage.domain.attendance.entity.Attendance;
 import com.keeper.homepage.domain.member.entity.embedded.Generation;
 import com.keeper.homepage.domain.member.entity.embedded.MeritDemerit;
 import com.keeper.homepage.domain.member.entity.embedded.Profile;
+import com.keeper.homepage.domain.member.entity.embedded.RealName;
 import com.keeper.homepage.domain.member.entity.friend.Friend;
 import com.keeper.homepage.domain.member.entity.job.MemberHasMemberJob;
 import com.keeper.homepage.domain.member.entity.job.MemberJob;
@@ -61,7 +62,8 @@ public class Member {
   @AttributeOverrides({
       @AttributeOverride(name = "loginId", column = @Column(name = "login_id", nullable = false, unique = true, length = MAX_LOGIN_ID_LENGTH)),
       @AttributeOverride(name = "password", column = @Column(name = "password", nullable = false, length = 512)),
-      @AttributeOverride(name = "emailAddress", column = @Column(name = "email_address", nullable = false, unique = true, length = MAX_EMAIL_LENGTH))
+      @AttributeOverride(name = "emailAddress", column = @Column(name = "email_address", nullable = false, unique = true, length = MAX_EMAIL_LENGTH)),
+      @AttributeOverride(name = "realName", column = @Column(name = "real_name", nullable = false, length = RealName.MAX_REAL_NAME_LENGTH))
   })
   private Profile profile;
 

--- a/src/main/java/com/keeper/homepage/domain/member/entity/Member.java
+++ b/src/main/java/com/keeper/homepage/domain/member/entity/Member.java
@@ -59,6 +59,7 @@ public class Member {
   @Embedded
   @AttributeOverrides({
       @AttributeOverride(name = "loginId", column = @Column(name = "login_id", nullable = false, unique = true, length = MAX_LOGIN_ID_LENGTH)),
+      @AttributeOverride(name = "password", column = @Column(name = "password", nullable = false, length = 512)),
   })
   private Profile profile;
 

--- a/src/main/java/com/keeper/homepage/domain/member/entity/Member.java
+++ b/src/main/java/com/keeper/homepage/domain/member/entity/Member.java
@@ -1,5 +1,6 @@
 package com.keeper.homepage.domain.member.entity;
 
+import static com.keeper.homepage.domain.member.entity.embedded.EmailAddress.MAX_EMAIL_LENGTH;
 import static com.keeper.homepage.domain.member.entity.embedded.LoginId.MAX_LOGIN_ID_LENGTH;
 import static com.keeper.homepage.domain.member.entity.rank.MemberRank.MemberRankType.일반회원;
 import static com.keeper.homepage.domain.member.entity.type.MemberType.MemberTypeEnum.정회원;
@@ -60,6 +61,7 @@ public class Member {
   @AttributeOverrides({
       @AttributeOverride(name = "loginId", column = @Column(name = "login_id", nullable = false, unique = true, length = MAX_LOGIN_ID_LENGTH)),
       @AttributeOverride(name = "password", column = @Column(name = "password", nullable = false, length = 512)),
+      @AttributeOverride(name = "emailAddress", column = @Column(name = "email_address", nullable = false, unique = true, length = MAX_EMAIL_LENGTH))
   })
   private Profile profile;
 

--- a/src/main/java/com/keeper/homepage/domain/member/entity/Member.java
+++ b/src/main/java/com/keeper/homepage/domain/member/entity/Member.java
@@ -2,6 +2,7 @@ package com.keeper.homepage.domain.member.entity;
 
 import static com.keeper.homepage.domain.member.entity.embedded.EmailAddress.MAX_EMAIL_LENGTH;
 import static com.keeper.homepage.domain.member.entity.embedded.LoginId.MAX_LOGIN_ID_LENGTH;
+import static com.keeper.homepage.domain.member.entity.embedded.Nickname.MAX_NICKNAME_LENGTH;
 import static com.keeper.homepage.domain.member.entity.rank.MemberRank.MemberRankType.일반회원;
 import static com.keeper.homepage.domain.member.entity.type.MemberType.MemberTypeEnum.정회원;
 import static jakarta.persistence.CascadeType.ALL;
@@ -63,7 +64,8 @@ public class Member {
       @AttributeOverride(name = "loginId", column = @Column(name = "login_id", nullable = false, unique = true, length = MAX_LOGIN_ID_LENGTH)),
       @AttributeOverride(name = "password", column = @Column(name = "password", nullable = false, length = 512)),
       @AttributeOverride(name = "emailAddress", column = @Column(name = "email_address", nullable = false, unique = true, length = MAX_EMAIL_LENGTH)),
-      @AttributeOverride(name = "realName", column = @Column(name = "real_name", nullable = false, length = RealName.MAX_REAL_NAME_LENGTH))
+      @AttributeOverride(name = "realName", column = @Column(name = "real_name", nullable = false, length = RealName.MAX_REAL_NAME_LENGTH)),
+      @AttributeOverride(name = "nickName", column = @Column(name = "nick_name", nullable = false, length = MAX_NICKNAME_LENGTH))
   })
   private Profile profile;
 

--- a/src/main/java/com/keeper/homepage/domain/member/entity/Member.java
+++ b/src/main/java/com/keeper/homepage/domain/member/entity/Member.java
@@ -3,7 +3,8 @@ package com.keeper.homepage.domain.member.entity;
 import static com.keeper.homepage.domain.member.entity.embedded.EmailAddress.MAX_EMAIL_LENGTH;
 import static com.keeper.homepage.domain.member.entity.embedded.LoginId.MAX_LOGIN_ID_LENGTH;
 import static com.keeper.homepage.domain.member.entity.embedded.Nickname.MAX_NICKNAME_LENGTH;
-import static com.keeper.homepage.domain.member.entity.embedded.RealName.*;
+import static com.keeper.homepage.domain.member.entity.embedded.Password.HASHED_PASSWORD_MAX_LENGTH;
+import static com.keeper.homepage.domain.member.entity.embedded.RealName.MAX_REAL_NAME_LENGTH;
 import static com.keeper.homepage.domain.member.entity.embedded.StudentId.MAX_STUDENT_ID_LENGTH;
 import static com.keeper.homepage.domain.member.entity.rank.MemberRank.MemberRankType.일반회원;
 import static com.keeper.homepage.domain.member.entity.type.MemberType.MemberTypeEnum.정회원;
@@ -14,7 +15,6 @@ import com.keeper.homepage.domain.attendance.entity.Attendance;
 import com.keeper.homepage.domain.member.entity.embedded.Generation;
 import com.keeper.homepage.domain.member.entity.embedded.MeritDemerit;
 import com.keeper.homepage.domain.member.entity.embedded.Profile;
-import com.keeper.homepage.domain.member.entity.embedded.RealName;
 import com.keeper.homepage.domain.member.entity.friend.Friend;
 import com.keeper.homepage.domain.member.entity.job.MemberHasMemberJob;
 import com.keeper.homepage.domain.member.entity.job.MemberJob;
@@ -64,7 +64,7 @@ public class Member {
   @Embedded
   @AttributeOverrides({
       @AttributeOverride(name = "loginId", column = @Column(name = "login_id", nullable = false, unique = true, length = MAX_LOGIN_ID_LENGTH)),
-      @AttributeOverride(name = "password", column = @Column(name = "password", nullable = false, length = 512)),
+      @AttributeOverride(name = "password", column = @Column(name = "password", nullable = false, length = HASHED_PASSWORD_MAX_LENGTH)),
       @AttributeOverride(name = "emailAddress", column = @Column(name = "email_address", nullable = false, unique = true, length = MAX_EMAIL_LENGTH)),
       @AttributeOverride(name = "realName", column = @Column(name = "real_name", nullable = false, length = MAX_REAL_NAME_LENGTH)),
       @AttributeOverride(name = "nickName", column = @Column(name = "nick_name", nullable = false, length = MAX_NICKNAME_LENGTH)),

--- a/src/main/java/com/keeper/homepage/domain/member/entity/Member.java
+++ b/src/main/java/com/keeper/homepage/domain/member/entity/Member.java
@@ -3,6 +3,7 @@ package com.keeper.homepage.domain.member.entity;
 import static com.keeper.homepage.domain.member.entity.embedded.EmailAddress.MAX_EMAIL_LENGTH;
 import static com.keeper.homepage.domain.member.entity.embedded.LoginId.MAX_LOGIN_ID_LENGTH;
 import static com.keeper.homepage.domain.member.entity.embedded.Nickname.MAX_NICKNAME_LENGTH;
+import static com.keeper.homepage.domain.member.entity.embedded.StudentId.MAX_STUDENT_ID_LENGTH;
 import static com.keeper.homepage.domain.member.entity.rank.MemberRank.MemberRankType.일반회원;
 import static com.keeper.homepage.domain.member.entity.type.MemberType.MemberTypeEnum.정회원;
 import static jakarta.persistence.CascadeType.ALL;
@@ -65,7 +66,8 @@ public class Member {
       @AttributeOverride(name = "password", column = @Column(name = "password", nullable = false, length = 512)),
       @AttributeOverride(name = "emailAddress", column = @Column(name = "email_address", nullable = false, unique = true, length = MAX_EMAIL_LENGTH)),
       @AttributeOverride(name = "realName", column = @Column(name = "real_name", nullable = false, length = RealName.MAX_REAL_NAME_LENGTH)),
-      @AttributeOverride(name = "nickName", column = @Column(name = "nick_name", nullable = false, length = MAX_NICKNAME_LENGTH))
+      @AttributeOverride(name = "nickName", column = @Column(name = "nick_name", nullable = false, length = MAX_NICKNAME_LENGTH)),
+      @AttributeOverride(name = "studentId", column = @Column(name = "student_id", unique = true, length = MAX_STUDENT_ID_LENGTH))
   })
   private Profile profile;
 

--- a/src/main/java/com/keeper/homepage/domain/member/entity/embedded/EmailAddress.java
+++ b/src/main/java/com/keeper/homepage/domain/member/entity/embedded/EmailAddress.java
@@ -1,0 +1,38 @@
+package com.keeper.homepage.domain.member.entity.embedded;
+
+import jakarta.persistence.Embeddable;
+import java.util.regex.Pattern;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@EqualsAndHashCode(of = {"emailAddress"})
+public class EmailAddress {
+
+  public static final String EMAIL_INVALID = "이메일 형식이 유효하지 않습니다.";
+  public static final String EMAIL_REGEX = "^[a-zA-Z0-9_+&*-]+(?:\\.[a-zA-Z0-9_+&*-]+)*@(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,7}";
+  public static final int MAX_EMAIL_LENGTH = 250;
+
+  private static final Pattern EMAIL_FORMAT = Pattern.compile(EMAIL_REGEX);
+
+  private String emailAddress;
+
+  public static EmailAddress from(String emailAddress) {
+    if (isInvalidFormat(emailAddress)) {
+      throw new IllegalArgumentException(EMAIL_INVALID);
+    }
+    return new EmailAddress(emailAddress);
+  }
+
+  private static boolean isInvalidFormat(String emailAddress) {
+    return !EMAIL_FORMAT.matcher(emailAddress).find();
+  }
+
+  public String get() {
+    return this.emailAddress;
+  }
+}

--- a/src/main/java/com/keeper/homepage/domain/member/entity/embedded/LoginId.java
+++ b/src/main/java/com/keeper/homepage/domain/member/entity/embedded/LoginId.java
@@ -5,10 +5,8 @@ import java.util.regex.Pattern;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Getter
 @Embeddable
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)

--- a/src/main/java/com/keeper/homepage/domain/member/entity/embedded/LoginId.java
+++ b/src/main/java/com/keeper/homepage/domain/member/entity/embedded/LoginId.java
@@ -1,0 +1,40 @@
+package com.keeper.homepage.domain.member.entity.embedded;
+
+import jakarta.persistence.Embeddable;
+import java.util.regex.Pattern;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@EqualsAndHashCode(of = {"loginId"})
+public class LoginId {
+
+  public static final int MAX_LOGIN_ID_LENGTH = 80;
+  public static final String LOGIN_ID_INVALID = "로그인 아이디는 4~12자 영어, 숫자, '_'만 가능합니다.";
+  public static final String LOGIN_ID_REGEX = "^[a-zA-Z0-9_]{4,12}";
+
+  private static final Pattern LOGIN_ID_FORMAT = Pattern.compile(LOGIN_ID_REGEX);
+
+  private String loginId;
+
+  public static LoginId from(String loginId) {
+    if (isInvalidFormat(loginId)) {
+      throw new IllegalArgumentException(LOGIN_ID_INVALID);
+    }
+    return new LoginId(loginId);
+  }
+
+  private static boolean isInvalidFormat(String loginId) {
+    return !LOGIN_ID_FORMAT.matcher(loginId).find();
+  }
+
+  public String get() {
+    return this.loginId;
+  }
+}

--- a/src/main/java/com/keeper/homepage/domain/member/entity/embedded/Nickname.java
+++ b/src/main/java/com/keeper/homepage/domain/member/entity/embedded/Nickname.java
@@ -1,0 +1,38 @@
+package com.keeper.homepage.domain.member.entity.embedded;
+
+import jakarta.persistence.Embeddable;
+import java.util.regex.Pattern;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@EqualsAndHashCode(of = {"nickName"})
+public class Nickname {
+
+  public static final int MAX_NICKNAME_LENGTH = 40;
+  public static final String NICKNAME_REGEX = "^[a-zA-Z0-9가-힣ㄱ-ㅎㅏ-ㅣ]{1,16}";
+  public static final String NICKNAME_INVALID = "닉네임은 1~16자 한글, 영어, 숫자만 가능합니다.";
+
+  private static final Pattern NICKNAME_FORMAT = Pattern.compile(NICKNAME_REGEX);
+
+  private String nickName;
+
+  public static Nickname from(String nickname) {
+    if (isInvalidFormat(nickname)) {
+      throw new IllegalArgumentException(NICKNAME_INVALID);
+    }
+    return new Nickname(nickname);
+  }
+
+  private static boolean isInvalidFormat(String nickname) {
+    return !NICKNAME_FORMAT.matcher(nickname).find();
+  }
+
+  public String get() {
+    return this.nickName;
+  }
+}

--- a/src/main/java/com/keeper/homepage/domain/member/entity/embedded/Password.java
+++ b/src/main/java/com/keeper/homepage/domain/member/entity/embedded/Password.java
@@ -1,0 +1,43 @@
+package com.keeper.homepage.domain.member.entity.embedded;
+
+import com.keeper.homepage.global.config.password.PasswordFactory;
+import jakarta.persistence.Embeddable;
+import java.util.regex.Pattern;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@EqualsAndHashCode(of = {"password"})
+public class Password {
+
+  public static final String PASSWORD_INVALID = "비밀번호는 8~20자여야 하고 영어, 숫자가 포함되어야 합니다.";
+  public static final String PASSWORD_REGEX = "^(?=.*?[A-Za-z])(?=.*?\\d).{8,20}$";
+
+  private static final Pattern PASSWORD_FORMAT = Pattern.compile(PASSWORD_REGEX);
+
+  private String password;
+
+  public static Password from(String rawPassword) {
+    return new Password(PasswordFactory.getPasswordEncoder().encode(rawPassword));
+  }
+
+  public static Password from(String rawPassword, PasswordEncoder passwordEncoder) {
+    if (isInvalidFormat(rawPassword)) {
+      throw new IllegalArgumentException(PASSWORD_INVALID);
+    }
+    return new Password(passwordEncoder.encode(rawPassword));
+  }
+
+  public String get() {
+    return this.password;
+  }
+
+  private static boolean isInvalidFormat(String rawPassword) {
+    return !PASSWORD_FORMAT.matcher(rawPassword).find();
+  }
+}

--- a/src/main/java/com/keeper/homepage/domain/member/entity/embedded/Password.java
+++ b/src/main/java/com/keeper/homepage/domain/member/entity/embedded/Password.java
@@ -15,6 +15,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 @EqualsAndHashCode(of = {"password"})
 public class Password {
 
+  public static final int HASHED_PASSWORD_MAX_LENGTH = 512;
   public static final String PASSWORD_INVALID = "비밀번호는 8~20자여야 하고 영어, 숫자가 포함되어야 합니다.";
   public static final String PASSWORD_REGEX = "^(?=.*?[A-Za-z])(?=.*?\\d).{8,20}$";
 

--- a/src/main/java/com/keeper/homepage/domain/member/entity/embedded/Profile.java
+++ b/src/main/java/com/keeper/homepage/domain/member/entity/embedded/Profile.java
@@ -30,8 +30,8 @@ public class Profile {
   @Column(name = "email_address", nullable = false, unique = true, length = MAX_EMAIL_LENGTH)
   private String emailAddress;
 
-  @Column(name = "password", nullable = false, length = 512)
-  private String password;
+  @Embedded
+  private Password password;
 
   @Column(name = "real_name", nullable = false, length = MAX_REAL_NAME_LENGTH)
   private String realName;
@@ -50,7 +50,7 @@ public class Profile {
   private Thumbnail thumbnail;
 
   @Builder
-  private Profile(LoginId loginId, String emailAddress, String password, String realName,
+  private Profile(LoginId loginId, String emailAddress, Password password, String realName,
       String nickname, LocalDate birthday, String studentId, Thumbnail thumbnail) {
     this.loginId = loginId;
     this.emailAddress = emailAddress;

--- a/src/main/java/com/keeper/homepage/domain/member/entity/embedded/Profile.java
+++ b/src/main/java/com/keeper/homepage/domain/member/entity/embedded/Profile.java
@@ -19,7 +19,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Profile {
 
-  public static final int MAX_EMAIL_LENGTH = 250;
   public static final int MAX_REAL_NAME_LENGTH = 40;
   public static final int MAX_NICKNAME_LENGTH = 40;
   public static final int MAX_STUDENT_ID_LENGTH = 45;
@@ -27,8 +26,8 @@ public class Profile {
   @Embedded
   private LoginId loginId;
 
-  @Column(name = "email_address", nullable = false, unique = true, length = MAX_EMAIL_LENGTH)
-  private String emailAddress;
+  @Embedded
+  private EmailAddress emailAddress;
 
   @Embedded
   private Password password;
@@ -50,7 +49,7 @@ public class Profile {
   private Thumbnail thumbnail;
 
   @Builder
-  private Profile(LoginId loginId, String emailAddress, Password password, String realName,
+  private Profile(LoginId loginId, EmailAddress emailAddress, Password password, String realName,
       String nickname, LocalDate birthday, String studentId, Thumbnail thumbnail) {
     this.loginId = loginId;
     this.emailAddress = emailAddress;

--- a/src/main/java/com/keeper/homepage/domain/member/entity/embedded/Profile.java
+++ b/src/main/java/com/keeper/homepage/domain/member/entity/embedded/Profile.java
@@ -4,6 +4,7 @@ import com.keeper.homepage.domain.thumbnail.entity.Thumbnail;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
+import jakarta.persistence.Embedded;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
@@ -18,14 +19,13 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Profile {
 
-  public static final int MAX_LOGIN_ID_LENGTH = 80;
   public static final int MAX_EMAIL_LENGTH = 250;
   public static final int MAX_REAL_NAME_LENGTH = 40;
   public static final int MAX_NICKNAME_LENGTH = 40;
   public static final int MAX_STUDENT_ID_LENGTH = 45;
 
-  @Column(name = "login_id", nullable = false, unique = true, length = MAX_LOGIN_ID_LENGTH)
-  private String loginId;
+  @Embedded
+  private LoginId loginId;
 
   @Column(name = "email_address", nullable = false, unique = true, length = MAX_EMAIL_LENGTH)
   private String emailAddress;
@@ -50,7 +50,7 @@ public class Profile {
   private Thumbnail thumbnail;
 
   @Builder
-  private Profile(String loginId, String emailAddress, String password, String realName,
+  private Profile(LoginId loginId, String emailAddress, String password, String realName,
       String nickname, LocalDate birthday, String studentId, Thumbnail thumbnail) {
     this.loginId = loginId;
     this.emailAddress = emailAddress;

--- a/src/main/java/com/keeper/homepage/domain/member/entity/embedded/Profile.java
+++ b/src/main/java/com/keeper/homepage/domain/member/entity/embedded/Profile.java
@@ -19,7 +19,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Profile {
 
-  public static final int MAX_NICKNAME_LENGTH = 40;
   public static final int MAX_STUDENT_ID_LENGTH = 45;
 
   @Embedded
@@ -34,8 +33,8 @@ public class Profile {
   @Embedded
   private RealName realName;
 
-  @Column(name = "nick_name", nullable = false, length = MAX_NICKNAME_LENGTH)
-  private String nickname;
+  @Embedded
+  private Nickname nickname;
 
   @Column(name = "birthday")
   private LocalDate birthday;
@@ -49,7 +48,7 @@ public class Profile {
 
   @Builder
   private Profile(LoginId loginId, EmailAddress emailAddress, Password password, RealName realName,
-      String nickname, LocalDate birthday, String studentId, Thumbnail thumbnail) {
+      Nickname nickname, LocalDate birthday, String studentId, Thumbnail thumbnail) {
     this.loginId = loginId;
     this.emailAddress = emailAddress;
     this.password = password;

--- a/src/main/java/com/keeper/homepage/domain/member/entity/embedded/Profile.java
+++ b/src/main/java/com/keeper/homepage/domain/member/entity/embedded/Profile.java
@@ -19,7 +19,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Profile {
 
-  public static final int MAX_REAL_NAME_LENGTH = 40;
   public static final int MAX_NICKNAME_LENGTH = 40;
   public static final int MAX_STUDENT_ID_LENGTH = 45;
 
@@ -32,8 +31,8 @@ public class Profile {
   @Embedded
   private Password password;
 
-  @Column(name = "real_name", nullable = false, length = MAX_REAL_NAME_LENGTH)
-  private String realName;
+  @Embedded
+  private RealName realName;
 
   @Column(name = "nick_name", nullable = false, length = MAX_NICKNAME_LENGTH)
   private String nickname;
@@ -49,7 +48,7 @@ public class Profile {
   private Thumbnail thumbnail;
 
   @Builder
-  private Profile(LoginId loginId, EmailAddress emailAddress, Password password, String realName,
+  private Profile(LoginId loginId, EmailAddress emailAddress, Password password, RealName realName,
       String nickname, LocalDate birthday, String studentId, Thumbnail thumbnail) {
     this.loginId = loginId;
     this.emailAddress = emailAddress;

--- a/src/main/java/com/keeper/homepage/domain/member/entity/embedded/Profile.java
+++ b/src/main/java/com/keeper/homepage/domain/member/entity/embedded/Profile.java
@@ -19,8 +19,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Profile {
 
-  public static final int MAX_STUDENT_ID_LENGTH = 45;
-
   @Embedded
   private LoginId loginId;
 
@@ -39,8 +37,8 @@ public class Profile {
   @Column(name = "birthday")
   private LocalDate birthday;
 
-  @Column(name = "student_id", unique = true, length = MAX_STUDENT_ID_LENGTH)
-  private String studentId;
+  @Embedded
+  private StudentId studentId;
 
   @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
   @JoinColumn(name = "thumbnail_id")
@@ -48,7 +46,7 @@ public class Profile {
 
   @Builder
   private Profile(LoginId loginId, EmailAddress emailAddress, Password password, RealName realName,
-      Nickname nickname, LocalDate birthday, String studentId, Thumbnail thumbnail) {
+      Nickname nickname, LocalDate birthday, StudentId studentId, Thumbnail thumbnail) {
     this.loginId = loginId;
     this.emailAddress = emailAddress;
     this.password = password;

--- a/src/main/java/com/keeper/homepage/domain/member/entity/embedded/RealName.java
+++ b/src/main/java/com/keeper/homepage/domain/member/entity/embedded/RealName.java
@@ -1,0 +1,38 @@
+package com.keeper.homepage.domain.member.entity.embedded;
+
+import jakarta.persistence.Embeddable;
+import java.util.regex.Pattern;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@EqualsAndHashCode(of = {"realName"})
+public class RealName {
+
+  public static final int MAX_REAL_NAME_LENGTH = 40;
+  public static final String REAL_NAME_REGEX = "^[a-zA-Z가-힣]{1,20}";
+  public static final String REAL_NAME_INVALID = "실명은 1~20자 한글, 영어만 가능합니다.";
+
+  private static final Pattern REAL_NAME_FORMAT = Pattern.compile(REAL_NAME_REGEX);
+
+  private String realName;
+
+  public static RealName from(String realName) {
+    if (isInvalidFormat(realName)) {
+      throw new IllegalArgumentException(REAL_NAME_INVALID);
+    }
+    return new RealName(realName);
+  }
+
+  private static boolean isInvalidFormat(String realName) {
+    return !REAL_NAME_FORMAT.matcher(realName).find();
+  }
+
+  public String get() {
+    return this.realName;
+  }
+}

--- a/src/main/java/com/keeper/homepage/domain/member/entity/embedded/StudentId.java
+++ b/src/main/java/com/keeper/homepage/domain/member/entity/embedded/StudentId.java
@@ -1,0 +1,38 @@
+package com.keeper.homepage.domain.member.entity.embedded;
+
+import jakarta.persistence.Embeddable;
+import java.util.regex.Pattern;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@EqualsAndHashCode(of = {"studentId"})
+public class StudentId {
+
+  public static final String STUDENT_ID_INVALID = "학번은 숫자만 가능합니다.";
+  public static final int MAX_STUDENT_ID_LENGTH = 45;
+  public static final String STUDENT_ID_REGEX = "^[0-9]*$";
+
+  private static final Pattern STUDENT_ID_FORMAT = Pattern.compile(STUDENT_ID_REGEX);
+
+  private String studentId;
+
+  public static StudentId from(String studentId) {
+    if (isInvalidFormat(studentId)) {
+      throw new IllegalArgumentException(STUDENT_ID_INVALID);
+    }
+    return new StudentId(studentId);
+  }
+
+  private static boolean isInvalidFormat(String studentId) {
+    return !STUDENT_ID_FORMAT.matcher(studentId).find();
+  }
+
+  public String get() {
+    return this.studentId;
+  }
+}

--- a/src/test/java/com/keeper/homepage/IntegrationTest.java
+++ b/src/test/java/com/keeper/homepage/IntegrationTest.java
@@ -27,6 +27,7 @@ import com.keeper.homepage.domain.member.dao.role.MemberHasMemberJobRepository;
 import com.keeper.homepage.domain.member.dao.role.MemberJobRepository;
 import com.keeper.homepage.domain.member.dao.type.MemberTypeRepository;
 import com.keeper.homepage.domain.thumbnail.dao.ThumbnailRepository;
+import com.keeper.homepage.global.config.password.PasswordFactory;
 import com.keeper.homepage.global.config.security.JwtTokenProvider;
 import com.keeper.homepage.global.util.file.FileUtil;
 import com.keeper.homepage.global.util.mail.MailUtil;
@@ -139,6 +140,8 @@ public class IntegrationTest {
   @SpyBean
   protected RedisUtil redisUtil;
 
+  protected PasswordEncoder passwordEncoder = PasswordFactory.getPasswordEncoder();
+
   /******* Spring Bean *******/
   @Autowired
   protected WebApplicationContext webApplicationContext;
@@ -148,9 +151,6 @@ public class IntegrationTest {
 
   @Autowired
   protected ObjectMapper objectMapper;
-
-  @Autowired
-  protected PasswordEncoder passwordEncoder;
 
   @PersistenceContext
   protected EntityManager em;

--- a/src/test/java/com/keeper/homepage/IntegrationTest.java
+++ b/src/test/java/com/keeper/homepage/IntegrationTest.java
@@ -38,6 +38,7 @@ import jakarta.persistence.PersistenceContext;
 import java.io.File;
 import java.io.IOException;
 import java.time.LocalDate;
+import java.util.Random;
 import org.apache.tomcat.util.http.fileupload.FileUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -58,6 +59,8 @@ import org.springframework.web.filter.CharacterEncodingFilter;
 @Transactional
 @SpringBootTest
 public class IntegrationTest {
+
+  public static final Random RANDOM = new Random();
 
   /******* Repository *******/
   @SpyBean
@@ -198,5 +201,16 @@ public class IntegrationTest {
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
+  }
+
+  public static String generateRandomString(int length) {
+    char leftLimit = '0';
+    char rightLimit = 'z';
+
+    return RANDOM.ints(leftLimit, rightLimit + 1)
+        .filter(i -> Character.isAlphabetic(i) || Character.isDigit(i))
+        .limit(length)
+        .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
+        .toString();
   }
 }

--- a/src/test/java/com/keeper/homepage/domain/auth/api/SignUpControllerTest.java
+++ b/src/test/java/com/keeper/homepage/domain/auth/api/SignUpControllerTest.java
@@ -102,7 +102,7 @@ class SignUpControllerTest extends IntegrationTest {
     @DisplayName("유효한 요청일 경우 회원가입은 성공해야 한다.")
     void should_successfully_when_validRequest() throws Exception {
       long createdMemberId = 1L;
-      doReturn(createdMemberId).when(signUpService).signUp(any());
+      doReturn(createdMemberId).when(signUpService).signUp(any(), any());
       callSignUpApi(validRequest)
           .andExpect(status().isCreated())
           .andExpect(header().string(HttpHeaders.LOCATION, "/members/" + createdMemberId))
@@ -127,14 +127,14 @@ class SignUpControllerTest extends IntegrationTest {
     @ParameterizedTest
     @MethodSource
     @DisplayName("잘못된 형식의 요청일 경우 400 Bad Request를 반환해야 한다.")
-    void should_400BadRequest_when_invalidRequest(String field, String invalidValue)
+    void should_400BadRequest_when_invalidRequest(String field, Object invalidValue)
         throws Exception {
       Object validValue = ReflectionTestUtils.getField(validRequest, field);
       ReflectionTestUtils.setField(validRequest, field, invalidValue);
       callSignUpApi(validRequest)
           .andExpect(status().isBadRequest())
           .andExpect(content().string(containsString(field)))
-          .andExpect(content().string(containsString(invalidValue)));
+          .andExpect(content().string(containsString(invalidValue.toString())));
       ReflectionTestUtils.setField(validRequest, field, validValue);
     }
 
@@ -188,7 +188,7 @@ class SignUpControllerTest extends IntegrationTest {
     @Test
     @DisplayName("이미 존재하는 로그인 아이디일 경우 true를 반환해야 한다.")
     void should_returnTrue_when_existsLoginId() throws Exception {
-      callCheckDuplicateApi(Field.LOGIN_ID, member.getProfile().getLoginId())
+      callCheckDuplicateApi(Field.LOGIN_ID, member.getProfile().getLoginId().get())
           .andDo(print())
           .andExpect(status().isOk())
           .andExpect(jsonPath("$.duplicate").value(true))

--- a/src/test/java/com/keeper/homepage/domain/auth/api/SignUpControllerTest.java
+++ b/src/test/java/com/keeper/homepage/domain/auth/api/SignUpControllerTest.java
@@ -90,7 +90,7 @@ class SignUpControllerTest extends IntegrationTest {
     private final SignUpRequest validRequest = SignUpRequest.builder()
         .loginId("loginId_1337")
         .email("keeper@keeper.or.kr")
-        .password("password123!@#$")
+        .rawPassword("password123!@#$")
         .realName("정현모minion")
         .nickname("0v0zㅣ존")
         .authCode("0123456789")
@@ -146,12 +146,12 @@ class SignUpControllerTest extends IntegrationTest {
           Arguments.arguments("loginId", "no-dash-haha"),
           Arguments.arguments("email", "a@a."),
           Arguments.arguments("email", "notEmail"),
-          Arguments.arguments("password", "a".repeat(6) + "0"),
-          Arguments.arguments("password", "a".repeat(20) + "0"),
-          Arguments.arguments("password", "abcdefghij"),
-          Arguments.arguments("password", "0123456789"),
-          Arguments.arguments("password", "noNumber###"),
-          Arguments.arguments("password", "0123456!@#$"),
+          Arguments.arguments("rawPassword", "a".repeat(6) + "0"),
+          Arguments.arguments("rawPassword", "a".repeat(20) + "0"),
+          Arguments.arguments("rawPassword", "abcdefghij"),
+          Arguments.arguments("rawPassword", "0123456789"),
+          Arguments.arguments("rawPassword", "noNumber###"),
+          Arguments.arguments("rawPassword", "0123456!@#$"),
           Arguments.arguments("realName", "a".repeat(21)),
           Arguments.arguments("realName", ""),
           Arguments.arguments("realName", "  "),

--- a/src/test/java/com/keeper/homepage/domain/auth/api/SignUpControllerTest.java
+++ b/src/test/java/com/keeper/homepage/domain/auth/api/SignUpControllerTest.java
@@ -45,7 +45,7 @@ class SignUpControllerTest extends IntegrationTest {
 
   @Nested
   @DisplayName("이메일 인증 테스트")
-  class EmailAuth {
+  class EmailAddressAuth {
 
     private static final String VALID_EMAIL = "email@email.com";
 
@@ -204,7 +204,7 @@ class SignUpControllerTest extends IntegrationTest {
     @Test
     @DisplayName("이미 존재하는 이메일일 경우 true를 반환해야 한다.")
     void should_returnTrue_when_existsEmail() throws Exception {
-      callCheckDuplicateApi(Field.EMAIL, member.getProfile().getEmailAddress())
+      callCheckDuplicateApi(Field.EMAIL, member.getProfile().getEmailAddress().get())
           .andDo(print())
           .andExpect(status().isOk())
           .andExpect(jsonPath("$.duplicate").value(true))

--- a/src/test/java/com/keeper/homepage/domain/auth/api/SignUpControllerTest.java
+++ b/src/test/java/com/keeper/homepage/domain/auth/api/SignUpControllerTest.java
@@ -220,7 +220,7 @@ class SignUpControllerTest extends IntegrationTest {
     @Test
     @DisplayName("이미 존재하는 학번일 경우 true를 반환해야 한다.")
     void should_returnTrue_when_exigetStudentId() throws Exception {
-      callCheckDuplicateApi(Field.STUDENT_ID, member.getProfile().getStudentId())
+      callCheckDuplicateApi(Field.STUDENT_ID, member.getProfile().getStudentId().get())
           .andDo(print())
           .andExpect(status().isOk())
           .andExpect(jsonPath("$.duplicate").value(true))

--- a/src/test/java/com/keeper/homepage/domain/auth/application/EmailAddressAuthServiceTest.java
+++ b/src/test/java/com/keeper/homepage/domain/auth/application/EmailAddressAuthServiceTest.java
@@ -10,7 +10,7 @@ import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-class EmailAuthServiceTest extends IntegrationTest {
+class EmailAddressAuthServiceTest extends IntegrationTest {
 
   @Test
   @DisplayName("알파벳과 숫자로 이루어진 인증 코드가 잘 생성되어야 하고, Redis에 해당 내용이 들어있어야 한다.")

--- a/src/test/java/com/keeper/homepage/domain/auth/application/SignUpServiceTest.java
+++ b/src/test/java/com/keeper/homepage/domain/auth/application/SignUpServiceTest.java
@@ -11,6 +11,7 @@ import com.keeper.homepage.domain.member.entity.embedded.EmailAddress;
 import com.keeper.homepage.domain.member.entity.embedded.LoginId;
 import com.keeper.homepage.domain.member.entity.embedded.Password;
 import com.keeper.homepage.domain.member.entity.embedded.Profile;
+import com.keeper.homepage.domain.member.entity.embedded.RealName;
 import java.time.LocalDate;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -28,7 +29,7 @@ class SignUpServiceTest extends IntegrationTest {
         .loginId(LoginId.from("loginId_1337"))
         .emailAddress(EmailAddress.from("keeper@keeper.or.kr"))
         .password(Password.from(rawPassword))
-        .realName("정현모minion")
+        .realName(RealName.from("정현모minion"))
         .nickname("0v0zㅣ존")
         .birthday(LocalDate.of(1970, 1, 1))
         .studentId("197012345")

--- a/src/test/java/com/keeper/homepage/domain/auth/application/SignUpServiceTest.java
+++ b/src/test/java/com/keeper/homepage/domain/auth/application/SignUpServiceTest.java
@@ -9,6 +9,7 @@ import com.keeper.homepage.IntegrationTest;
 import com.keeper.homepage.domain.member.entity.Member;
 import com.keeper.homepage.domain.member.entity.embedded.EmailAddress;
 import com.keeper.homepage.domain.member.entity.embedded.LoginId;
+import com.keeper.homepage.domain.member.entity.embedded.Nickname;
 import com.keeper.homepage.domain.member.entity.embedded.Password;
 import com.keeper.homepage.domain.member.entity.embedded.Profile;
 import com.keeper.homepage.domain.member.entity.embedded.RealName;
@@ -30,7 +31,7 @@ class SignUpServiceTest extends IntegrationTest {
         .emailAddress(EmailAddress.from("keeper@keeper.or.kr"))
         .password(Password.from(rawPassword))
         .realName(RealName.from("정현모minion"))
-        .nickname("0v0zㅣ존")
+        .nickname(Nickname.from("0v0zㅣ존"))
         .birthday(LocalDate.of(1970, 1, 1))
         .studentId("197012345")
         .build();

--- a/src/test/java/com/keeper/homepage/domain/auth/application/SignUpServiceTest.java
+++ b/src/test/java/com/keeper/homepage/domain/auth/application/SignUpServiceTest.java
@@ -6,35 +6,43 @@ import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 
 import com.keeper.homepage.IntegrationTest;
-import com.keeper.homepage.domain.auth.dto.request.SignUpRequest;
 import com.keeper.homepage.domain.member.entity.Member;
+import com.keeper.homepage.domain.member.entity.embedded.LoginId;
+import com.keeper.homepage.domain.member.entity.embedded.Profile;
 import java.time.LocalDate;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 class SignUpServiceTest extends IntegrationTest {
 
-  private final SignUpRequest validRequest = SignUpRequest.builder()
-      .loginId("loginId_1337")
-      .email("keeper@keeper.or.kr")
-      .password("password123!@#$")
-      .realName("정현모minion")
-      .nickname("0v0zㅣ존")
-      .authCode("0123456789")
-      .birthday(LocalDate.of(1970, 1, 1))
-      .studentId("197012345")
-      .build();
+  private Profile profile;
+  private final String rawPassword = "password123!@#$";
+  private final String authCode = "0123456789";
+
+  @BeforeEach
+  void setupProfile() {
+    profile = Profile.builder()
+        .loginId(LoginId.from("loginId_1337"))
+        .emailAddress("keeper@keeper.or.kr")
+        .password(passwordEncoder.encode(rawPassword))
+        .realName("정현모minion")
+        .nickname("0v0zㅣ존")
+        .birthday(LocalDate.of(1970, 1, 1))
+        .studentId("197012345")
+        .build();
+  }
 
   @Test
   @DisplayName("회원가입 시 비밀번호는 암호화되어야 한다.")
   void should_encrypted_when_signUp() {
     doReturn("").when(signUpService).getActualAuthCode(any());
     doNothing().when(signUpService).checkAuthCodeMatch(any(), any());
-    long savedMemberId = signUpService.signUp(validRequest);
+    long savedMemberId = signUpService.signUp(profile, authCode);
 
     Member savedMember = memberRepository.findById(savedMemberId).orElseThrow();
     String hashedPassword = savedMember.getProfile().getPassword();
-    assertThat(hashedPassword).isNotEqualTo(validRequest.getPassword());
-    assertThat(passwordEncoder.matches(validRequest.getPassword(), hashedPassword)).isTrue();
+    assertThat(hashedPassword).isNotEqualTo(rawPassword);
+    assertThat(passwordEncoder.matches(rawPassword, hashedPassword)).isTrue();
   }
 }

--- a/src/test/java/com/keeper/homepage/domain/auth/application/SignUpServiceTest.java
+++ b/src/test/java/com/keeper/homepage/domain/auth/application/SignUpServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.doReturn;
 
 import com.keeper.homepage.IntegrationTest;
 import com.keeper.homepage.domain.member.entity.Member;
+import com.keeper.homepage.domain.member.entity.embedded.EmailAddress;
 import com.keeper.homepage.domain.member.entity.embedded.LoginId;
 import com.keeper.homepage.domain.member.entity.embedded.Password;
 import com.keeper.homepage.domain.member.entity.embedded.Profile;
@@ -25,7 +26,7 @@ class SignUpServiceTest extends IntegrationTest {
   void setupProfile() {
     profile = Profile.builder()
         .loginId(LoginId.from("loginId_1337"))
-        .emailAddress("keeper@keeper.or.kr")
+        .emailAddress(EmailAddress.from("keeper@keeper.or.kr"))
         .password(Password.from(rawPassword))
         .realName("정현모minion")
         .nickname("0v0zㅣ존")

--- a/src/test/java/com/keeper/homepage/domain/auth/application/SignUpServiceTest.java
+++ b/src/test/java/com/keeper/homepage/domain/auth/application/SignUpServiceTest.java
@@ -13,6 +13,7 @@ import com.keeper.homepage.domain.member.entity.embedded.Nickname;
 import com.keeper.homepage.domain.member.entity.embedded.Password;
 import com.keeper.homepage.domain.member.entity.embedded.Profile;
 import com.keeper.homepage.domain.member.entity.embedded.RealName;
+import com.keeper.homepage.domain.member.entity.embedded.StudentId;
 import java.time.LocalDate;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -33,7 +34,7 @@ class SignUpServiceTest extends IntegrationTest {
         .realName(RealName.from("정현모minion"))
         .nickname(Nickname.from("0v0zㅣ존"))
         .birthday(LocalDate.of(1970, 1, 1))
-        .studentId("197012345")
+        .studentId(StudentId.from("197012345"))
         .build();
   }
 

--- a/src/test/java/com/keeper/homepage/domain/auth/application/SignUpServiceTest.java
+++ b/src/test/java/com/keeper/homepage/domain/auth/application/SignUpServiceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.doReturn;
 import com.keeper.homepage.IntegrationTest;
 import com.keeper.homepage.domain.member.entity.Member;
 import com.keeper.homepage.domain.member.entity.embedded.LoginId;
+import com.keeper.homepage.domain.member.entity.embedded.Password;
 import com.keeper.homepage.domain.member.entity.embedded.Profile;
 import java.time.LocalDate;
 import org.junit.jupiter.api.BeforeEach;
@@ -25,7 +26,7 @@ class SignUpServiceTest extends IntegrationTest {
     profile = Profile.builder()
         .loginId(LoginId.from("loginId_1337"))
         .emailAddress("keeper@keeper.or.kr")
-        .password(passwordEncoder.encode(rawPassword))
+        .password(Password.from(rawPassword))
         .realName("정현모minion")
         .nickname("0v0zㅣ존")
         .birthday(LocalDate.of(1970, 1, 1))
@@ -41,7 +42,7 @@ class SignUpServiceTest extends IntegrationTest {
     long savedMemberId = signUpService.signUp(profile, authCode);
 
     Member savedMember = memberRepository.findById(savedMemberId).orElseThrow();
-    String hashedPassword = savedMember.getProfile().getPassword();
+    String hashedPassword = savedMember.getProfile().getPassword().get();
     assertThat(hashedPassword).isNotEqualTo(rawPassword);
     assertThat(passwordEncoder.matches(rawPassword, hashedPassword)).isTrue();
   }

--- a/src/test/java/com/keeper/homepage/domain/member/MemberTestHelper.java
+++ b/src/test/java/com/keeper/homepage/domain/member/MemberTestHelper.java
@@ -10,11 +10,13 @@ import static com.keeper.homepage.domain.member.entity.embedded.Profile.MAX_STUD
 import com.keeper.homepage.domain.member.dao.MemberRepository;
 import com.keeper.homepage.domain.member.entity.Member;
 import com.keeper.homepage.domain.member.entity.embedded.LoginId;
+import com.keeper.homepage.domain.member.entity.embedded.Password;
 import com.keeper.homepage.domain.member.entity.embedded.Profile;
 import com.keeper.homepage.domain.thumbnail.entity.Thumbnail;
 import com.keeper.homepage.global.util.thumbnail.ThumbnailTestHelper;
 import java.time.LocalDate;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -38,7 +40,7 @@ public class MemberTestHelper {
 
     private LoginId loginId;
     private String email;
-    private String password;
+    private Password password;
     private String realName;
     private String nickname;
     private LocalDate birthday;
@@ -64,7 +66,7 @@ public class MemberTestHelper {
       return this;
     }
 
-    public MemberBuilder password(String password) {
+    public MemberBuilder password(Password password) {
       this.password = password;
       return this;
     }
@@ -130,7 +132,8 @@ public class MemberTestHelper {
               .loginId(loginId != null ? loginId
                   : LoginId.from(generateRandomString(MAX_LOGIN_ID_LENGTH)))
               .emailAddress(email != null ? email : generateRandomString(MAX_EMAIL_LENGTH))
-              .password(password != null ? password : generateRandomString(100))
+              .password(password != null ? password :
+                  Password.from(generateRandomString(10) + "1a", MOCK_PASSWORD_ENCODER))
               .realName(realName != null ? realName : generateRandomString(MAX_REAL_NAME_LENGTH))
               .nickname(nickname != null ? nickname : generateRandomString(MAX_NICKNAME_LENGTH))
               .birthday(birthday != null ? birthday : LocalDate.of(1970, 1, 1))
@@ -146,4 +149,16 @@ public class MemberTestHelper {
           .build());
     }
   }
+
+  private static final PasswordEncoder MOCK_PASSWORD_ENCODER = new PasswordEncoder() {
+    @Override
+    public String encode(CharSequence rawPassword) {
+      return rawPassword.toString();
+    }
+
+    @Override
+    public boolean matches(CharSequence rawPassword, String encodedPassword) {
+      return rawPassword.toString().equals(encodedPassword);
+    }
+  };
 }

--- a/src/test/java/com/keeper/homepage/domain/member/MemberTestHelper.java
+++ b/src/test/java/com/keeper/homepage/domain/member/MemberTestHelper.java
@@ -1,18 +1,19 @@
 package com.keeper.homepage.domain.member;
 
+import static com.keeper.homepage.IntegrationTest.generateRandomString;
+import static com.keeper.homepage.domain.member.entity.embedded.LoginId.MAX_LOGIN_ID_LENGTH;
 import static com.keeper.homepage.domain.member.entity.embedded.Profile.MAX_EMAIL_LENGTH;
-import static com.keeper.homepage.domain.member.entity.embedded.Profile.MAX_LOGIN_ID_LENGTH;
 import static com.keeper.homepage.domain.member.entity.embedded.Profile.MAX_NICKNAME_LENGTH;
 import static com.keeper.homepage.domain.member.entity.embedded.Profile.MAX_REAL_NAME_LENGTH;
 import static com.keeper.homepage.domain.member.entity.embedded.Profile.MAX_STUDENT_ID_LENGTH;
 
 import com.keeper.homepage.domain.member.dao.MemberRepository;
 import com.keeper.homepage.domain.member.entity.Member;
+import com.keeper.homepage.domain.member.entity.embedded.LoginId;
 import com.keeper.homepage.domain.member.entity.embedded.Profile;
 import com.keeper.homepage.domain.thumbnail.entity.Thumbnail;
 import com.keeper.homepage.global.util.thumbnail.ThumbnailTestHelper;
 import java.time.LocalDate;
-import java.util.UUID;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -35,7 +36,7 @@ public class MemberTestHelper {
 
   public final class MemberBuilder {
 
-    private String loginId;
+    private LoginId loginId;
     private String email;
     private String password;
     private String realName;
@@ -53,7 +54,7 @@ public class MemberTestHelper {
     private MemberBuilder() {
     }
 
-    public MemberBuilder loginId(String loginId) {
+    public MemberBuilder loginId(LoginId loginId) {
       this.loginId = loginId;
       return this;
     }
@@ -126,14 +127,15 @@ public class MemberTestHelper {
     public Member build() {
       return memberRepository.save(Member.builder()
           .profile(Profile.builder()
-              .loginId(loginId != null ? loginId : getRandomUUIDLengthWith(MAX_LOGIN_ID_LENGTH))
-              .emailAddress(email != null ? email : getRandomUUIDLengthWith(MAX_EMAIL_LENGTH))
-              .password(password != null ? password : getRandomUUIDLengthWith(100))
-              .realName(realName != null ? realName : getRandomUUIDLengthWith(MAX_REAL_NAME_LENGTH))
-              .nickname(nickname != null ? nickname : getRandomUUIDLengthWith(MAX_NICKNAME_LENGTH))
+              .loginId(loginId != null ? loginId
+                  : LoginId.from(generateRandomString(MAX_LOGIN_ID_LENGTH)))
+              .emailAddress(email != null ? email : generateRandomString(MAX_EMAIL_LENGTH))
+              .password(password != null ? password : generateRandomString(100))
+              .realName(realName != null ? realName : generateRandomString(MAX_REAL_NAME_LENGTH))
+              .nickname(nickname != null ? nickname : generateRandomString(MAX_NICKNAME_LENGTH))
               .birthday(birthday != null ? birthday : LocalDate.of(1970, 1, 1))
               .studentId(studentId != null ? studentId
-                  : getRandomUUIDLengthWith(MAX_STUDENT_ID_LENGTH))
+                  : generateRandomString(MAX_STUDENT_ID_LENGTH))
               .thumbnail(thumbnail != null ? thumbnail : thumbnailTestHelper.generateThumbnail())
               .build())
           .point(point != null ? point : 0)
@@ -142,13 +144,6 @@ public class MemberTestHelper {
           .demerit(demerit != null ? demerit : 0)
           .totalAttendance(totalAttendance != null ? totalAttendance : 0)
           .build());
-    }
-
-    private static String getRandomUUIDLengthWith(int length) {
-      String randomString = UUID.randomUUID()
-          .toString();
-      length = Math.min(length, randomString.length());
-      return randomString.substring(0, length);
     }
   }
 }

--- a/src/test/java/com/keeper/homepage/domain/member/MemberTestHelper.java
+++ b/src/test/java/com/keeper/homepage/domain/member/MemberTestHelper.java
@@ -2,13 +2,13 @@ package com.keeper.homepage.domain.member;
 
 import static com.keeper.homepage.IntegrationTest.generateRandomString;
 import static com.keeper.homepage.domain.member.entity.embedded.LoginId.MAX_LOGIN_ID_LENGTH;
-import static com.keeper.homepage.domain.member.entity.embedded.Profile.MAX_EMAIL_LENGTH;
 import static com.keeper.homepage.domain.member.entity.embedded.Profile.MAX_NICKNAME_LENGTH;
 import static com.keeper.homepage.domain.member.entity.embedded.Profile.MAX_REAL_NAME_LENGTH;
 import static com.keeper.homepage.domain.member.entity.embedded.Profile.MAX_STUDENT_ID_LENGTH;
 
 import com.keeper.homepage.domain.member.dao.MemberRepository;
 import com.keeper.homepage.domain.member.entity.Member;
+import com.keeper.homepage.domain.member.entity.embedded.EmailAddress;
 import com.keeper.homepage.domain.member.entity.embedded.LoginId;
 import com.keeper.homepage.domain.member.entity.embedded.Password;
 import com.keeper.homepage.domain.member.entity.embedded.Profile;
@@ -39,7 +39,7 @@ public class MemberTestHelper {
   public final class MemberBuilder {
 
     private LoginId loginId;
-    private String email;
+    private EmailAddress email;
     private Password password;
     private String realName;
     private String nickname;
@@ -61,7 +61,7 @@ public class MemberTestHelper {
       return this;
     }
 
-    public MemberBuilder emailAddress(String emailAddress) {
+    public MemberBuilder emailAddress(EmailAddress emailAddress) {
       this.email = emailAddress;
       return this;
     }
@@ -131,7 +131,8 @@ public class MemberTestHelper {
           .profile(Profile.builder()
               .loginId(loginId != null ? loginId
                   : LoginId.from(generateRandomString(MAX_LOGIN_ID_LENGTH)))
-              .emailAddress(email != null ? email : generateRandomString(MAX_EMAIL_LENGTH))
+              .emailAddress(email != null ? email : EmailAddress.from(
+                  generateRandomString(50) + '@' + generateRandomString(50) + ".com"))
               .password(password != null ? password :
                   Password.from(generateRandomString(10) + "1a", MOCK_PASSWORD_ENCODER))
               .realName(realName != null ? realName : generateRandomString(MAX_REAL_NAME_LENGTH))

--- a/src/test/java/com/keeper/homepage/domain/member/MemberTestHelper.java
+++ b/src/test/java/com/keeper/homepage/domain/member/MemberTestHelper.java
@@ -1,7 +1,7 @@
 package com.keeper.homepage.domain.member;
 
 import static com.keeper.homepage.IntegrationTest.generateRandomString;
-import static com.keeper.homepage.domain.member.entity.embedded.Profile.MAX_STUDENT_ID_LENGTH;
+import static com.keeper.homepage.domain.member.entity.embedded.StudentId.MAX_STUDENT_ID_LENGTH;
 
 import com.keeper.homepage.domain.member.dao.MemberRepository;
 import com.keeper.homepage.domain.member.entity.Member;
@@ -11,6 +11,7 @@ import com.keeper.homepage.domain.member.entity.embedded.Nickname;
 import com.keeper.homepage.domain.member.entity.embedded.Password;
 import com.keeper.homepage.domain.member.entity.embedded.Profile;
 import com.keeper.homepage.domain.member.entity.embedded.RealName;
+import com.keeper.homepage.domain.member.entity.embedded.StudentId;
 import com.keeper.homepage.domain.thumbnail.entity.Thumbnail;
 import com.keeper.homepage.global.util.thumbnail.ThumbnailTestHelper;
 import java.time.LocalDate;
@@ -44,7 +45,7 @@ public class MemberTestHelper {
     private RealName realName;
     private Nickname nickname;
     private LocalDate birthday;
-    private String studentId;
+    private StudentId studentId;
     private Integer point;
     private Integer level;
     private Thumbnail thumbnail;
@@ -86,7 +87,7 @@ public class MemberTestHelper {
       return this;
     }
 
-    public MemberBuilder studentId(String studentId) {
+    public MemberBuilder studentId(StudentId studentId) {
       this.studentId = studentId;
       return this;
     }
@@ -141,7 +142,7 @@ public class MemberTestHelper {
                   Nickname.from(generateRandomAlphabeticString(20)))
               .birthday(birthday != null ? birthday : LocalDate.of(1970, 1, 1))
               .studentId(studentId != null ? studentId
-                  : generateRandomString(MAX_STUDENT_ID_LENGTH))
+                  : StudentId.from(generateRandomDigitString(MAX_STUDENT_ID_LENGTH)))
               .thumbnail(thumbnail != null ? thumbnail : thumbnailTestHelper.generateThumbnail())
               .build())
           .point(point != null ? point : 0)
@@ -166,12 +167,23 @@ public class MemberTestHelper {
   };
 
   private static String generateRandomAlphabeticString(int length) {
-    final Random RANDOM = new Random();
+    final Random random = new Random();
     char leftLimit = '0';
     char rightLimit = 'z';
 
-    return RANDOM.ints(leftLimit, rightLimit + 1)
+    return random.ints(leftLimit, rightLimit + 1)
         .filter(Character::isAlphabetic)
+        .limit(length)
+        .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
+        .toString();
+  }
+
+  private static String generateRandomDigitString(int length) {
+    final Random random = new Random();
+    char leftLimit = '0';
+    char rightLimit = '9';
+
+    return random.ints(leftLimit, rightLimit + 1)
         .limit(length)
         .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
         .toString();

--- a/src/test/java/com/keeper/homepage/domain/member/MemberTestHelper.java
+++ b/src/test/java/com/keeper/homepage/domain/member/MemberTestHelper.java
@@ -1,13 +1,13 @@
 package com.keeper.homepage.domain.member;
 
 import static com.keeper.homepage.IntegrationTest.generateRandomString;
-import static com.keeper.homepage.domain.member.entity.embedded.Profile.MAX_NICKNAME_LENGTH;
 import static com.keeper.homepage.domain.member.entity.embedded.Profile.MAX_STUDENT_ID_LENGTH;
 
 import com.keeper.homepage.domain.member.dao.MemberRepository;
 import com.keeper.homepage.domain.member.entity.Member;
 import com.keeper.homepage.domain.member.entity.embedded.EmailAddress;
 import com.keeper.homepage.domain.member.entity.embedded.LoginId;
+import com.keeper.homepage.domain.member.entity.embedded.Nickname;
 import com.keeper.homepage.domain.member.entity.embedded.Password;
 import com.keeper.homepage.domain.member.entity.embedded.Profile;
 import com.keeper.homepage.domain.member.entity.embedded.RealName;
@@ -42,7 +42,7 @@ public class MemberTestHelper {
     private EmailAddress email;
     private Password password;
     private RealName realName;
-    private String nickname;
+    private Nickname nickname;
     private LocalDate birthday;
     private String studentId;
     private Integer point;
@@ -76,7 +76,7 @@ public class MemberTestHelper {
       return this;
     }
 
-    public MemberBuilder nickname(String nickname) {
+    public MemberBuilder nickname(Nickname nickname) {
       this.nickname = nickname;
       return this;
     }
@@ -137,7 +137,8 @@ public class MemberTestHelper {
                   Password.from(generateRandomString(10) + "1a", MOCK_PASSWORD_ENCODER))
               .realName(realName != null ? realName :
                   RealName.from(generateRandomAlphabeticString(20)))
-              .nickname(nickname != null ? nickname : generateRandomString(MAX_NICKNAME_LENGTH))
+              .nickname(nickname != null ? nickname :
+                  Nickname.from(generateRandomAlphabeticString(20)))
               .birthday(birthday != null ? birthday : LocalDate.of(1970, 1, 1))
               .studentId(studentId != null ? studentId
                   : generateRandomString(MAX_STUDENT_ID_LENGTH))

--- a/src/test/java/com/keeper/homepage/domain/member/MemberTestHelper.java
+++ b/src/test/java/com/keeper/homepage/domain/member/MemberTestHelper.java
@@ -1,9 +1,7 @@
 package com.keeper.homepage.domain.member;
 
 import static com.keeper.homepage.IntegrationTest.generateRandomString;
-import static com.keeper.homepage.domain.member.entity.embedded.LoginId.MAX_LOGIN_ID_LENGTH;
 import static com.keeper.homepage.domain.member.entity.embedded.Profile.MAX_NICKNAME_LENGTH;
-import static com.keeper.homepage.domain.member.entity.embedded.Profile.MAX_REAL_NAME_LENGTH;
 import static com.keeper.homepage.domain.member.entity.embedded.Profile.MAX_STUDENT_ID_LENGTH;
 
 import com.keeper.homepage.domain.member.dao.MemberRepository;
@@ -12,9 +10,11 @@ import com.keeper.homepage.domain.member.entity.embedded.EmailAddress;
 import com.keeper.homepage.domain.member.entity.embedded.LoginId;
 import com.keeper.homepage.domain.member.entity.embedded.Password;
 import com.keeper.homepage.domain.member.entity.embedded.Profile;
+import com.keeper.homepage.domain.member.entity.embedded.RealName;
 import com.keeper.homepage.domain.thumbnail.entity.Thumbnail;
 import com.keeper.homepage.global.util.thumbnail.ThumbnailTestHelper;
 import java.time.LocalDate;
+import java.util.Random;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
@@ -41,7 +41,7 @@ public class MemberTestHelper {
     private LoginId loginId;
     private EmailAddress email;
     private Password password;
-    private String realName;
+    private RealName realName;
     private String nickname;
     private LocalDate birthday;
     private String studentId;
@@ -71,7 +71,7 @@ public class MemberTestHelper {
       return this;
     }
 
-    public MemberBuilder realName(String realName) {
+    public MemberBuilder realName(RealName realName) {
       this.realName = realName;
       return this;
     }
@@ -130,12 +130,13 @@ public class MemberTestHelper {
       return memberRepository.save(Member.builder()
           .profile(Profile.builder()
               .loginId(loginId != null ? loginId
-                  : LoginId.from(generateRandomString(MAX_LOGIN_ID_LENGTH)))
+                  : LoginId.from(generateRandomString(12)))
               .emailAddress(email != null ? email : EmailAddress.from(
                   generateRandomString(50) + '@' + generateRandomString(50) + ".com"))
               .password(password != null ? password :
                   Password.from(generateRandomString(10) + "1a", MOCK_PASSWORD_ENCODER))
-              .realName(realName != null ? realName : generateRandomString(MAX_REAL_NAME_LENGTH))
+              .realName(realName != null ? realName :
+                  RealName.from(generateRandomAlphabeticString(20)))
               .nickname(nickname != null ? nickname : generateRandomString(MAX_NICKNAME_LENGTH))
               .birthday(birthday != null ? birthday : LocalDate.of(1970, 1, 1))
               .studentId(studentId != null ? studentId
@@ -162,4 +163,16 @@ public class MemberTestHelper {
       return rawPassword.toString().equals(encodedPassword);
     }
   };
+
+  private static String generateRandomAlphabeticString(int length) {
+    final Random RANDOM = new Random();
+    char leftLimit = '0';
+    char rightLimit = 'z';
+
+    return RANDOM.ints(leftLimit, rightLimit + 1)
+        .filter(Character::isAlphabetic)
+        .limit(length)
+        .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
+        .toString();
+  }
 }

--- a/src/test/java/com/keeper/homepage/domain/member/dao/MemberRepositoryTest.java
+++ b/src/test/java/com/keeper/homepage/domain/member/dao/MemberRepositoryTest.java
@@ -12,6 +12,7 @@ import com.keeper.homepage.domain.member.entity.embedded.EmailAddress;
 import com.keeper.homepage.domain.member.entity.embedded.LoginId;
 import com.keeper.homepage.domain.member.entity.embedded.Password;
 import com.keeper.homepage.domain.member.entity.embedded.Profile;
+import com.keeper.homepage.domain.member.entity.embedded.RealName;
 import com.keeper.homepage.domain.member.entity.job.MemberHasMemberJob;
 import com.keeper.homepage.domain.member.entity.job.MemberJob;
 import java.util.List;
@@ -42,7 +43,7 @@ class MemberRepositoryTest extends IntegrationTest {
               .loginId(LoginId.from("ABCD"))
               .emailAddress(EmailAddress.from("ABC@keeper.com"))
               .password(Password.from("password123"))
-              .realName("realName")
+              .realName(RealName.from("realName"))
               .nickname("nickname")
               .build())
           .build();

--- a/src/test/java/com/keeper/homepage/domain/member/dao/MemberRepositoryTest.java
+++ b/src/test/java/com/keeper/homepage/domain/member/dao/MemberRepositoryTest.java
@@ -9,6 +9,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.keeper.homepage.IntegrationTest;
 import com.keeper.homepage.domain.member.entity.Member;
 import com.keeper.homepage.domain.member.entity.embedded.LoginId;
+import com.keeper.homepage.domain.member.entity.embedded.Password;
 import com.keeper.homepage.domain.member.entity.embedded.Profile;
 import com.keeper.homepage.domain.member.entity.job.MemberHasMemberJob;
 import com.keeper.homepage.domain.member.entity.job.MemberJob;
@@ -39,7 +40,7 @@ class MemberRepositoryTest extends IntegrationTest {
           .profile(Profile.builder()
               .loginId(LoginId.from("ABCD"))
               .emailAddress("ABC@keeper.com")
-              .password("password")
+              .password(Password.from("password123"))
               .realName("realName")
               .nickname("nickname")
               .build())

--- a/src/test/java/com/keeper/homepage/domain/member/dao/MemberRepositoryTest.java
+++ b/src/test/java/com/keeper/homepage/domain/member/dao/MemberRepositoryTest.java
@@ -10,6 +10,7 @@ import com.keeper.homepage.IntegrationTest;
 import com.keeper.homepage.domain.member.entity.Member;
 import com.keeper.homepage.domain.member.entity.embedded.EmailAddress;
 import com.keeper.homepage.domain.member.entity.embedded.LoginId;
+import com.keeper.homepage.domain.member.entity.embedded.Nickname;
 import com.keeper.homepage.domain.member.entity.embedded.Password;
 import com.keeper.homepage.domain.member.entity.embedded.Profile;
 import com.keeper.homepage.domain.member.entity.embedded.RealName;
@@ -44,7 +45,7 @@ class MemberRepositoryTest extends IntegrationTest {
               .emailAddress(EmailAddress.from("ABC@keeper.com"))
               .password(Password.from("password123"))
               .realName(RealName.from("realName"))
-              .nickname("nickname")
+              .nickname(Nickname.from("nickname"))
               .build())
           .build();
 

--- a/src/test/java/com/keeper/homepage/domain/member/dao/MemberRepositoryTest.java
+++ b/src/test/java/com/keeper/homepage/domain/member/dao/MemberRepositoryTest.java
@@ -8,6 +8,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.keeper.homepage.IntegrationTest;
 import com.keeper.homepage.domain.member.entity.Member;
+import com.keeper.homepage.domain.member.entity.embedded.LoginId;
 import com.keeper.homepage.domain.member.entity.embedded.Profile;
 import com.keeper.homepage.domain.member.entity.job.MemberHasMemberJob;
 import com.keeper.homepage.domain.member.entity.job.MemberJob;
@@ -36,7 +37,7 @@ class MemberRepositoryTest extends IntegrationTest {
     void should_saveSuccessfully_when_defaultColumnIsNull() {
       Member memberBeforeSave = Member.builder()
           .profile(Profile.builder()
-              .loginId("ABC")
+              .loginId(LoginId.from("ABCD"))
               .emailAddress("ABC@keeper.com")
               .password("password")
               .realName("realName")

--- a/src/test/java/com/keeper/homepage/domain/member/dao/MemberRepositoryTest.java
+++ b/src/test/java/com/keeper/homepage/domain/member/dao/MemberRepositoryTest.java
@@ -8,6 +8,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.keeper.homepage.IntegrationTest;
 import com.keeper.homepage.domain.member.entity.Member;
+import com.keeper.homepage.domain.member.entity.embedded.EmailAddress;
 import com.keeper.homepage.domain.member.entity.embedded.LoginId;
 import com.keeper.homepage.domain.member.entity.embedded.Password;
 import com.keeper.homepage.domain.member.entity.embedded.Profile;
@@ -39,7 +40,7 @@ class MemberRepositoryTest extends IntegrationTest {
       Member memberBeforeSave = Member.builder()
           .profile(Profile.builder()
               .loginId(LoginId.from("ABCD"))
-              .emailAddress("ABC@keeper.com")
+              .emailAddress(EmailAddress.from("ABC@keeper.com"))
               .password(Password.from("password123"))
               .realName("realName")
               .nickname("nickname")


### PR DESCRIPTION
## 🔥 Related Issue

close: #52

## 📝 Description

- `LoginId` Embedded 객체 생성
- `Password` Embedded 객체 생성
    - `rawPassword`, `hashedPassword` 구분
    - `Password` 객체엔 실제로 암호화 된 문자열만 가진다.
    - 테스트 시 패스워드 암호화에 드는 시간을 아끼기 위해 `MockPasswordEncoder` 추가
    - 값 객체에서도 `PasswordEncoder`를 쓰기 위해 `@Bean`으로 주입하지 않고 `PasswordEncoderFactory` 생성
- `EmailAddress` Embedded 객체 생성
- `RealName` Embedded 객체 생성
- `Nickname` Embedded 객체 생성
- `StudentId` Embedded 객체 생성

## ⭐️ Review

브랜치명 `feature/feature` ㅋㅋㅋ