### PR TITLE
Feature/게시글 수정 및 삭제 기능 구현

### DIFF
--- a/src/docs/asciidoc/post/post.adoc
+++ b/src/docs/asciidoc/post/post.adoc
@@ -98,3 +98,81 @@ include::{snippets}/find-secret-post/http-response.adoc[]
 ==== Response Fields
 
 include::{snippets}/find-secret-post/response-fields.adoc[]
+
+== *게시글 수정하기*
+
+=== 요청
+
+==== Request
+
+include::{snippets}/update-post/http-request.adoc[]
+
+==== Request Cookies
+
+include::{snippets}/update-post/request-cookies.adoc[]
+
+==== Path Parameters
+
+include::{snippets}/update-post/path-parameters.adoc[]
+
+==== Query Parameters
+
+include::{snippets}/update-post/query-parameters.adoc[]
+
+==== Request Parts
+
+include::{snippets}/update-post/request-parts.adoc[]
+
+=== 응답
+
+==== Response
+
+include::{snippets}/update-post/http-response.adoc[]
+
+==== Response Headers
+
+include::{snippets}/update-post/response-headers.adoc[]
+
+== *게시글 삭제하기*
+
+=== 요청
+
+==== Request
+
+include::{snippets}/delete-post/http-request.adoc[]
+
+==== Request Cookies
+
+include::{snippets}/delete-post/request-cookies.adoc[]
+
+==== Path Parameters
+
+include::{snippets}/delete-post/path-parameters.adoc[]
+
+=== 응답
+
+==== Response
+
+include::{snippets}/delete-post/http-response.adoc[]
+
+== *관리자 권한으로 게시글 삭제하기*
+
+=== 요청
+
+==== Request
+
+include::{snippets}/admin-delete-post/http-request.adoc[]
+
+==== Request Cookies
+
+include::{snippets}/admin-delete-post/request-cookies.adoc[]
+
+==== Path Parameters
+
+include::{snippets}/admin-delete-post/path-parameters.adoc[]
+
+=== 응답
+
+==== Response
+
+include::{snippets}/admin-delete-post/http-response.adoc[]

--- a/src/main/java/com/keeper/homepage/domain/file/dao/FileRepository.java
+++ b/src/main/java/com/keeper/homepage/domain/file/dao/FileRepository.java
@@ -1,8 +1,13 @@
 package com.keeper.homepage.domain.file.dao;
 
 import com.keeper.homepage.domain.file.entity.FileEntity;
+import com.keeper.homepage.domain.post.entity.Post;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface FileRepository extends JpaRepository<FileEntity, Long> {
 
+  List<FileEntity> findAllByPost(Post post);
+
+  List<FileEntity> findAllByPostAndIdNot(Post post, Long fileId);
 }

--- a/src/main/java/com/keeper/homepage/domain/post/api/AdminPostController.java
+++ b/src/main/java/com/keeper/homepage/domain/post/api/AdminPostController.java
@@ -1,0 +1,30 @@
+package com.keeper.homepage.domain.post.api;
+
+import com.keeper.homepage.domain.member.entity.Member;
+import com.keeper.homepage.domain.post.application.AdminPostService;
+import com.keeper.homepage.global.config.security.annotation.LoginMember;
+import java.net.URI;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Secured({"ROLE_회장", "ROLE_부회장"})
+@RequestMapping("/admin/posts")
+public class AdminPostController {
+
+  private final AdminPostService adminPostService;
+
+  @DeleteMapping("/{postId}")
+  public ResponseEntity<Void> deletePost(
+      @PathVariable long postId
+  ) {
+    adminPostService.delete(postId);
+    return ResponseEntity.noContent().build();
+  }
+}

--- a/src/main/java/com/keeper/homepage/domain/post/api/PostController.java
+++ b/src/main/java/com/keeper/homepage/domain/post/api/PostController.java
@@ -2,21 +2,22 @@ package com.keeper.homepage.domain.post.api;
 
 import com.keeper.homepage.domain.member.entity.Member;
 import com.keeper.homepage.domain.post.application.PostService;
-import com.keeper.homepage.domain.post.dto.request.PostRequest;
+import com.keeper.homepage.domain.post.dto.request.PostCreateRequest;
+import com.keeper.homepage.domain.post.dto.request.PostUpdateRequest;
 import com.keeper.homepage.domain.post.dto.response.PostResponse;
 import com.keeper.homepage.global.config.security.annotation.LoginMember;
 import com.keeper.homepage.global.util.web.WebUtil;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.lang.Nullable;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -31,7 +32,7 @@ public class PostController {
   @PostMapping
   public ResponseEntity<Void> createPost(
       @LoginMember Member member,
-      @ModelAttribute @Valid PostRequest request
+      @ModelAttribute @Valid PostCreateRequest request
   ) {
     Long postId = postService.create(
         request.toEntity(member, WebUtil.getUserIP()),
@@ -54,4 +55,24 @@ public class PostController {
         .body(postResponse);
   }
 
+  @PutMapping("/{postId}")
+  public ResponseEntity<Void> updatePost(
+      @LoginMember Member member,
+      @PathVariable long postId,
+      @ModelAttribute @Valid PostUpdateRequest request
+  ) {
+    postService.update(member, postId, request);
+    return ResponseEntity.status(HttpStatus.CREATED)
+        .location(URI.create("/posts/" + postId))
+        .build();
+  }
+
+  @DeleteMapping("/{postId}")
+  public ResponseEntity<Void> deletePost(
+      @LoginMember Member member,
+      @PathVariable long postId
+  ) {
+    postService.delete(member, postId);
+    return ResponseEntity.noContent().build();
+  }
 }

--- a/src/main/java/com/keeper/homepage/domain/post/application/AdminPostService.java
+++ b/src/main/java/com/keeper/homepage/domain/post/application/AdminPostService.java
@@ -1,0 +1,22 @@
+package com.keeper.homepage.domain.post.application;
+
+import com.keeper.homepage.domain.post.application.convenience.ValidPostFindService;
+import com.keeper.homepage.domain.post.dao.PostRepository;
+import com.keeper.homepage.domain.post.entity.Post;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminPostService {
+
+  private final PostRepository postRepository;
+  private final ValidPostFindService validPostFindService;
+
+  public void delete(long postId) {
+    Post post = validPostFindService.findById(postId);
+    postRepository.delete(post);
+  }
+}

--- a/src/main/java/com/keeper/homepage/domain/post/dto/request/PostCreateRequest.java
+++ b/src/main/java/com/keeper/homepage/domain/post/dto/request/PostCreateRequest.java
@@ -4,8 +4,6 @@ import static lombok.AccessLevel.PRIVATE;
 
 import com.keeper.homepage.domain.member.entity.Member;
 import com.keeper.homepage.domain.post.entity.Post;
-import com.keeper.homepage.domain.post.entity.category.Category;
-import com.keeper.homepage.domain.thumbnail.entity.Thumbnail;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PositiveOrZero;
@@ -14,14 +12,13 @@ import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import org.hibernate.validator.constraints.Length;
 import org.springframework.lang.Nullable;
 import org.springframework.web.multipart.MultipartFile;
 
 @Getter
 @Builder
 @AllArgsConstructor(access = PRIVATE)
-public class PostRequest {
+public class PostCreateRequest {
 
   public static final int MAX_REQUEST_TITLE_LENGTH = 50;
   public static final int MAX_REQUEST_PASSWORD_LENGTH = 16;
@@ -53,7 +50,10 @@ public class PostRequest {
   @PositiveOrZero(message = "올바른 카테고리 아이디를 입력해주세요.")
   private Long categoryId;
 
+  @Nullable
   private MultipartFile thumbnail;
+
+  @Nullable
   private List<MultipartFile> files;
 
   public Post toEntity(Member member, String ipAddress) {

--- a/src/main/java/com/keeper/homepage/domain/post/dto/request/PostUpdateRequest.java
+++ b/src/main/java/com/keeper/homepage/domain/post/dto/request/PostUpdateRequest.java
@@ -1,0 +1,53 @@
+package com.keeper.homepage.domain.post.dto.request;
+
+import static lombok.AccessLevel.*;
+import static lombok.AccessLevel.PRIVATE;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.lang.Nullable;
+import org.springframework.web.multipart.MultipartFile;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = PRIVATE)
+public class PostUpdateRequest {
+
+  public static final int MAX_REQUEST_TITLE_LENGTH = 50;
+  public static final int MAX_REQUEST_PASSWORD_LENGTH = 16;
+
+  @NotBlank(message = "게시글 제목을 입력해주세요.")
+  @Size(max = MAX_REQUEST_TITLE_LENGTH, message = "게시글 제목은 {max}자 이하로 입력해주세요.")
+  private String title;
+
+  @NotBlank(message = "게시글 본문을 입력해주세요.")
+  private String content;
+
+  @Nullable
+  private Boolean allowComment;
+
+  @Nullable
+  private Boolean isNotice;
+
+  @Nullable
+  private Boolean isSecret;
+
+  @Nullable
+  private Boolean isTemp;
+
+  @Nullable
+  @Size(max = MAX_REQUEST_PASSWORD_LENGTH, message = "비밀번호는 {max}자 이하로 입력해주세요.")
+  private String password;
+
+  @Nullable
+  private MultipartFile thumbnail;
+
+  @Nullable
+  private List<MultipartFile> files;
+}

--- a/src/main/java/com/keeper/homepage/domain/post/dto/response/PostResponse.java
+++ b/src/main/java/com/keeper/homepage/domain/post/dto/response/PostResponse.java
@@ -1,7 +1,5 @@
 package com.keeper.homepage.domain.post.dto.response;
 
-import static com.keeper.homepage.domain.thumbnail.entity.Thumbnail.DefaultThumbnail.POST_THUMBNAIL;
-import static java.util.stream.Collectors.*;
 import static lombok.AccessLevel.PRIVATE;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
@@ -27,6 +25,10 @@ public class PostResponse {
   private List<FileResponse> files;
   private Integer likeCount;
   private Integer dislikeCount;
+  private Boolean allowComment;
+  private Boolean isNotice;
+  private Boolean isSecret;
+  private Boolean isTemp;
 
   @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
   private LocalDateTime registerTime;
@@ -48,6 +50,10 @@ public class PostResponse {
         .files(files)
         .likeCount(post.getLikeCount())
         .dislikeCount(post.getDislikeCount())
+        .allowComment(post.allowComment())
+        .isNotice(post.isNotice())
+        .isSecret(post.isSecret())
+        .isTemp(post.isTemp())
         .build();
   }
 }

--- a/src/main/java/com/keeper/homepage/domain/post/entity/Post.java
+++ b/src/main/java/com/keeper/homepage/domain/post/entity/Post.java
@@ -141,7 +141,7 @@ public class Post extends BaseEntity {
     category.getPosts().add(this);
   }
 
-  public void registerThumbnail(Thumbnail thumbnail) {
+  public void changeThumbnail(Thumbnail thumbnail) {
     this.thumbnail = thumbnail;
   }
 
@@ -161,15 +161,31 @@ public class Post extends BaseEntity {
     return Objects.equals(this.getPassword(), password);
   }
 
-  public boolean isNotice() {
-    return this.isNotice;
+  public Boolean isNotice() {
+    return getIsNotice();
   }
 
-  public boolean isTemp() {
-    return this.isTemp;
+  public Boolean isTemp() {
+    return getIsTemp();
   }
 
-  public boolean isSecret() {
-    return this.isSecret;
+  public Boolean isSecret() {
+    return getIsSecret();
+  }
+
+  public Boolean allowComment() {
+    return getAllowComment();
+  }
+
+  public void update(String title, String content, String ipAddress, Boolean allowComment,
+      Boolean isNotice, Boolean isSecret, Boolean isTemp, String password) {
+    this.title = title;
+    this.content = content;
+    this.ipAddress = ipAddress;
+    this.allowComment = allowComment;
+    this.isNotice = isNotice;
+    this.isSecret = isSecret;
+    this.isTemp = isTemp;
+    this.password = password;
   }
 }

--- a/src/main/java/com/keeper/homepage/global/error/ErrorCode.java
+++ b/src/main/java/com/keeper/homepage/global/error/ErrorCode.java
@@ -33,6 +33,7 @@ public enum ErrorCode {
   POST_NOT_FOUND("존재하지 않는 게시글입니다.", HttpStatus.NOT_FOUND),
   POST_CANNOT_ACCESSIBLE("게시글에 접근할 권한이 없습니다.", HttpStatus.FORBIDDEN),
   POST_PASSWORD_MISMATCH("게시글의 비밀번호가 일치하지 않습니다.", HttpStatus.FORBIDDEN),
+  POST_PASSWORD_NEED("게시글의 비밀번호를 입력해주세요.", HttpStatus.BAD_REQUEST),
   ;
 
   private final String message;

--- a/src/test/java/com/keeper/homepage/domain/post/api/AdminPostControllerTest.java
+++ b/src/test/java/com/keeper/homepage/domain/post/api/AdminPostControllerTest.java
@@ -1,0 +1,84 @@
+package com.keeper.homepage.domain.post.api;
+
+import static com.keeper.homepage.domain.member.entity.job.MemberJob.MemberJobType.ROLE_회원;
+import static com.keeper.homepage.domain.member.entity.job.MemberJob.MemberJobType.ROLE_회장;
+import static com.keeper.homepage.global.config.security.data.JwtType.ACCESS_TOKEN;
+import static com.keeper.homepage.global.restdocs.RestDocsHelper.getSecuredValue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.restdocs.cookies.CookieDocumentation.cookieWithName;
+import static org.springframework.restdocs.cookies.CookieDocumentation.requestCookies;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.responseHeaders;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.keeper.homepage.domain.member.entity.Member;
+import com.keeper.homepage.domain.post.entity.Post;
+import com.keeper.homepage.domain.post.entity.category.Category;
+import com.keeper.homepage.global.util.web.WebUtil;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+public class AdminPostControllerTest extends PostApiTestHelper {
+
+  private String adminToken;
+  private String memberToken;
+  private Post post;
+  private Category category;
+
+  @BeforeEach
+  void setUp() {
+    long adminId = memberTestHelper.generate().getId();
+    Member member = memberTestHelper.generate();
+    long memberId = member.getId();
+    adminToken = jwtTokenProvider.createAccessToken(ACCESS_TOKEN, adminId, ROLE_회원, ROLE_회장);
+    memberToken = jwtTokenProvider.createAccessToken(ACCESS_TOKEN, memberId, ROLE_회원);
+    post = Post.builder()
+        .title("게시글 제목")
+        .content("게시글 내용")
+        .member(member)
+        .ipAddress(WebUtil.getUserIP())
+        .build();
+    category = categoryTestHelper.generate();
+  }
+
+  @Nested
+  @DisplayName("관리자 권한으로 게시글 삭제")
+  class AdminDeletePost {
+
+    @Test
+    @DisplayName("관리자라면 게시글 삭제가 성공한다.")
+    public void 관리자라면_게시글_삭제가_성공한다() throws Exception {
+      String securedValue = getSecuredValue(AdminPostController.class, "deletePost");
+
+      long postId = postService.create(post, category.getId(), null, null);
+
+      callAdminDeletePostApi(adminToken, postId)
+          .andExpect(status().isNoContent())
+          .andDo(document("admin-delete-post",
+              requestCookies(
+                  cookieWithName(ACCESS_TOKEN.getTokenName())
+                      .description("ACCESS TOKEN %s".formatted(securedValue))
+              ),
+              pathParameters(
+                  parameterWithName("postId")
+                      .description("삭제하고자 하는 게시글의 ID")
+              )));
+    }
+
+    @Test
+    @DisplayName("일반 회원이라면 게시글 삭제가 실패한다.")
+    public void 일반_회원이라면_게시글_삭제가_실패한다() throws Exception {
+      long postId = postService.create(post, category.getId(), null, null);
+
+      callAdminDeletePostApi(memberToken, postId)
+          .andExpect(status().isForbidden());
+    }
+  }
+}

--- a/src/test/java/com/keeper/homepage/domain/post/api/PostApiTestHelper.java
+++ b/src/test/java/com/keeper/homepage/domain/post/api/PostApiTestHelper.java
@@ -10,6 +10,7 @@ import java.util.Collection;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.util.MultiValueMap;
@@ -57,5 +58,35 @@ public class PostApiTestHelper extends IntegrationTest {
     return mockMvc.perform(get("/posts/{postId}", postId)
         .cookie(new Cookie(ACCESS_TOKEN.getTokenName(), accessToken))
         .param("password", password));
+  }
+
+  ResultActions callUpdatePostApiWithFiles(String accessToken, long postId,
+      MockMultipartFile thumbnail,
+      MockMultipartFile file,
+      MultiValueMap<String, String> params)
+      throws Exception {
+    return mockMvc.perform(RestDocumentationRequestBuilders.multipart("/posts/{postId}", postId)
+        .file(thumbnail)
+        .file(file)
+        .with(request -> {
+          request.setMethod("PUT");
+          return request;
+        })
+        .queryParams(params)
+        .cookie(new Cookie(ACCESS_TOKEN.getTokenName(), accessToken))
+        .contentType(MediaType.MULTIPART_FORM_DATA));
+
+  }
+
+  ResultActions callDeletePostApi(String accessToken, long postId)
+      throws Exception {
+    return mockMvc.perform(RestDocumentationRequestBuilders.delete("/posts/{postId}", postId)
+        .cookie(new Cookie(ACCESS_TOKEN.getTokenName(), accessToken)));
+  }
+
+  ResultActions callAdminDeletePostApi(String adminToken, long postId)
+      throws Exception {
+    return mockMvc.perform(RestDocumentationRequestBuilders.delete("/admin/posts/{postId}", postId)
+        .cookie(new Cookie(ACCESS_TOKEN.getTokenName(), adminToken)));
   }
 }

--- a/src/test/java/com/keeper/homepage/domain/post/api/PostControllerTest.java
+++ b/src/test/java/com/keeper/homepage/domain/post/api/PostControllerTest.java
@@ -318,7 +318,11 @@ public class PostControllerTest extends PostApiTestHelper {
                   fieldWithPath("files[].uploadTime").description("게시글 첨부파일 업로드 시간"),
                   fieldWithPath("files[].ipAddress").description("게시글 첨부파일 IP 주소"),
                   fieldWithPath("likeCount").description("게시글의 좋아요 수"),
-                  fieldWithPath("dislikeCount").description("게시글의 싫어요 수")
+                  fieldWithPath("dislikeCount").description("게시글의 싫어요 수"),
+                  fieldWithPath("allowComment").description("댓글 허용 여부"),
+                  fieldWithPath("isNotice").description("공지글 여부"),
+                  fieldWithPath("isSecret").description("비밀글 여부"),
+                  fieldWithPath("isTemp").description("임시 저장글 여부")
               )));
     }
 

--- a/src/test/java/com/keeper/homepage/domain/post/api/PostControllerTest.java
+++ b/src/test/java/com/keeper/homepage/domain/post/api/PostControllerTest.java
@@ -4,8 +4,8 @@ import static com.keeper.homepage.domain.member.entity.job.MemberJob.MemberJobTy
 import static com.keeper.homepage.domain.post.application.PostService.EXAM_ACCESSIBLE_ATTENDANCE_COUNT;
 import static com.keeper.homepage.domain.post.application.PostService.EXAM_ACCESSIBLE_COMMENT_COUNT;
 import static com.keeper.homepage.domain.post.application.PostService.EXAM_ACCESSIBLE_POINT;
-import static com.keeper.homepage.domain.post.dto.request.PostRequest.MAX_REQUEST_PASSWORD_LENGTH;
-import static com.keeper.homepage.domain.post.dto.request.PostRequest.MAX_REQUEST_TITLE_LENGTH;
+import static com.keeper.homepage.domain.post.dto.request.PostCreateRequest.MAX_REQUEST_PASSWORD_LENGTH;
+import static com.keeper.homepage.domain.post.dto.request.PostCreateRequest.MAX_REQUEST_TITLE_LENGTH;
 import static com.keeper.homepage.global.config.security.data.JwtType.ACCESS_TOKEN;
 import static com.keeper.homepage.global.restdocs.RestDocsHelper.getSecuredValue;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -29,9 +29,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.keeper.homepage.domain.member.entity.Member;
+import com.keeper.homepage.domain.post.dto.request.PostUpdateRequest;
 import com.keeper.homepage.domain.post.entity.Post;
 import com.keeper.homepage.domain.post.entity.category.Category;
-import com.keeper.homepage.domain.seminar.api.SeminarController;
 import com.keeper.homepage.global.util.web.WebUtil;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -47,12 +47,12 @@ import org.springframework.util.MultiValueMap;
 
 public class PostControllerTest extends PostApiTestHelper {
 
-  private final long postId = 1;
   private Category category;
   private MockMultipartFile thumbnail, file;
   private final MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
   private Member member, other;
   private String memberToken, otherToken;
+  private Post post;
 
   private static final LocalDate now = LocalDate.now();
 
@@ -60,28 +60,25 @@ public class PostControllerTest extends PostApiTestHelper {
   void setUp() throws IOException {
     member = memberTestHelper.builder().point(EXAM_ACCESSIBLE_POINT).build();
     other = memberTestHelper.generate();
-    for (int i = 0; i < EXAM_ACCESSIBLE_COMMENT_COUNT; i++) {
-      commentRepository.save(commentTestHelper.builder().member(member).build());
-    }
-    for (int i = 0; i < EXAM_ACCESSIBLE_ATTENDANCE_COUNT; i++) {
-      attendanceRepository
-          .save(attendanceTestHelper.builder().member(member).date(now.plusDays(i)).build());
-    }
-
-    long memberId = member.getId();
-    long otherId = other.getId();
-    memberToken = jwtTokenProvider.createAccessToken(ACCESS_TOKEN, memberId, ROLE_회원);
-    otherToken = jwtTokenProvider.createAccessToken(ACCESS_TOKEN, otherId, ROLE_회원);
-
+    memberToken = jwtTokenProvider.createAccessToken(ACCESS_TOKEN, member.getId(), ROLE_회원);
+    otherToken = jwtTokenProvider.createAccessToken(ACCESS_TOKEN, other.getId(), ROLE_회원);
     category = categoryTestHelper.generate();
     thumbnail = thumbnailTestHelper.getSmallThumbnailFile();
     file = new MockMultipartFile("files", "testImage_1x1.png", "image/png",
         new FileInputStream("src/test/resources/images/testImage_1x1.png"));
+    post = Post.builder()
+        .title("게시글 제목")
+        .content("게시글 내용")
+        .member(member)
+        .ipAddress(WebUtil.getUserIP())
+        .build();
   }
 
   @Nested
   @DisplayName("게시글 생성")
   class CreatePost {
+
+    private final long postId = 1;
 
     @Test
     @DisplayName("썸네일과 파일이 포함된 게시글을 생성하면 게시글 생성이 성공한다.")
@@ -118,7 +115,8 @@ public class PostControllerTest extends PostApiTestHelper {
                       .optional(),
                   parameterWithName("password")
                       .description(
-                          "게시글 비밀번호를 입력해주세요. (최대 가능 길이 : " + MAX_REQUEST_PASSWORD_LENGTH + ")")
+                          "게시글 비밀번호를 입력해주세요. (최대 가능 길이 : " + MAX_REQUEST_PASSWORD_LENGTH
+                              + ", 비밀글일 경우 필수값입니다.)")
                       .optional(),
                   parameterWithName("categoryId")
                       .description("게시글 카테고리를 입력해주세요.")
@@ -182,6 +180,18 @@ public class PostControllerTest extends PostApiTestHelper {
       callCreatePostApi(memberToken, params)
           .andExpect(status().isCreated())
           .andExpect(header().string("location", "/posts/" + postId));
+    }
+
+    @Test
+    @DisplayName("비밀글의 경우 비밀번호가 없으면 게시글 생성은 실패한다.")
+    public void 비밀글의_경우_비밀번호가_없으면_게시글_생성은_실패한다() throws Exception {
+      params.add("title", "게시글 제목");
+      params.add("content", "게시글 내용");
+      params.add("isSecret", "true");
+      params.add("categoryId", category.getId().toString());
+
+      callCreatePostApi(memberToken, params)
+          .andExpect(status().isBadRequest());
     }
 
     @Test
@@ -265,7 +275,6 @@ public class PostControllerTest extends PostApiTestHelper {
       params.add("password", "게시글 비밀번호");
       params.add("categoryId", category.getId().toString());
     }
-
   }
 
   @Nested
@@ -274,20 +283,23 @@ public class PostControllerTest extends PostApiTestHelper {
 
     private static final long virtualPostId = 1;
 
+    @BeforeEach
+    void setUp() throws IOException {
+      for (int i = 0; i < EXAM_ACCESSIBLE_COMMENT_COUNT; i++) {
+        commentRepository.save(commentTestHelper.builder().member(member).build());
+      }
+      for (int i = 0; i < EXAM_ACCESSIBLE_ATTENDANCE_COUNT; i++) {
+        attendanceRepository
+            .save(attendanceTestHelper.builder().member(member).date(now.plusDays(i)).build());
+      }
+    }
+
     @Test
     @DisplayName("게시글을 조회하면 성공적으로 조회된다.")
     public void should_success_when_getPost() throws Exception {
       String securedValue = getSecuredValue(PostController.class, "getPost");
 
-      Post post = Post.builder()
-          .title("게시글 제목")
-          .content("게시글 내용")
-          .member(member)
-          .ipAddress(WebUtil.getUserIP())
-          .password("게시글 암호")
-          .build();
-
-      Long postId = postService.create(post, category.getId(), thumbnail, List.of(thumbnail));
+      long postId = postService.create(post, category.getId(), thumbnail, List.of(thumbnail));
       em.flush();
       em.clear();
 
@@ -374,7 +386,11 @@ public class PostControllerTest extends PostApiTestHelper {
                   fieldWithPath("files[].uploadTime").description("게시글 첨부파일 업로드 시간"),
                   fieldWithPath("files[].ipAddress").description("게시글 첨부파일 IP 주소"),
                   fieldWithPath("likeCount").description("게시글의 좋아요 수"),
-                  fieldWithPath("dislikeCount").description("게시글의 싫어요 수")
+                  fieldWithPath("dislikeCount").description("게시글의 싫어요 수"),
+                  fieldWithPath("allowComment").description("댓글 허용 여부"),
+                  fieldWithPath("isNotice").description("공지글 여부"),
+                  fieldWithPath("isSecret").description("비밀글 여부"),
+                  fieldWithPath("isTemp").description("임시 저장글 여부")
               )));
     }
 
@@ -408,6 +424,119 @@ public class PostControllerTest extends PostApiTestHelper {
           .andExpect(status().isForbidden());
 
       callFindPostApiWithPassword(otherToken, postId, "다른 비밀번호")
+          .andExpect(status().isForbidden());
+    }
+  }
+
+  @Nested
+  @DisplayName("게시글 수정")
+  class UpdatePost {
+
+    @Test
+    @DisplayName("내가 작성한 게시글인 경우 게시글 수정은 성공한다.")
+    public void 내가_작성한_게시글인_경우_게시글_수정은_성공한다() throws Exception {
+      String securedValue = getSecuredValue(PostController.class, "updatePost");
+
+      long postId = postService.create(post, category.getId(), thumbnail, List.of(file));
+      addAllParams();
+
+      callUpdatePostApiWithFiles(memberToken, postId, thumbnail, file, params)
+          .andExpect(status().isCreated())
+          .andExpect(header().string("location", "/posts/" + postId))
+          .andDo(document("update-post",
+              requestCookies(
+                  cookieWithName(ACCESS_TOKEN.getTokenName())
+                      .description("ACCESS TOKEN %s".formatted(securedValue))
+              ),
+              pathParameters(
+                  parameterWithName("postId")
+                      .description("수정하고자 하는 게시글의 ID")
+              ),
+              queryParameters(
+                  parameterWithName("title")
+                      .description("게시글 제목을 입력해주세요. (최대 가능 길이 : " + MAX_REQUEST_TITLE_LENGTH + ")"),
+                  parameterWithName("content")
+                      .description("게시글 내용을 입력해주세요."),
+                  parameterWithName("allowComment")
+                      .description("댓글 허용 여부 (null일 때 default : " + true + ")")
+                      .optional(),
+                  parameterWithName("isNotice")
+                      .description("공지글 여부 (null일 때 default : " + false + ")")
+                      .optional(),
+                  parameterWithName("isSecret")
+                      .description("비밀글 여부 (null일 때 default : " + false + ")")
+                      .optional(),
+                  parameterWithName("isTemp")
+                      .description("임시 저장글 여부 (null일 때 default : " + false + ")")
+                      .optional(),
+                  parameterWithName("password")
+                      .description(
+                          "게시글 비밀번호를 입력해주세요. (최대 가능 길이 : " + MAX_REQUEST_PASSWORD_LENGTH
+                              + ", 비밀글일 경우 필수값입니다.)")
+                      .optional()
+              ),
+              requestParts(
+                  partWithName("thumbnail").description("게시글의 썸네일")
+                      .optional(),
+                  partWithName("files").description("게시글의 첨부 파일")
+                      .optional()
+              ),
+              responseHeaders(
+                  headerWithName("Location").description("수정한 게시글을 불러오는 URI 입니다.")
+              )));
+    }
+
+    @Test
+    @DisplayName("내가 작성한 게시글이 아닐 경우 게시글 수정은 실패한다.")
+    public void 내가_작성한_게시글이_아닐_경우_게시글_수정은_실패한다() throws Exception {
+      long postId = postService.create(post, category.getId(), thumbnail, List.of(thumbnail));
+      addAllParams();
+
+      callUpdatePostApiWithFiles(otherToken, postId, thumbnail, file, params)
+          .andExpect(status().isForbidden());
+    }
+
+    private void addAllParams() {
+      params.add("title", "게시글 제목");
+      params.add("content", "게시글 내용");
+      params.add("allowComment", "true");
+      params.add("isNotice", "false");
+      params.add("isSecret", "false");
+      params.add("isTemp", "false");
+      params.add("password", "게시글 비밀번호");
+    }
+  }
+
+  @Nested
+  @DisplayName("게시글 삭제")
+  class DeletePost {
+
+    @Test
+    @DisplayName("내가 작성한 게시글인 경우 게시글 삭제는 성공한다.")
+    public void 내가_작성한_게시글인_경우_게시글_삭제는_성공한다() throws Exception {
+      String securedValue = getSecuredValue(PostController.class, "deletePost");
+
+      long postId = postService.create(post, category.getId(), thumbnail, List.of(file));
+
+      callDeletePostApi(memberToken, postId)
+          .andExpect(status().isNoContent())
+          .andDo(document("delete-post",
+              requestCookies(
+                  cookieWithName(ACCESS_TOKEN.getTokenName())
+                      .description("ACCESS TOKEN %s".formatted(securedValue))
+              ),
+              pathParameters(
+                  parameterWithName("postId")
+                      .description("삭제하고자 하는 게시글의 ID")
+              )));
+    }
+
+    @Test
+    @DisplayName("내가 작성한 게시글이 아닌 경우 게시글 삭제는 실패한다.")
+    public void 내가_작성한_게시글이_아닌_경우_게시글_삭제는_실패한다() throws Exception {
+      long postId = postService.create(post, category.getId(), thumbnail, List.of(file));
+
+      callDeletePostApi(otherToken, postId)
           .andExpect(status().isForbidden());
     }
   }


### PR DESCRIPTION
## 🔥 Related Issue

close: #98

## 📝 Description

게시글 수정, 삭제, 관리자 권한으로 삭제 api를 구현하였습니다.

게시글이 비밀글인 경우, `password`를 필수로 입력받게끔 검증하는 로직을 추가하였습니다.

### 기획서
https://enormous-button-c5d.notion.site/A-20bc63f1b35c4153800146cf1002fafa

## ⭐️ Review

개강이 코앞이네요... ㅠ ㅠ