### PR TITLE
Feature/스터디 목록 조회 구현

### DIFF
--- a/src/docs/asciidoc/study/study.adoc
+++ b/src/docs/asciidoc/study/study.adoc
@@ -60,3 +60,55 @@ include::{snippets}/delete-study/path-parameters.adoc[]
 ==== Response
 
 include::{snippets}/delete-study/http-response.adoc[]
+
+== *스터디 목록 조회*
+
+=== 요청
+
+==== Request
+
+include::{snippets}/get-studies/http-request.adoc[]
+
+==== Request Cookies
+
+include::{snippets}/get-studies/request-cookies.adoc[]
+
+==== Query Parameters
+
+include::{snippets}/get-studies/query-parameters.adoc[]
+
+=== 응답
+
+==== Response
+
+include::{snippets}/get-studies/http-response.adoc[]
+
+==== Response Fields
+
+include::{snippets}/get-studies/response-fields.adoc[]
+
+== *스터디 조회*
+
+=== 요청
+
+==== Request
+
+include::{snippets}/get-study/http-request.adoc[]
+
+==== Request Cookies
+
+include::{snippets}/get-study/request-cookies.adoc[]
+
+==== Path Parameters
+
+include::{snippets}/get-study/path-parameters.adoc[]
+
+=== 응답
+
+==== Response
+
+include::{snippets}/get-study/http-response.adoc[]
+
+==== Response Fields
+
+include::{snippets}/get-study/response-fields.adoc[]

--- a/src/main/java/com/keeper/homepage/domain/member/entity/Member.java
+++ b/src/main/java/com/keeper/homepage/domain/member/entity/Member.java
@@ -275,6 +275,10 @@ public class Member {
     return this.profile.getNickname().get();
   }
 
+  public String getRealName() {
+    return this.profile.getRealName().get();
+  }
+
   public boolean isHeadMember(Study study) {
     return study.getHeadMember().equals(this);
   }

--- a/src/main/java/com/keeper/homepage/domain/study/api/StudyController.java
+++ b/src/main/java/com/keeper/homepage/domain/study/api/StudyController.java
@@ -3,16 +3,20 @@ package com.keeper.homepage.domain.study.api;
 import com.keeper.homepage.domain.member.entity.Member;
 import com.keeper.homepage.domain.study.application.StudyService;
 import com.keeper.homepage.domain.study.dto.request.StudyCreateRequest;
+import com.keeper.homepage.domain.study.dto.response.StudyDetailResponse;
+import com.keeper.homepage.domain.study.dto.response.StudyListResponse;
 import com.keeper.homepage.global.config.security.annotation.LoginMember;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -39,5 +43,24 @@ public class StudyController {
   ) {
     studyService.delete(member, studyId);
     return ResponseEntity.noContent().build();
+  }
+
+  @GetMapping("/{studyId}")
+  public ResponseEntity<StudyDetailResponse> getStudy(
+      @PathVariable long studyId
+  ) {
+    StudyDetailResponse response = studyService.getStudy(studyId);
+    return ResponseEntity.status(HttpStatus.OK)
+        .body(response);
+  }
+
+  @GetMapping
+  public ResponseEntity<StudyListResponse> getStudies(
+      @RequestParam int year,
+      @RequestParam int season
+  ) {
+    StudyListResponse listResponse = studyService.getStudies(year, season);
+    return ResponseEntity.status(HttpStatus.OK)
+        .body(listResponse);
   }
 }

--- a/src/main/java/com/keeper/homepage/domain/study/application/StudyService.java
+++ b/src/main/java/com/keeper/homepage/domain/study/application/StudyService.java
@@ -6,10 +6,14 @@ import static com.keeper.homepage.global.error.ErrorCode.STUDY_CANNOT_ACCESSIBLE
 import com.keeper.homepage.domain.member.entity.Member;
 import com.keeper.homepage.domain.study.application.convenience.StudyFindService;
 import com.keeper.homepage.domain.study.dao.StudyRepository;
+import com.keeper.homepage.domain.study.dto.response.StudyDetailResponse;
+import com.keeper.homepage.domain.study.dto.response.StudyListResponse;
+import com.keeper.homepage.domain.study.dto.response.StudyResponse;
 import com.keeper.homepage.domain.study.entity.Study;
 import com.keeper.homepage.domain.thumbnail.entity.Thumbnail;
 import com.keeper.homepage.global.error.BusinessException;
 import com.keeper.homepage.global.util.thumbnail.ThumbnailUtil;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -41,5 +45,18 @@ public class StudyService {
       throw new BusinessException(study.getId(), "study", STUDY_CANNOT_ACCESSIBLE);
     }
     studyRepository.delete(study);
+  }
+
+  public StudyDetailResponse getStudy(long studyId) {
+    Study study = studyFindService.findById(studyId);
+    return StudyDetailResponse.from(study);
+  }
+
+  public StudyListResponse getStudies(int year, int season) {
+    List<Study> studies = studyRepository.findAllByYearAndSeason(year, season);
+    List<StudyResponse> studyResponses = studies.stream()
+        .map(StudyResponse::from)
+        .toList();
+    return StudyListResponse.from(studyResponses);
   }
 }

--- a/src/main/java/com/keeper/homepage/domain/study/application/StudyService.java
+++ b/src/main/java/com/keeper/homepage/domain/study/application/StudyService.java
@@ -1,9 +1,11 @@
 package com.keeper.homepage.domain.study.application;
 
+import static com.keeper.homepage.domain.thumbnail.entity.Thumbnail.DefaultThumbnail.DEFAULT_POST_THUMBNAIL;
 import static com.keeper.homepage.global.error.ErrorCode.POST_CANNOT_ACCESSIBLE;
 import static com.keeper.homepage.global.error.ErrorCode.STUDY_CANNOT_ACCESSIBLE;
 
 import com.keeper.homepage.domain.member.entity.Member;
+import com.keeper.homepage.domain.post.entity.Post;
 import com.keeper.homepage.domain.study.application.convenience.StudyFindService;
 import com.keeper.homepage.domain.study.dao.StudyRepository;
 import com.keeper.homepage.domain.study.dto.response.StudyDetailResponse;
@@ -14,6 +16,7 @@ import com.keeper.homepage.domain.thumbnail.entity.Thumbnail;
 import com.keeper.homepage.global.error.BusinessException;
 import com.keeper.homepage.global.util.thumbnail.ThumbnailUtil;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/main/java/com/keeper/homepage/domain/study/dao/StudyRepository.java
+++ b/src/main/java/com/keeper/homepage/domain/study/dao/StudyRepository.java
@@ -1,8 +1,10 @@
 package com.keeper.homepage.domain.study.dao;
 
 import com.keeper.homepage.domain.study.entity.Study;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface StudyRepository extends JpaRepository<Study, Long> {
 
+  List<Study> findAllByYearAndSeason(int year, int season);
 }

--- a/src/main/java/com/keeper/homepage/domain/study/dto/request/StudyCreateRequest.java
+++ b/src/main/java/com/keeper/homepage/domain/study/dto/request/StudyCreateRequest.java
@@ -1,11 +1,19 @@
 package com.keeper.homepage.domain.study.dto.request;
 
+import static com.keeper.homepage.domain.study.entity.embedded.GitLink.GIT_LINK_INVALID;
+import static com.keeper.homepage.domain.study.entity.embedded.GitLink.GIT_LINK_REGEX;
+import static com.keeper.homepage.domain.study.entity.embedded.NoteLink.NOTION_LINK_INVALID;
+import static com.keeper.homepage.domain.study.entity.embedded.NoteLink.NOTION_LINK_REGEX;
 import static lombok.AccessLevel.PRIVATE;
 
 import com.keeper.homepage.domain.member.entity.Member;
+import com.keeper.homepage.domain.study.entity.embedded.GitLink;
+import com.keeper.homepage.domain.study.entity.embedded.Link;
+import com.keeper.homepage.domain.study.entity.embedded.NoteLink;
 import com.keeper.homepage.domain.study.entity.Study;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -36,9 +44,11 @@ public class StudyCreateRequest {
   private Integer season;
 
   @Nullable
+  @Pattern(regexp = GIT_LINK_REGEX, message = GIT_LINK_INVALID)
   private String gitLink;
 
   @Nullable
+  @Pattern(regexp = NOTION_LINK_REGEX, message = NOTION_LINK_INVALID)
   private String noteLink;
 
   @Nullable
@@ -54,9 +64,11 @@ public class StudyCreateRequest {
         .headMember(member)
         .year(year)
         .season(season)
-        .gitLink(gitLink)
-        .noteLink(noteLink)
-        .etcLink(etcLink)
+        .link(Link.builder()
+            .gitLink(GitLink.from(gitLink))
+            .noteLink(NoteLink.from(noteLink))
+            .etcLink(etcLink)
+            .build())
         .build();
   }
 }

--- a/src/main/java/com/keeper/homepage/domain/study/dto/response/StudyDetailResponse.java
+++ b/src/main/java/com/keeper/homepage/domain/study/dto/response/StudyDetailResponse.java
@@ -1,0 +1,39 @@
+package com.keeper.homepage.domain.study.dto.response;
+
+import static java.util.stream.Collectors.toList;
+import static lombok.AccessLevel.PRIVATE;
+
+import com.keeper.homepage.domain.member.entity.Member;
+import com.keeper.homepage.domain.study.entity.Study;
+import com.keeper.homepage.domain.study.entity.StudyHasMember;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = PRIVATE)
+public class StudyDetailResponse {
+
+  private String information;
+  private List<String> members;
+  private String gitLink;
+  private String noteLink;
+  private String etcLink;
+
+  public static StudyDetailResponse from(Study study) {
+    return StudyDetailResponse.builder()
+        .information(study.getInformation())
+        .members(study.getStudyMembers()
+            .stream()
+            .map(StudyHasMember::getMember)
+            .map(Member::getRealName)
+            .toList())
+        .gitLink(study.getGitLink())
+        .noteLink(study.getNoteLink())
+        .etcLink(study.getEtcLink())
+        .build();
+  }
+}

--- a/src/main/java/com/keeper/homepage/domain/study/dto/response/StudyDetailResponse.java
+++ b/src/main/java/com/keeper/homepage/domain/study/dto/response/StudyDetailResponse.java
@@ -1,6 +1,5 @@
 package com.keeper.homepage.domain.study.dto.response;
 
-import static java.util.stream.Collectors.toList;
 import static lombok.AccessLevel.PRIVATE;
 
 import com.keeper.homepage.domain.member.entity.Member;
@@ -31,7 +30,7 @@ public class StudyDetailResponse {
             .map(Member::getRealName)
             .toList())
         .gitLink(study.getGitLink())
-        .noteLink(study.getNoteLink())
+        .noteLink(study.getNotionLink())
         .etcLink(study.getEtcLink())
         .build();
   }

--- a/src/main/java/com/keeper/homepage/domain/study/dto/response/StudyDetailResponse.java
+++ b/src/main/java/com/keeper/homepage/domain/study/dto/response/StudyDetailResponse.java
@@ -7,7 +7,6 @@ import com.keeper.homepage.domain.member.entity.Member;
 import com.keeper.homepage.domain.study.entity.Study;
 import com.keeper.homepage.domain.study.entity.StudyHasMember;
 import java.util.List;
-import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/keeper/homepage/domain/study/dto/response/StudyListResponse.java
+++ b/src/main/java/com/keeper/homepage/domain/study/dto/response/StudyListResponse.java
@@ -1,0 +1,10 @@
+package com.keeper.homepage.domain.study.dto.response;
+
+import java.util.List;
+
+public record StudyListResponse(List<StudyResponse> studies) {
+
+  public static StudyListResponse from(List<StudyResponse> studies) {
+    return new StudyListResponse(studies);
+  }
+}

--- a/src/main/java/com/keeper/homepage/domain/study/dto/response/StudyResponse.java
+++ b/src/main/java/com/keeper/homepage/domain/study/dto/response/StudyResponse.java
@@ -1,0 +1,29 @@
+package com.keeper.homepage.domain.study.dto.response;
+
+import static lombok.AccessLevel.PRIVATE;
+
+import com.keeper.homepage.domain.study.entity.Study;
+import jakarta.persistence.criteria.CriteriaBuilder.In;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = PRIVATE)
+public class StudyResponse {
+
+  private Long studyId;
+  private String title;
+  private String headName;
+  private Integer memberCount;
+
+  public static StudyResponse from(Study study) {
+    return StudyResponse.builder()
+        .studyId(study.getId())
+        .title(study.getTitle())
+        .headName(study.getHeadMember().getRealName())
+        .memberCount(study.getStudyMembers().size())
+        .build();
+  }
+}

--- a/src/main/java/com/keeper/homepage/domain/study/dto/response/StudyResponse.java
+++ b/src/main/java/com/keeper/homepage/domain/study/dto/response/StudyResponse.java
@@ -3,7 +3,6 @@ package com.keeper.homepage.domain.study.dto.response;
 import static lombok.AccessLevel.PRIVATE;
 
 import com.keeper.homepage.domain.study.entity.Study;
-import jakarta.persistence.criteria.CriteriaBuilder.In;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -17,6 +16,7 @@ public class StudyResponse {
   private String title;
   private String headName;
   private Integer memberCount;
+  private String thumbnailPath;
 
   public static StudyResponse from(Study study) {
     return StudyResponse.builder()
@@ -24,6 +24,7 @@ public class StudyResponse {
         .title(study.getTitle())
         .headName(study.getHeadMember().getRealName())
         .memberCount(study.getStudyMembers().size())
+        .thumbnailPath(study.getThumbnailPath())
         .build();
   }
 }

--- a/src/main/java/com/keeper/homepage/domain/study/entity/Study.java
+++ b/src/main/java/com/keeper/homepage/domain/study/entity/Study.java
@@ -4,10 +4,14 @@ package com.keeper.homepage.domain.study.entity;
 import static com.keeper.homepage.domain.thumbnail.entity.Thumbnail.DefaultThumbnail.DEFAULT_POST_THUMBNAIL;
 
 import com.keeper.homepage.domain.member.entity.Member;
+import com.keeper.homepage.domain.study.entity.embedded.Link;
 import com.keeper.homepage.domain.thumbnail.entity.Thumbnail;
 import com.keeper.homepage.global.entity.BaseEntity;
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.AttributeOverrides;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -56,14 +60,13 @@ public class Study extends BaseEntity {
   @Column(name = "season")
   private Integer season;
 
-  @Column(name = "git_link", length = MAX_LINK_LENGTH)
-  private String gitLink;
-
-  @Column(name = "note_link", length = MAX_LINK_LENGTH)
-  private String noteLink;
-
-  @Column(name = "etc_link", length = MAX_LINK_LENGTH)
-  private String etcLink;
+  @Embedded
+  @AttributeOverrides({
+      @AttributeOverride(name = "gitLink", column = @Column(name = "git_link", length = MAX_LINK_LENGTH)),
+      @AttributeOverride(name = "noteLink", column = @Column(name = "note_link", length = MAX_LINK_LENGTH)),
+      @AttributeOverride(name = "etcLink", column = @Column(name = "etc_link", length = MAX_LINK_LENGTH))
+  })
+  private Link link;
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "thumbnail_id", nullable = false)
@@ -77,15 +80,13 @@ public class Study extends BaseEntity {
   private final Set<StudyHasMember> studyMembers = new HashSet<>();
 
   @Builder
-  private Study(String title, String information, Integer year, Integer season, String gitLink, String noteLink,
-      String etcLink, Thumbnail thumbnail, Member headMember) {
+  private Study(String title, String information, Integer year, Integer season, Link link, Thumbnail thumbnail,
+      Member headMember) {
     this.title = title;
     this.information = information;
     this.year = year;
     this.season = season;
-    this.gitLink = gitLink;
-    this.noteLink = noteLink;
-    this.etcLink = etcLink;
+    this.link = link;
     this.thumbnail = thumbnail;
     this.headMember = headMember;
   }
@@ -98,5 +99,17 @@ public class Study extends BaseEntity {
     return Optional.ofNullable(this.thumbnail)
         .map(Thumbnail::getPath)
         .orElse(DEFAULT_POST_THUMBNAIL.getPath());
+  }
+
+  public String getGitLink() {
+    return this.link.getGitLink().get();
+  }
+
+  public String getNotionLink() {
+    return this.link.getNoteLink().get();
+  }
+
+  public String getEtcLink() {
+    return this.link.getEtcLink();
   }
 }

--- a/src/main/java/com/keeper/homepage/domain/study/entity/Study.java
+++ b/src/main/java/com/keeper/homepage/domain/study/entity/Study.java
@@ -1,6 +1,8 @@
 package com.keeper.homepage.domain.study.entity;
 
 
+import static com.keeper.homepage.domain.thumbnail.entity.Thumbnail.DefaultThumbnail.DEFAULT_POST_THUMBNAIL;
+
 import com.keeper.homepage.domain.member.entity.Member;
 import com.keeper.homepage.domain.thumbnail.entity.Thumbnail;
 import com.keeper.homepage.global.entity.BaseEntity;
@@ -16,6 +18,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -80,19 +83,25 @@ public class Study extends BaseEntity {
   private Study(String title, String information, Integer memberNumber,
       Integer year, Integer season, String gitLink, String noteLink, String etcLink,
       Thumbnail thumbnail, Member headMember) {
-      this.title = title;
-      this.information = information;
-      this.memberNumber = memberNumber;
-      this.year = year;
-      this.season = season;
-      this.gitLink = gitLink;
-      this.noteLink = noteLink;
-      this.etcLink = etcLink;
-      this.thumbnail = thumbnail;
-      this.headMember = headMember;
+    this.title = title;
+    this.information = information;
+    this.memberNumber = memberNumber;
+    this.year = year;
+    this.season = season;
+    this.gitLink = gitLink;
+    this.noteLink = noteLink;
+    this.etcLink = etcLink;
+    this.thumbnail = thumbnail;
+    this.headMember = headMember;
   }
 
   public void changeThumbnail(Thumbnail thumbnail) {
     this.thumbnail = thumbnail;
+  }
+
+  public String getThumbnailPath() {
+    return Optional.ofNullable(this.thumbnail)
+        .map(Thumbnail::getPath)
+        .orElse(DEFAULT_POST_THUMBNAIL.getPath());
   }
 }

--- a/src/main/java/com/keeper/homepage/domain/study/entity/embedded/GitLink.java
+++ b/src/main/java/com/keeper/homepage/domain/study/entity/embedded/GitLink.java
@@ -1,0 +1,38 @@
+package com.keeper.homepage.domain.study.entity.embedded;
+
+import static lombok.AccessLevel.PRIVATE;
+import static lombok.AccessLevel.PROTECTED;
+
+import jakarta.persistence.Embeddable;
+import java.util.regex.Pattern;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@NoArgsConstructor(access = PROTECTED)
+@AllArgsConstructor(access = PRIVATE)
+public class GitLink {
+
+  public static final String GIT_LINK_INVALID = "https://github.com 로 시작하는 깃허브 주소를 입력해주세요.";
+  public static final String GIT_LINK_REGEX = "^https://github.com/\\S+$";
+
+  private static final Pattern GIT_LINK_FORMAT = Pattern.compile(GIT_LINK_REGEX);
+
+  private String gitLink;
+
+  public static GitLink from(String gitLink) {
+    if (isInvalidFormat(gitLink)) {
+      throw new IllegalArgumentException(GIT_LINK_INVALID);
+    }
+    return new GitLink(gitLink);
+  }
+
+  private static boolean isInvalidFormat(String gitLink) {
+    return !GIT_LINK_FORMAT.matcher(gitLink).find();
+  }
+
+  public String get() {
+    return this.gitLink;
+  }
+}

--- a/src/main/java/com/keeper/homepage/domain/study/entity/embedded/Link.java
+++ b/src/main/java/com/keeper/homepage/domain/study/entity/embedded/Link.java
@@ -1,0 +1,30 @@
+package com.keeper.homepage.domain.study.entity.embedded;
+
+import static lombok.AccessLevel.PROTECTED;
+
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.Embedded;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Embeddable
+@NoArgsConstructor(access = PROTECTED)
+public class Link {
+
+  @Embedded
+  private GitLink gitLink;
+
+  @Embedded
+  private NoteLink noteLink;
+
+  private String etcLink;
+
+  @Builder
+  private Link(GitLink gitLink, NoteLink noteLink, String etcLink) {
+    this.gitLink = gitLink;
+    this.noteLink = noteLink;
+    this.etcLink = etcLink;
+  }
+}

--- a/src/main/java/com/keeper/homepage/domain/study/entity/embedded/NoteLink.java
+++ b/src/main/java/com/keeper/homepage/domain/study/entity/embedded/NoteLink.java
@@ -1,0 +1,37 @@
+package com.keeper.homepage.domain.study.entity.embedded;
+
+import static lombok.AccessLevel.PRIVATE;
+import static lombok.AccessLevel.PROTECTED;
+
+import jakarta.persistence.Embeddable;
+import java.util.regex.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@NoArgsConstructor(access = PROTECTED)
+@AllArgsConstructor(access = PRIVATE)
+public class NoteLink {
+
+  public static final String NOTION_LINK_INVALID = "https://www.notion.so/ 로 시작하는 노션 주소를 입력해주세요.";
+  public static final String NOTION_LINK_REGEX = "^https://www.notion.so/\\S+$";
+
+  private static final Pattern NOTION_LINK_FORMAT = Pattern.compile(NOTION_LINK_REGEX);
+
+  private String noteLink;
+
+  public static NoteLink from(String noteLink) {
+    if (isInvalidFormat(noteLink)) {
+      throw new IllegalArgumentException(NOTION_LINK_INVALID);
+    }
+    return new NoteLink(noteLink);
+  }
+
+  private static boolean isInvalidFormat(String noteLink) {
+    return !NOTION_LINK_FORMAT.matcher(noteLink).find();
+  }
+
+  public String get() {
+    return this.noteLink;
+  }
+}

--- a/src/test/java/com/keeper/homepage/domain/study/StudyTestHelper.java
+++ b/src/test/java/com/keeper/homepage/domain/study/StudyTestHelper.java
@@ -96,9 +96,9 @@ public class StudyTestHelper {
           .memberNumber(memberNumber)
           .year(year)
           .season(season)
-          .gitLink(gitLink)
-          .noteLink(noteLink)
-          .etcLink(etcLink)
+          .gitLink(gitLink != null ? gitLink : "github.com")
+          .noteLink(noteLink != null ? noteLink : "notion.com")
+          .etcLink(etcLink != null ? etcLink : "etc.com")
           .thumbnail(thumbnail)
           .headMember(headMember != null ? headMember : memberTestHelper.generate())
           .build());

--- a/src/test/java/com/keeper/homepage/domain/study/StudyTestHelper.java
+++ b/src/test/java/com/keeper/homepage/domain/study/StudyTestHelper.java
@@ -3,6 +3,9 @@ package com.keeper.homepage.domain.study;
 import com.keeper.homepage.domain.member.MemberTestHelper;
 import com.keeper.homepage.domain.member.entity.Member;
 import com.keeper.homepage.domain.study.dao.StudyRepository;
+import com.keeper.homepage.domain.study.entity.embedded.GitLink;
+import com.keeper.homepage.domain.study.entity.embedded.Link;
+import com.keeper.homepage.domain.study.entity.embedded.NoteLink;
 import com.keeper.homepage.domain.study.entity.Study;
 import com.keeper.homepage.domain.thumbnail.entity.Thumbnail;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -30,8 +33,8 @@ public class StudyTestHelper {
     private String information;
     private Integer year;
     private Integer season;
-    private String gitLink;
-    private String noteLink;
+    private GitLink gitLink;
+    private NoteLink noteLink;
     private String etcLink;
     private Thumbnail thumbnail;
     private Member headMember;
@@ -56,12 +59,12 @@ public class StudyTestHelper {
       return this;
     }
 
-    public StudyBuilder gitLink(String gitLink) {
+    public StudyBuilder gitLink(GitLink gitLink) {
       this.gitLink = gitLink;
       return this;
     }
 
-    public StudyBuilder noteLink(String noteLink) {
+    public StudyBuilder NoteLink(NoteLink noteLink) {
       this.noteLink = noteLink;
       return this;
     }
@@ -87,9 +90,11 @@ public class StudyTestHelper {
           .information(information != null ? information : "스터디 소개")
           .year(year)
           .season(season)
-          .gitLink(gitLink != null ? gitLink : "github.com")
-          .noteLink(noteLink != null ? noteLink : "notion.com")
-          .etcLink(etcLink != null ? etcLink : "etc.com")
+          .link(Link.builder()
+              .gitLink(gitLink != null ? gitLink : GitLink.from("https://github.com/KEEPER31337/Homepage-Back-R2"))
+              .noteLink(noteLink != null ? noteLink : NoteLink.from("https://www.notion.so/Java-Spring"))
+              .etcLink(etcLink != null ? etcLink : "etc.com")
+              .build())
           .thumbnail(thumbnail)
           .headMember(headMember != null ? headMember : memberTestHelper.generate())
           .build());

--- a/src/test/java/com/keeper/homepage/domain/study/api/StudyApiTestHelper.java
+++ b/src/test/java/com/keeper/homepage/domain/study/api/StudyApiTestHelper.java
@@ -3,6 +3,7 @@ package com.keeper.homepage.domain.study.api;
 import static com.keeper.homepage.global.config.security.data.JwtType.ACCESS_TOKEN;
 import static org.springframework.http.HttpMethod.POST;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 
 import com.keeper.homepage.IntegrationTest;
@@ -35,6 +36,20 @@ public class StudyApiTestHelper extends IntegrationTest {
   ResultActions callDeleteStudyApi(String accessToken, long studyId)
       throws Exception {
     return mockMvc.perform(delete("/studies/{studyId}", studyId)
+        .cookie(new Cookie(ACCESS_TOKEN.getTokenName(), accessToken)));
+  }
+
+  ResultActions callGetStudyApi(String accessToken, long studyId)
+      throws Exception {
+    return mockMvc.perform(get("/studies/{studyId}", studyId)
+        .cookie(new Cookie(ACCESS_TOKEN.getTokenName(), accessToken)));
+  }
+
+  ResultActions callGetStudiesApi(String accessToken, int year, int season)
+      throws Exception {
+    return mockMvc.perform(get("/studies")
+        .param("year", String.valueOf(year))
+        .param("season", String.valueOf(season))
         .cookie(new Cookie(ACCESS_TOKEN.getTokenName(), accessToken)));
   }
 }

--- a/src/test/java/com/keeper/homepage/domain/study/api/StudyControllerTest.java
+++ b/src/test/java/com/keeper/homepage/domain/study/api/StudyControllerTest.java
@@ -52,8 +52,8 @@ public class StudyControllerTest extends StudyApiTestHelper {
   class CreateStudy {
 
     @Test
-    @DisplayName("썸네일과 파일이 포함된 게시글을 생성하면 게시글 생성이 성공한다.")
-    void should_201CREATED_when_createPostWithThumbnailAndFiles() throws Exception {
+    @DisplayName("유효한 요청 시 스터디 생성은 성공한다.")
+    public void 유효한_요청_시_스터디_생성은_성공한다() throws Exception {
       String securedValue = getSecuredValue(StudyController.class, "createStudy");
 
       addAllParams(params);
@@ -92,9 +92,39 @@ public class StudyControllerTest extends StudyApiTestHelper {
       params.add("information", "자바 스터디 입니다");
       params.add("year", "2023");
       params.add("season", "1");
-      params.add("gitLink", "github.com");
-      params.add("noteLink", "notion.com");
+      params.add("gitLink", "https://github.com/KEEPER31337/Homepage-Back-R2");
+      params.add("noteLink", "https://www.notion.so/Java-Spring");
       params.add("etcLink", "etc.com");
+    }
+
+    @Test
+    @DisplayName("깃허브 링크가 아닌 링크를 입력할 경우 스터디 생성은 실패한다.")
+    public void 깃허브_링크가_아닌_링크를_입력할_경우_스터디_생성은_실패한다() throws Exception {
+      params.add("title", "자바 스터디");
+      params.add("information", "자바 스터디 입니다");
+      params.add("year", "2023");
+      params.add("season", "1");
+      params.add("gitLink", "https://www.youtube.com/");
+      params.add("noteLink", "https://www.notion.so/Java-Spring");
+      params.add("etcLink", "etc.com");
+
+      callCreateStudyApiWithThumbnail(memberToken, thumbnail, params)
+          .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("노션 링크가 아닌 링크를 입력할 경우 스터디 생성은 실패한다.")
+    public void 노션_링크가_아닌_링크를_입력할_경우_스터디_생성은_실패한다() throws Exception {
+      params.add("title", "자바 스터디");
+      params.add("information", "자바 스터디 입니다");
+      params.add("year", "2023");
+      params.add("season", "1");
+      params.add("gitLink", "https://github.com/KEEPER31337/Homepage-Back-R2");
+      params.add("noteLink", "https://www.youtube.com/");
+      params.add("etcLink", "etc.com");
+
+      callCreateStudyApiWithThumbnail(memberToken, thumbnail, params)
+          .andExpect(status().isBadRequest());
     }
   }
 

--- a/src/test/java/com/keeper/homepage/domain/study/api/StudyControllerTest.java
+++ b/src/test/java/com/keeper/homepage/domain/study/api/StudyControllerTest.java
@@ -179,6 +179,7 @@ public class StudyControllerTest extends StudyApiTestHelper {
               ),
               responseFields(
                   fieldWithPath("studies[].studyId").description("스터디 ID"),
+                  fieldWithPath("studies[].thumbnailPath").description("스터디 썸네일 경로"),
                   fieldWithPath("studies[].title").description("스터디 이름"),
                   fieldWithPath("studies[].headName").description("스터디장 이름 (실명)"),
                   fieldWithPath("studies[].memberCount").description("스터디원 수")


### PR DESCRIPTION
## 🔥 Related Issue

close: #124

## 📝 Description

스터디 조회 api와 스터디 목록 조회 api를 개발했습니다.

## ⭐️ Review

- `memberNumber`(현재 스터디원 수) 컬럼 대신 DB에서 스터디원을 세는 방식을 채택했기 때문에 이 컬럼은 추후 삭제될 예정입니다.
- 스터디장이 스터디를 생성할 시 스터디원으로 추가되어야 할 것 같은데 이건 #176 에서 개발 후 검토하겠습니다~
- 스터디장 및 스터디원들의 이름은 실명으로 표기한다는 [기획서](https://enormous-button-c5d.notion.site/B1-B8-496c3d967d3b40ee8e166c9687065d5c) 내용에 따라서 구현했습니다!