### PR TITLE
Feature/스터디 추가 삭제 api 구현

### DIFF
--- a/src/docs/asciidoc/keeper.adoc
+++ b/src/docs/asciidoc/keeper.adoc
@@ -36,3 +36,7 @@ link:seminar/seminar.html[API 문서 보기]
 == *LIBRARY API*
 
 link:library/book-manage[API 문서 보기]
+
+== *STUDY API*
+
+link:study/study.html[API 문서 보기]

--- a/src/docs/asciidoc/study/study.adoc
+++ b/src/docs/asciidoc/study/study.adoc
@@ -1,0 +1,40 @@
+ifndef::snippets[]
+:snippets: ./build/generated-snippets
+endif::[]
+
+= STUDY API 문서
+:icons: font
+:source-highlighter: highlight.js
+:toc: left
+:toclevels: 1
+:sectlinks:
+
+== API 목록
+
+link:../keeper.html[API 목록으로 돌아가기]
+
+== *스터디 생성*
+
+=== 요청
+
+==== Request
+
+include::{snippets}/create-study/http-request.adoc[]
+
+==== Request Cookies
+
+include::{snippets}/create-study/request-cookies.adoc[]
+
+==== Query Parameters
+
+include::{snippets}/create-study/query-parameters.adoc[]
+
+==== Request Parts
+
+include::{snippets}/create-study/request-parts.adoc[]
+
+=== 응답
+
+==== Response
+
+include::{snippets}/create-study/http-response.adoc[]

--- a/src/docs/asciidoc/study/study.adoc
+++ b/src/docs/asciidoc/study/study.adoc
@@ -38,3 +38,25 @@ include::{snippets}/create-study/request-parts.adoc[]
 ==== Response
 
 include::{snippets}/create-study/http-response.adoc[]
+
+== *스터디 삭제*
+
+=== 요청
+
+==== Request
+
+include::{snippets}/delete-study/http-request.adoc[]
+
+==== Request Cookies
+
+include::{snippets}/delete-study/request-cookies.adoc[]
+
+==== Path Parameters
+
+include::{snippets}/delete-study/path-parameters.adoc[]
+
+=== 응답
+
+==== Response
+
+include::{snippets}/delete-study/http-response.adoc[]

--- a/src/main/java/com/keeper/homepage/domain/member/entity/Member.java
+++ b/src/main/java/com/keeper/homepage/domain/member/entity/Member.java
@@ -14,8 +14,6 @@ import com.keeper.homepage.domain.attendance.entity.Attendance;
 import com.keeper.homepage.domain.library.entity.Book;
 import com.keeper.homepage.domain.library.entity.BookBorrowInfo;
 import com.keeper.homepage.domain.library.entity.BookBorrowStatus;
-import com.keeper.homepage.domain.thumbnail.entity.Thumbnail;
-import jakarta.persistence.CascadeType;
 import com.keeper.homepage.domain.member.entity.comment.MemberHasCommentDislike;
 import com.keeper.homepage.domain.member.entity.comment.MemberHasCommentLike;
 import com.keeper.homepage.domain.member.entity.embedded.Generation;
@@ -35,7 +33,6 @@ import com.keeper.homepage.domain.study.entity.Study;
 import com.keeper.homepage.domain.study.entity.StudyHasMember;
 import jakarta.persistence.AttributeOverride;
 import jakarta.persistence.AttributeOverrides;
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -50,7 +47,6 @@ import jakarta.persistence.Table;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.Period;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -135,7 +131,7 @@ public class Member {
   @OneToMany(mappedBy = "member", cascade = ALL, orphanRemoval = true)
   private final Set<MemberHasCommentDislike> commentDislikes = new HashSet<>();
 
-  @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+  @OneToMany(mappedBy = "member", cascade = ALL, orphanRemoval = true)
   private final Set<StudyHasMember> studyMembers = new HashSet<>();
 
   @Builder
@@ -277,5 +273,9 @@ public class Member {
 
   public String getNickname() {
     return this.profile.getNickname().get();
+  }
+
+  public boolean isHeadMember(Study study) {
+    return study.getHeadMember().equals(this);
   }
 }

--- a/src/main/java/com/keeper/homepage/domain/post/dto/request/PostCreateRequest.java
+++ b/src/main/java/com/keeper/homepage/domain/post/dto/request/PostCreateRequest.java
@@ -20,11 +20,11 @@ import org.springframework.web.multipart.MultipartFile;
 @AllArgsConstructor(access = PRIVATE)
 public class PostCreateRequest {
 
-  public static final int MAX_REQUEST_TITLE_LENGTH = 50;
-  public static final int MAX_REQUEST_PASSWORD_LENGTH = 16;
+  public static final int POST_TITLE_LENGTH = 50;
+  public static final int POST_PASSWORD_LENGTH = 16;
 
   @NotBlank(message = "게시글 제목을 입력해주세요.")
-  @Size(max = MAX_REQUEST_TITLE_LENGTH, message = "게시글 제목은 {max}자 이하로 입력해주세요.")
+  @Size(max = POST_TITLE_LENGTH, message = "게시글 제목은 {max}자 이하로 입력해주세요.")
   private String title;
 
   @NotBlank(message = "게시글 본문을 입력해주세요.")
@@ -43,7 +43,7 @@ public class PostCreateRequest {
   private Boolean isTemp;
 
   @Nullable
-  @Size(max = MAX_REQUEST_PASSWORD_LENGTH, message = "비밀번호는 {max}자 이하로 입력해주세요.")
+  @Size(max = POST_PASSWORD_LENGTH, message = "비밀번호는 {max}자 이하로 입력해주세요.")
   private String password;
 
   @NotNull(message = "카테고리 아이디를 입력해주세요.")

--- a/src/main/java/com/keeper/homepage/domain/post/dto/request/PostUpdateRequest.java
+++ b/src/main/java/com/keeper/homepage/domain/post/dto/request/PostUpdateRequest.java
@@ -1,18 +1,16 @@
 package com.keeper.homepage.domain.post.dto.request;
 
-import static lombok.AccessLevel.*;
+import static com.keeper.homepage.domain.post.dto.request.PostCreateRequest.POST_PASSWORD_LENGTH;
+import static com.keeper.homepage.domain.post.dto.request.PostCreateRequest.POST_TITLE_LENGTH;
 import static lombok.AccessLevel.PRIVATE;
 
-import com.keeper.homepage.domain.member.entity.Member;
 import com.keeper.homepage.domain.post.entity.Post;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import java.util.List;
-import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import org.springframework.lang.Nullable;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -21,11 +19,8 @@ import org.springframework.web.multipart.MultipartFile;
 @AllArgsConstructor(access = PRIVATE)
 public class PostUpdateRequest {
 
-  public static final int MAX_REQUEST_TITLE_LENGTH = 50;
-  public static final int MAX_REQUEST_PASSWORD_LENGTH = 16;
-
   @NotBlank(message = "게시글 제목을 입력해주세요.")
-  @Size(max = MAX_REQUEST_TITLE_LENGTH, message = "게시글 제목은 {max}자 이하로 입력해주세요.")
+  @Size(max = POST_TITLE_LENGTH, message = "게시글 제목은 {max}자 이하로 입력해주세요.")
   private String title;
 
   @NotBlank(message = "게시글 본문을 입력해주세요.")
@@ -44,7 +39,7 @@ public class PostUpdateRequest {
   private Boolean isTemp;
 
   @Nullable
-  @Size(max = MAX_REQUEST_PASSWORD_LENGTH, message = "비밀번호는 {max}자 이하로 입력해주세요.")
+  @Size(max = POST_PASSWORD_LENGTH, message = "비밀번호는 {max}자 이하로 입력해주세요.")
   private String password;
 
   @Nullable

--- a/src/main/java/com/keeper/homepage/domain/study/api/StudyController.java
+++ b/src/main/java/com/keeper/homepage/domain/study/api/StudyController.java
@@ -1,0 +1,34 @@
+package com.keeper.homepage.domain.study.api;
+
+import com.keeper.homepage.domain.member.entity.Member;
+import com.keeper.homepage.domain.study.application.StudyService;
+import com.keeper.homepage.domain.study.dto.request.StudyCreateRequest;
+import com.keeper.homepage.global.config.security.annotation.LoginMember;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/studies")
+public class StudyController {
+
+  private final StudyService studyService;
+
+  @PostMapping
+  public ResponseEntity<Void> createStudy(
+      @LoginMember Member member,
+      @ModelAttribute @Valid StudyCreateRequest request
+  ) {
+    studyService.create(request.toEntity(member), request.getThumbnail());
+    return ResponseEntity.status(HttpStatus.CREATED)
+        .build();
+  }
+}

--- a/src/main/java/com/keeper/homepage/domain/study/api/StudyController.java
+++ b/src/main/java/com/keeper/homepage/domain/study/api/StudyController.java
@@ -31,4 +31,13 @@ public class StudyController {
     return ResponseEntity.status(HttpStatus.CREATED)
         .build();
   }
+
+  @DeleteMapping("/{studyId}")
+  public ResponseEntity<Void> deleteStudy(
+      @LoginMember Member member,
+      @PathVariable long studyId
+  ) {
+    studyService.delete(member, studyId);
+    return ResponseEntity.noContent().build();
+  }
 }

--- a/src/main/java/com/keeper/homepage/domain/study/application/StudyService.java
+++ b/src/main/java/com/keeper/homepage/domain/study/application/StudyService.java
@@ -1,0 +1,29 @@
+package com.keeper.homepage.domain.study.application;
+
+import com.keeper.homepage.domain.study.dao.StudyRepository;
+import com.keeper.homepage.domain.study.entity.Study;
+import com.keeper.homepage.domain.thumbnail.entity.Thumbnail;
+import com.keeper.homepage.global.util.thumbnail.ThumbnailUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class StudyService {
+
+  private final StudyRepository studyRepository;
+  private final ThumbnailUtil thumbnailUtil;
+
+  public void create(Study study, MultipartFile thumbnail) {
+    saveStudyThumbnail(study, thumbnail);
+    studyRepository.save(study);
+  }
+
+  private void saveStudyThumbnail(Study study, MultipartFile thumbnail) {
+    Thumbnail savedThumbnail = thumbnailUtil.saveThumbnail(thumbnail).orElse(null);
+    study.changeThumbnail(savedThumbnail);
+  }
+}

--- a/src/main/java/com/keeper/homepage/domain/study/application/StudyService.java
+++ b/src/main/java/com/keeper/homepage/domain/study/application/StudyService.java
@@ -1,8 +1,14 @@
 package com.keeper.homepage.domain.study.application;
 
+import static com.keeper.homepage.global.error.ErrorCode.POST_CANNOT_ACCESSIBLE;
+import static com.keeper.homepage.global.error.ErrorCode.STUDY_CANNOT_ACCESSIBLE;
+
+import com.keeper.homepage.domain.member.entity.Member;
+import com.keeper.homepage.domain.study.application.convenience.StudyFindService;
 import com.keeper.homepage.domain.study.dao.StudyRepository;
 import com.keeper.homepage.domain.study.entity.Study;
 import com.keeper.homepage.domain.thumbnail.entity.Thumbnail;
+import com.keeper.homepage.global.error.BusinessException;
 import com.keeper.homepage.global.util.thumbnail.ThumbnailUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -16,6 +22,7 @@ public class StudyService {
 
   private final StudyRepository studyRepository;
   private final ThumbnailUtil thumbnailUtil;
+  private final StudyFindService studyFindService;
 
   public void create(Study study, MultipartFile thumbnail) {
     saveStudyThumbnail(study, thumbnail);
@@ -25,5 +32,14 @@ public class StudyService {
   private void saveStudyThumbnail(Study study, MultipartFile thumbnail) {
     Thumbnail savedThumbnail = thumbnailUtil.saveThumbnail(thumbnail).orElse(null);
     study.changeThumbnail(savedThumbnail);
+  }
+
+  public void delete(Member member, long studyId) {
+    Study study = studyFindService.findById(studyId);
+
+    if (!member.isHeadMember(study)) {
+      throw new BusinessException(study.getId(), "study", STUDY_CANNOT_ACCESSIBLE);
+    }
+    studyRepository.delete(study);
   }
 }

--- a/src/main/java/com/keeper/homepage/domain/study/application/convenience/StudyFindService.java
+++ b/src/main/java/com/keeper/homepage/domain/study/application/convenience/StudyFindService.java
@@ -1,0 +1,23 @@
+package com.keeper.homepage.domain.study.application.convenience;
+
+import static com.keeper.homepage.global.error.ErrorCode.STUDY_NOT_FOUND;
+
+import com.keeper.homepage.domain.study.dao.StudyRepository;
+import com.keeper.homepage.domain.study.entity.Study;
+import com.keeper.homepage.global.error.BusinessException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class StudyFindService {
+
+  private final StudyRepository studyRepository;
+
+  public Study findById(long studyId) {
+    return studyRepository.findById(studyId)
+        .orElseThrow(() -> new BusinessException(studyId, "studyId", STUDY_NOT_FOUND));
+  }
+}

--- a/src/main/java/com/keeper/homepage/domain/study/dto/request/StudyCreateRequest.java
+++ b/src/main/java/com/keeper/homepage/domain/study/dto/request/StudyCreateRequest.java
@@ -18,15 +18,15 @@ import org.springframework.web.multipart.MultipartFile;
 @AllArgsConstructor(access = PRIVATE)
 public class StudyCreateRequest {
 
-  public static final int MAX_REQUEST_STUDY_TITLE_LENGTH = 45;
-  public static final int MAX_REQUEST_STUDY_INFORMATION_LENGTH = 100;
+  public static final int STUDY_TITLE_LENGTH = 45;
+  public static final int STUDY_INFORMATION_LENGTH = 100;
 
   @NotBlank(message = "스터디 이름을 입력해주세요.")
-  @Size(max = MAX_REQUEST_STUDY_TITLE_LENGTH, message = "스터디 이름은 {max}자 이하로 입력해주세요.")
+  @Size(max = STUDY_TITLE_LENGTH, message = "스터디 이름은 {max}자 이하로 입력해주세요.")
   private String title;
 
   @NotBlank(message = "스터디 설명을 입력해주세요.")
-  @Size(max = MAX_REQUEST_STUDY_INFORMATION_LENGTH, message = "스터디 설명은 {max}자 이하로 입력해주세요.")
+  @Size(max = STUDY_INFORMATION_LENGTH, message = "스터디 설명은 {max}자 이하로 입력해주세요.")
   private String information;
 
   @NotNull(message = "스터디 년도를 입력해주세요.")

--- a/src/main/java/com/keeper/homepage/domain/study/dto/request/StudyCreateRequest.java
+++ b/src/main/java/com/keeper/homepage/domain/study/dto/request/StudyCreateRequest.java
@@ -1,0 +1,62 @@
+package com.keeper.homepage.domain.study.dto.request;
+
+import static lombok.AccessLevel.PRIVATE;
+
+import com.keeper.homepage.domain.member.entity.Member;
+import com.keeper.homepage.domain.study.entity.Study;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.lang.Nullable;
+import org.springframework.web.multipart.MultipartFile;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = PRIVATE)
+public class StudyCreateRequest {
+
+  public static final int MAX_REQUEST_STUDY_TITLE_LENGTH = 45;
+  public static final int MAX_REQUEST_STUDY_INFORMATION_LENGTH = 100;
+
+  @NotBlank(message = "스터디 이름을 입력해주세요.")
+  @Size(max = MAX_REQUEST_STUDY_TITLE_LENGTH, message = "스터디 이름은 {max}자 이하로 입력해주세요.")
+  private String title;
+
+  @NotBlank(message = "스터디 설명을 입력해주세요.")
+  @Size(max = MAX_REQUEST_STUDY_INFORMATION_LENGTH, message = "스터디 설명은 {max}자 이하로 입력해주세요.")
+  private String information;
+
+  @NotNull(message = "스터디 년도를 입력해주세요.")
+  private Integer year;
+
+  @NotNull(message = "스터디 학기를 입력해주세요.")
+  private Integer season;
+
+  @Nullable
+  private String gitLink;
+
+  @Nullable
+  private String noteLink;
+
+  @Nullable
+  private String etcLink;
+
+  @Nullable
+  private MultipartFile thumbnail;
+
+  public Study toEntity(Member member) {
+    return Study.builder()
+        .title(title)
+        .information(information)
+        .headMember(member)
+        .year(year)
+        .season(season)
+        .gitLink(gitLink)
+        .noteLink(noteLink)
+        .etcLink(etcLink)
+        .build();
+  }
+}

--- a/src/main/java/com/keeper/homepage/domain/study/entity/Study.java
+++ b/src/main/java/com/keeper/homepage/domain/study/entity/Study.java
@@ -74,7 +74,7 @@ public class Study extends BaseEntity {
   private Member headMember;
 
   @OneToMany(mappedBy = "study", cascade = CascadeType.REMOVE)
-  private Set<StudyHasMember> studyMembers = new HashSet<>();
+  private final Set<StudyHasMember> studyMembers = new HashSet<>();
 
   @Builder
   private Study(String title, String information, Integer memberNumber,
@@ -90,5 +90,9 @@ public class Study extends BaseEntity {
       this.etcLink = etcLink;
       this.thumbnail = thumbnail;
       this.headMember = headMember;
+  }
+
+  public void changeThumbnail(Thumbnail thumbnail) {
+    this.thumbnail = thumbnail;
   }
 }

--- a/src/main/java/com/keeper/homepage/global/error/ErrorCode.java
+++ b/src/main/java/com/keeper/homepage/global/error/ErrorCode.java
@@ -48,6 +48,8 @@ public enum ErrorCode {
   BORROW_NOT_FOUND("존재하지 않는 대출 기록입니다.", HttpStatus.NOT_FOUND),
   BORROW_STATUS_IS_NOT_REQUESTS("대출 대기중이 아닙니다.", HttpStatus.BAD_REQUEST),
   BORROW_STATUS_IS_NOT_WAITING_RETURN("반납 대기중이 아닙니다.", HttpStatus.BAD_REQUEST),
+  // STUDY
+  STUDY_NOT_FOUND("존재하지 않는 스터디입니다.", HttpStatus.NOT_FOUND),
   ;
 
   private final String message;

--- a/src/main/java/com/keeper/homepage/global/error/ErrorCode.java
+++ b/src/main/java/com/keeper/homepage/global/error/ErrorCode.java
@@ -50,6 +50,7 @@ public enum ErrorCode {
   BORROW_STATUS_IS_NOT_WAITING_RETURN("반납 대기중이 아닙니다.", HttpStatus.BAD_REQUEST),
   // STUDY
   STUDY_NOT_FOUND("존재하지 않는 스터디입니다.", HttpStatus.NOT_FOUND),
+  STUDY_CANNOT_ACCESSIBLE("스터디에 접근할 권한이 없습니다.", HttpStatus.FORBIDDEN),
   ;
 
   private final String message;

--- a/src/test/java/com/keeper/homepage/IntegrationTest.java
+++ b/src/test/java/com/keeper/homepage/IntegrationTest.java
@@ -60,6 +60,8 @@ import com.keeper.homepage.domain.seminar.dao.SeminarAttendanceRepository;
 import com.keeper.homepage.domain.seminar.dao.SeminarAttendanceStatusRepository;
 import com.keeper.homepage.domain.seminar.dao.SeminarRepository;
 import com.keeper.homepage.domain.study.StudyTestHelper;
+import com.keeper.homepage.domain.study.application.StudyService;
+import com.keeper.homepage.domain.study.application.convenience.StudyFindService;
 import com.keeper.homepage.domain.study.dao.StudyHasMemberRepository;
 import com.keeper.homepage.domain.study.dao.StudyRepository;
 import com.keeper.homepage.domain.thumbnail.dao.ThumbnailRepository;
@@ -230,6 +232,9 @@ public class IntegrationTest {
 
   @SpyBean
   protected MemberFindService memberFindService;
+
+  @SpyBean
+  protected StudyService studyService;
 
   /******* Helper *******/
   @SpyBean

--- a/src/test/java/com/keeper/homepage/domain/post/api/PostControllerTest.java
+++ b/src/test/java/com/keeper/homepage/domain/post/api/PostControllerTest.java
@@ -4,8 +4,8 @@ import static com.keeper.homepage.domain.member.entity.job.MemberJob.MemberJobTy
 import static com.keeper.homepage.domain.post.application.PostService.EXAM_ACCESSIBLE_ATTENDANCE_COUNT;
 import static com.keeper.homepage.domain.post.application.PostService.EXAM_ACCESSIBLE_COMMENT_COUNT;
 import static com.keeper.homepage.domain.post.application.PostService.EXAM_ACCESSIBLE_POINT;
-import static com.keeper.homepage.domain.post.dto.request.PostCreateRequest.MAX_REQUEST_PASSWORD_LENGTH;
-import static com.keeper.homepage.domain.post.dto.request.PostCreateRequest.MAX_REQUEST_TITLE_LENGTH;
+import static com.keeper.homepage.domain.post.dto.request.PostCreateRequest.POST_PASSWORD_LENGTH;
+import static com.keeper.homepage.domain.post.dto.request.PostCreateRequest.POST_TITLE_LENGTH;
 import static com.keeper.homepage.global.config.security.data.JwtType.ACCESS_TOKEN;
 import static com.keeper.homepage.global.restdocs.RestDocsHelper.getSecuredValue;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -29,7 +29,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.keeper.homepage.domain.member.entity.Member;
-import com.keeper.homepage.domain.post.dto.request.PostUpdateRequest;
 import com.keeper.homepage.domain.post.entity.Post;
 import com.keeper.homepage.domain.post.entity.category.Category;
 import com.keeper.homepage.global.util.web.WebUtil;
@@ -98,7 +97,7 @@ public class PostControllerTest extends PostApiTestHelper {
               ),
               queryParameters(
                   parameterWithName("title")
-                      .description("게시글 제목을 입력해주세요. (최대 가능 길이 : " + MAX_REQUEST_TITLE_LENGTH + ")"),
+                      .description("게시글 제목을 입력해주세요. (최대 가능 길이 : " + POST_TITLE_LENGTH + ")"),
                   parameterWithName("content")
                       .description("게시글 내용을 입력해주세요."),
                   parameterWithName("allowComment")
@@ -115,7 +114,7 @@ public class PostControllerTest extends PostApiTestHelper {
                       .optional(),
                   parameterWithName("password")
                       .description(
-                          "게시글 비밀번호를 입력해주세요. (최대 가능 길이 : " + MAX_REQUEST_PASSWORD_LENGTH
+                          "게시글 비밀번호를 입력해주세요. (최대 가능 길이 : " + POST_PASSWORD_LENGTH
                               + ", 비밀글일 경우 필수값입니다.)")
                       .optional(),
                   parameterWithName("categoryId")
@@ -219,7 +218,7 @@ public class PostControllerTest extends PostApiTestHelper {
     @Test
     @DisplayName("게시글 제목이 최대 글자를 넘은 경우 게시글 생성은 실패한다.")
     void should_400BadRequest_when_tooLongTitle() throws Exception {
-      params.add("title", "a".repeat(MAX_REQUEST_TITLE_LENGTH + 1));
+      params.add("title", "a".repeat(POST_TITLE_LENGTH + 1));
       params.add("content", "게시글 내용");
       params.add("categoryId", category.getId().toString());
 
@@ -232,7 +231,7 @@ public class PostControllerTest extends PostApiTestHelper {
     void should_400BadRequest_when_tooLongPassword() throws Exception {
       params.add("title", "게시글 제목");
       params.add("content", "게시글 내용");
-      params.add("password", "a".repeat(MAX_REQUEST_PASSWORD_LENGTH + 1));
+      params.add("password", "a".repeat(POST_PASSWORD_LENGTH + 1));
       params.add("categoryId", category.getId().toString());
 
       callCreatePostApi(memberToken, params)
@@ -454,7 +453,7 @@ public class PostControllerTest extends PostApiTestHelper {
               ),
               queryParameters(
                   parameterWithName("title")
-                      .description("게시글 제목을 입력해주세요. (최대 가능 길이 : " + MAX_REQUEST_TITLE_LENGTH + ")"),
+                      .description("게시글 제목을 입력해주세요. (최대 가능 길이 : " + POST_TITLE_LENGTH + ")"),
                   parameterWithName("content")
                       .description("게시글 내용을 입력해주세요."),
                   parameterWithName("allowComment")
@@ -471,7 +470,7 @@ public class PostControllerTest extends PostApiTestHelper {
                       .optional(),
                   parameterWithName("password")
                       .description(
-                          "게시글 비밀번호를 입력해주세요. (최대 가능 길이 : " + MAX_REQUEST_PASSWORD_LENGTH
+                          "게시글 비밀번호를 입력해주세요. (최대 가능 길이 : " + POST_PASSWORD_LENGTH
                               + ", 비밀글일 경우 필수값입니다.)")
                       .optional()
               ),

--- a/src/test/java/com/keeper/homepage/domain/study/api/StudyApiTestHelper.java
+++ b/src/test/java/com/keeper/homepage/domain/study/api/StudyApiTestHelper.java
@@ -1,0 +1,33 @@
+package com.keeper.homepage.domain.study.api;
+
+import static com.keeper.homepage.global.config.security.data.JwtType.ACCESS_TOKEN;
+import static org.springframework.http.HttpMethod.POST;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+
+import com.keeper.homepage.IntegrationTest;
+import jakarta.servlet.http.Cookie;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.util.MultiValueMap;
+
+public class StudyApiTestHelper extends IntegrationTest {
+
+  ResultActions callCreateStudyApiWithThumbnail(String accessToken, MockMultipartFile thumbnail,
+      MultiValueMap<String, String> params)
+      throws Exception {
+    return mockMvc.perform(multipart(POST, "/studies")
+        .file(thumbnail)
+        .queryParams(params)
+        .cookie(new Cookie(ACCESS_TOKEN.getTokenName(), accessToken))
+        .contentType(MediaType.MULTIPART_FORM_DATA));
+  }
+
+  ResultActions callCreateStudyApi(String accessToken, MultiValueMap<String, String> params)
+      throws Exception {
+    return mockMvc.perform(multipart(POST, "/studies")
+        .queryParams(params)
+        .cookie(new Cookie(ACCESS_TOKEN.getTokenName(), accessToken))
+        .contentType(MediaType.MULTIPART_FORM_DATA));
+  }
+}

--- a/src/test/java/com/keeper/homepage/domain/study/api/StudyApiTestHelper.java
+++ b/src/test/java/com/keeper/homepage/domain/study/api/StudyApiTestHelper.java
@@ -2,6 +2,7 @@ package com.keeper.homepage.domain.study.api;
 
 import static com.keeper.homepage.global.config.security.data.JwtType.ACCESS_TOKEN;
 import static org.springframework.http.HttpMethod.POST;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 
 import com.keeper.homepage.IntegrationTest;
@@ -29,5 +30,11 @@ public class StudyApiTestHelper extends IntegrationTest {
         .queryParams(params)
         .cookie(new Cookie(ACCESS_TOKEN.getTokenName(), accessToken))
         .contentType(MediaType.MULTIPART_FORM_DATA));
+  }
+
+  ResultActions callDeleteStudyApi(String accessToken, long studyId)
+      throws Exception {
+    return mockMvc.perform(delete("/studies/{studyId}", studyId)
+        .cookie(new Cookie(ACCESS_TOKEN.getTokenName(), accessToken)));
   }
 }

--- a/src/test/java/com/keeper/homepage/domain/study/api/StudyControllerTest.java
+++ b/src/test/java/com/keeper/homepage/domain/study/api/StudyControllerTest.java
@@ -1,8 +1,8 @@
 package com.keeper.homepage.domain.study.api;
 
 import static com.keeper.homepage.domain.member.entity.job.MemberJob.MemberJobType.ROLE_회원;
-import static com.keeper.homepage.domain.study.dto.request.StudyCreateRequest.MAX_REQUEST_STUDY_INFORMATION_LENGTH;
-import static com.keeper.homepage.domain.study.dto.request.StudyCreateRequest.MAX_REQUEST_STUDY_TITLE_LENGTH;
+import static com.keeper.homepage.domain.study.dto.request.StudyCreateRequest.STUDY_INFORMATION_LENGTH;
+import static com.keeper.homepage.domain.study.dto.request.StudyCreateRequest.STUDY_TITLE_LENGTH;
 import static com.keeper.homepage.global.config.security.data.JwtType.ACCESS_TOKEN;
 import static com.keeper.homepage.global.restdocs.RestDocsHelper.getSecuredValue;
 import static org.springframework.restdocs.cookies.CookieDocumentation.cookieWithName;
@@ -47,7 +47,7 @@ public class StudyControllerTest extends StudyApiTestHelper {
     void should_201CREATED_when_createPostWithThumbnailAndFiles() throws Exception {
       String securedValue = getSecuredValue(StudyController.class, "createStudy");
 
-      addAllParams();
+      addAllParams(params);
 
       callCreateStudyApiWithThumbnail(memberToken, thumbnail, params)
           .andExpect(status().isCreated())
@@ -58,9 +58,9 @@ public class StudyControllerTest extends StudyApiTestHelper {
               ),
               queryParameters(
                   parameterWithName("title")
-                      .description("스터디 이름을 입력해주세요. (최대 가능 길이 : " + MAX_REQUEST_STUDY_TITLE_LENGTH + ")"),
+                      .description("스터디 이름을 입력해주세요. (최대 가능 길이 : " + STUDY_TITLE_LENGTH + ")"),
                   parameterWithName("information")
-                      .description("스터디 설명을 입력해주세요. (최대 가능 길이 : " + MAX_REQUEST_STUDY_INFORMATION_LENGTH + ")"),
+                      .description("스터디 설명을 입력해주세요. (최대 가능 길이 : " + STUDY_INFORMATION_LENGTH + ")"),
                   parameterWithName("year")
                       .description("스터디 년도를 입력해주세요."),
                   parameterWithName("season")
@@ -78,7 +78,7 @@ public class StudyControllerTest extends StudyApiTestHelper {
               )));
     }
 
-    private void addAllParams() {
+    private void addAllParams(MultiValueMap<String, String> params) {
       params.add("title", "자바 스터디");
       params.add("information", "자바 스터디 입니다");
       params.add("year", "2023");

--- a/src/test/java/com/keeper/homepage/domain/study/api/StudyControllerTest.java
+++ b/src/test/java/com/keeper/homepage/domain/study/api/StudyControllerTest.java
@@ -1,0 +1,91 @@
+package com.keeper.homepage.domain.study.api;
+
+import static com.keeper.homepage.domain.member.entity.job.MemberJob.MemberJobType.ROLE_회원;
+import static com.keeper.homepage.domain.study.dto.request.StudyCreateRequest.MAX_REQUEST_STUDY_INFORMATION_LENGTH;
+import static com.keeper.homepage.domain.study.dto.request.StudyCreateRequest.MAX_REQUEST_STUDY_TITLE_LENGTH;
+import static com.keeper.homepage.global.config.security.data.JwtType.ACCESS_TOKEN;
+import static com.keeper.homepage.global.restdocs.RestDocsHelper.getSecuredValue;
+import static org.springframework.restdocs.cookies.CookieDocumentation.cookieWithName;
+import static org.springframework.restdocs.cookies.CookieDocumentation.requestCookies;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.partWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.requestParts;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.keeper.homepage.domain.member.entity.Member;
+import java.io.IOException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+public class StudyControllerTest extends StudyApiTestHelper {
+
+  private Member member;
+  private MockMultipartFile thumbnail;
+  private String memberToken;
+  private final MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+
+  @BeforeEach
+  void setUp() throws IOException {
+    member = memberTestHelper.builder().build();
+    thumbnail = thumbnailTestHelper.getSmallThumbnailFile();
+    memberToken = jwtTokenProvider.createAccessToken(ACCESS_TOKEN, member.getId(), ROLE_회원);
+  }
+
+  @Nested
+  @DisplayName("스터디 생성")
+  class CreateStudy {
+
+    @Test
+    @DisplayName("썸네일과 파일이 포함된 게시글을 생성하면 게시글 생성이 성공한다.")
+    void should_201CREATED_when_createPostWithThumbnailAndFiles() throws Exception {
+      String securedValue = getSecuredValue(StudyController.class, "createStudy");
+
+      addAllParams();
+
+      callCreateStudyApiWithThumbnail(memberToken, thumbnail, params)
+          .andExpect(status().isCreated())
+          .andDo(document("create-study",
+              requestCookies(
+                  cookieWithName(ACCESS_TOKEN.getTokenName())
+                      .description("ACCESS TOKEN %s".formatted(securedValue) + " 스터디 생성자는 스터디장이 됩니다.")
+              ),
+              queryParameters(
+                  parameterWithName("title")
+                      .description("스터디 이름을 입력해주세요. (최대 가능 길이 : " + MAX_REQUEST_STUDY_TITLE_LENGTH + ")"),
+                  parameterWithName("information")
+                      .description("스터디 설명을 입력해주세요. (최대 가능 길이 : " + MAX_REQUEST_STUDY_INFORMATION_LENGTH + ")"),
+                  parameterWithName("year")
+                      .description("스터디 년도를 입력해주세요."),
+                  parameterWithName("season")
+                      .description("스터디 학기를 입력해주세요. (1: 1학기 2: 여름학기 3: 2학기 4: 겨울학기)"),
+                  parameterWithName("gitLink")
+                      .description("스터디 깃허브 링크를 입력해주세요.").optional(),
+                  parameterWithName("noteLink")
+                      .description("스터디 노트 링크를 입력해주세요.").optional(),
+                  parameterWithName("etcLink")
+                      .description("스터디 기타 링크를 입력해주세요.").optional()
+              ),
+              requestParts(
+                  partWithName("thumbnail").description("스터디의 썸네일")
+                      .optional()
+              )));
+    }
+
+    private void addAllParams() {
+      params.add("title", "자바 스터디");
+      params.add("information", "자바 스터디 입니다");
+      params.add("year", "2023");
+      params.add("season", "1");
+      params.add("gitLink", "github.com");
+      params.add("noteLink", "notion.com");
+      params.add("etcLink", "etc.com");
+    }
+  }
+}


### PR DESCRIPTION
## 🔥 Related Issue

close: #123

## 📝 Description

스터디 추가(생성), 삭제 기능을 구현했습니다!

## ⭐️ Review

스터디 제목, 내용 요청받을 때 최대 입력 가능 길이는 45, 100으로 일단 정해봤습니다! 기획서에 적어두겠습니다.

[스터디 기획서](https://enormous-button-c5d.notion.site/A1-A9-a9b13c9075f548c79f5f7408d113a2e9)