### PR TITLE
fix: API 문서 보이지 않던 문제 해결

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -56,12 +56,12 @@ tasks {
     }
     register<Copy>("copyDocs") {
         dependsOn(asciidoctor)
-        from("${asciidoctor.get().outputDir}/html5")
+        from("${asciidoctor.get().outputDir}")
         into("src/main/resources/static/docs")
     }
     bootJar {
         dependsOn(asciidoctor)
-        from("${asciidoctor.get().outputDir}/html5") {
+        from("${asciidoctor.get().outputDir}") {
             into("static/docs")
         }
     }


### PR DESCRIPTION
## 🔥 Related Issue

없음.

## 📝 Description

API 문서가 보이지 않던 문제를 해결했습니다.

원인: build된 asciidoc html 파일들이 copy를 통해 static 폴더에 들어가야하는데 이게 적용되고 있지 않았습니다.

## ⭐️ Review

화이팅~!