### PR TITLE
#179 야구 게임 백엔드 제작

### DIFF
--- a/src/docs/asciidoc/game/baseball.adoc
+++ b/src/docs/asciidoc/game/baseball.adoc
@@ -1,0 +1,59 @@
+ifndef::snippets[]
+:snippets: ./build/generated-snippets
+endif::[]
+
+= BASEBALL GAME API 문서
+:icons: font
+:source-highlighter: highlight.js
+:toc: left
+:toclevels: 1
+:sectlinks:
+
+== API 목록
+
+link:./game.html[GAME API 목록으로 돌아가기]
+
+== *플레이 했는지 확인하기*
+
+=== 요청
+
+==== Request
+
+include::{snippets}/baseball-is-already-played/http-request.adoc[]
+
+==== Request Cookies
+
+include::{snippets}/baseball-is-already-played/request-cookies.adoc[]
+
+=== 응답
+
+==== Response
+
+include::{snippets}/baseball-is-already-played/http-response.adoc[]
+
+NOTE: body에 boolean값으로 true, false가 반환됩니다.
+
+== *야구 게임 START*
+
+NOTE: 이 API를 호출하면 게임 플레이 횟수가 차감되고 베팅 포인트만큼 member의 포인트가 차감됩니다.
+게임 종료 후 베팅 포인트에 비례해서 포인트를 부여합니다.
+
+=== 요청
+
+==== Request
+
+include::{snippets}/baseball-start/http-request.adoc[]
+
+==== Request Cookies
+
+include::{snippets}/baseball-start/request-cookies.adoc[]
+
+==== Request Fields
+
+include::{snippets}/baseball-start/request-fields.adoc[]
+
+=== 응답
+
+==== Response
+
+include::{snippets}/baseball-start/http-response.adoc[]

--- a/src/docs/asciidoc/game/baseball.adoc
+++ b/src/docs/asciidoc/game/baseball.adoc
@@ -57,3 +57,47 @@ include::{snippets}/baseball-start/request-fields.adoc[]
 ==== Response
 
 include::{snippets}/baseball-start/http-response.adoc[]
+
+== *야구 게임 GUESS*
+
+NOTE: 이 API를 호출하면 게임 플레이 횟수가 차감되고 베팅 포인트만큼 member의 포인트가 차감됩니다.
+게임 종료 후 베팅 포인트에 비례해서 포인트를 부여합니다.
+
+=== 요청
+
+==== Request
+
+include::{snippets}/baseball-guess/http-request.adoc[]
+
+==== Request Cookies
+
+include::{snippets}/baseball-guess/request-cookies.adoc[]
+
+==== Request Fields
+
+include::{snippets}/baseball-guess/request-fields.adoc[]
+
+=== 응답
+
+==== Response
+
+include::{snippets}/baseball-guess/http-response.adoc[]
+
+==== Response Fields
+
+include::{snippets}/baseball-guess/response-fields.adoc[]
+
+NOTE: 타임아웃이 난 round가 있으면 아래와 같이 results 에 null이 들어갑니다.
+[source,json,options="nowrap"]
+----
+{
+  "guessNumber" : "1234",
+  "result" : [
+        {"strike" : 0, "ball" : 0},
+        null,
+        null,
+        { "strike" : 4, "ball" : 0 }
+  ],
+  "earnedPoint" : 2000
+}
+----

--- a/src/docs/asciidoc/game/game.adoc
+++ b/src/docs/asciidoc/game/game.adoc
@@ -1,0 +1,16 @@
+ifndef::snippets[]
+:snippets: ./build/generated-snippets
+endif::[]
+
+= GAME API 문서
+:icons: font
+:source-highlighter: highlight.js
+:toc: left
+:toclevels: 1
+:sectlinks:
+
+== API 목록
+
+link:../keeper.html[API 목록으로 돌아가기]
+
+link:./baseball.html[야구 게임 API]

--- a/src/docs/asciidoc/keeper.adoc
+++ b/src/docs/asciidoc/keeper.adoc
@@ -40,3 +40,7 @@ link:library/book-manage[API 문서 보기]
 == *STUDY API*
 
 link:study/study.html[API 문서 보기]
+
+== *GAME API*
+
+link:game/game.html[API 문서 보기]

--- a/src/main/java/com/keeper/homepage/domain/game/api/GameController.kt
+++ b/src/main/java/com/keeper/homepage/domain/game/api/GameController.kt
@@ -1,6 +1,8 @@
 package com.keeper.homepage.domain.game.api
 
 import com.keeper.homepage.domain.game.application.BaseballService
+import com.keeper.homepage.domain.game.dto.req.BaseballGuessRequest
+import com.keeper.homepage.domain.game.dto.req.BaseballGuessResponse
 import com.keeper.homepage.domain.game.dto.req.BaseballStartRequest
 import com.keeper.homepage.domain.member.entity.Member
 import com.keeper.homepage.global.config.security.annotation.LoginMember
@@ -25,5 +27,13 @@ class GameController(
     ): ResponseEntity<Void> {
         baseballService.start(requestMember, request.bettingPoint)
         return ResponseEntity.noContent().build()
+    }
+
+    @PostMapping("/baseball/guess")
+    fun baseballGuess(
+        @LoginMember requestMember: Member,
+        @RequestBody @Valid request: BaseballGuessRequest
+    ): ResponseEntity<BaseballGuessResponse> {
+        return ResponseEntity.ok(baseballService.guess(requestMember, request.guessNumber))
     }
 }

--- a/src/main/java/com/keeper/homepage/domain/game/api/GameController.kt
+++ b/src/main/java/com/keeper/homepage/domain/game/api/GameController.kt
@@ -1,0 +1,29 @@
+package com.keeper.homepage.domain.game.api
+
+import com.keeper.homepage.domain.game.application.BaseballService
+import com.keeper.homepage.domain.game.dto.req.BaseballStartRequest
+import com.keeper.homepage.domain.member.entity.Member
+import com.keeper.homepage.global.config.security.annotation.LoginMember
+import jakarta.validation.Valid
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+
+@RequestMapping("/game")
+@RestController
+class GameController(
+    private val baseballService: BaseballService
+) {
+    @GetMapping("/baseball/is-already-played")
+    fun baseballIsAlreadyPlayed(@LoginMember requestMember: Member): Boolean {
+        return baseballService.isAlreadyPlayed(requestMember)
+    }
+
+    @PostMapping("/baseball/start")
+    fun baseballStart(
+        @LoginMember requestMember: Member,
+        @RequestBody @Valid request: BaseballStartRequest
+    ): ResponseEntity<Void> {
+        baseballService.start(requestMember, request.bettingPoint)
+        return ResponseEntity.noContent().build()
+    }
+}

--- a/src/main/java/com/keeper/homepage/domain/game/api/GameController.kt
+++ b/src/main/java/com/keeper/homepage/domain/game/api/GameController.kt
@@ -16,8 +16,8 @@ class GameController(
     private val baseballService: BaseballService
 ) {
     @GetMapping("/baseball/is-already-played")
-    fun baseballIsAlreadyPlayed(@LoginMember requestMember: Member): Boolean {
-        return baseballService.isAlreadyPlayed(requestMember)
+    fun baseballIsAlreadyPlayed(@LoginMember requestMember: Member): ResponseEntity<Boolean> {
+        return ResponseEntity.ok(baseballService.isAlreadyPlayed(requestMember))
     }
 
     @PostMapping("/baseball/start")

--- a/src/main/java/com/keeper/homepage/domain/game/application/BaseballService.kt
+++ b/src/main/java/com/keeper/homepage/domain/game/application/BaseballService.kt
@@ -1,0 +1,66 @@
+package com.keeper.homepage.domain.game.application
+
+import com.keeper.homepage.domain.game.dao.GameRepository
+import com.keeper.homepage.domain.game.dto.BaseballResult
+import com.keeper.homepage.domain.game.entity.Game
+import com.keeper.homepage.domain.member.entity.Member
+import com.keeper.homepage.global.error.BusinessException
+import com.keeper.homepage.global.error.ErrorCode
+import com.keeper.homepage.global.util.redis.RedisUtil
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+import java.time.temporal.ChronoUnit
+
+const val REDIS_KEY_PREFIX = "baseball_"
+
+@Service
+@Transactional(readOnly = true)
+class BaseballService(
+    val redisUtil: RedisUtil,
+    val gameRepository: GameRepository
+) {
+    fun isAlreadyPlayed(requestMember: Member): Boolean {
+        initWhenNotExistGameMemberInfo(requestMember)
+        return gameRepository.findAllByMember(requestMember)
+            .map { game -> game.baseball.isAlreadyPlayed }
+            .orElse(true)
+    }
+
+    private fun initWhenNotExistGameMemberInfo(requestMember: Member) {
+        if (gameRepository.findAllByMember(requestMember).isEmpty) {
+            gameRepository.save(Game.newInstance(requestMember))
+        }
+    }
+
+    @Transactional
+    fun start(requestMember: Member, bettingPoint: Long) {
+        if (isAlreadyPlayed(requestMember)) {
+            throw BusinessException(requestMember.id, "memberId", ErrorCode.IS_ALREADY_PLAYED)
+        }
+        if (bettingPoint <= 0) {
+            throw BusinessException(requestMember.id, "memberId", ErrorCode.POINT_MUST_BE_POSITIVE)
+        }
+        if (requestMember.point < bettingPoint) {
+            throw BusinessException(requestMember.id, "memberId", ErrorCode.NOT_ENOUGH_POINT)
+        }
+
+        val game = gameRepository.findAllByMember(requestMember).get()
+        requestMember.minusPoint(bettingPoint.toInt())
+        game.baseball.increaseBaseballTimes()
+
+        val baseballResult = BaseballResult(bettingPoint = bettingPoint)
+        redisUtil.setDataExpire(
+            REDIS_KEY_PREFIX + requestMember.id.toString(),
+            baseballResult,
+            toMidNight()
+        ) // 다음날 자정에 redis data expired
+    }
+
+    private fun toMidNight(): Long {
+        return (LocalDateTime.now().plusDays(1)
+            .truncatedTo(ChronoUnit.DAYS)
+            .toEpochSecond(ZoneOffset.UTC) - LocalDateTime.now().toEpochSecond(ZoneOffset.UTC)) * 1000
+    }
+}

--- a/src/main/java/com/keeper/homepage/domain/game/application/BaseballService.kt
+++ b/src/main/java/com/keeper/homepage/domain/game/application/BaseballService.kt
@@ -26,13 +26,13 @@ class BaseballService(
 ) {
     fun isAlreadyPlayed(requestMember: Member): Boolean {
         initWhenNotExistGameMemberInfo(requestMember)
-        return gameRepository.findAllByMember(requestMember)
+        return gameRepository.findByMember(requestMember)
             .map { game -> game.baseball.isAlreadyPlayed }
             .orElse(true)
     }
 
     fun initWhenNotExistGameMemberInfo(requestMember: Member) {
-        if (gameRepository.findAllByMember(requestMember).isEmpty) {
+        if (gameRepository.findByMember(requestMember).isEmpty) {
             gameRepository.save(Game.newInstance(requestMember))
         }
     }
@@ -49,7 +49,7 @@ class BaseballService(
             throw BusinessException(requestMember.id, "memberId", ErrorCode.NOT_ENOUGH_POINT)
         }
 
-        val game = gameRepository.findAllByMember(requestMember).get()
+        val game = gameRepository.findByMember(requestMember).get()
         requestMember.minusPoint(bettingPoint)
         game.baseball.increaseBaseballTimes()
 
@@ -87,7 +87,7 @@ class BaseballService(
             BaseballResult::class.java
         ).orElseThrow { throw BusinessException(requestMember.id, "memberId", ErrorCode.NOT_PLAYED_YET) }
 
-        val gameEntity = gameRepository.findAllByMember(requestMember).orElseThrow()
+        val gameEntity = gameRepository.findByMember(requestMember).orElseThrow()
         if (baseballResult.results.size >= TRY_COUNT || isAlreadyCorrect(baseballResult)) {
             return BaseballGuessResponse(guessNumber, baseballResult.results, gameEntity.baseball.baseballDayPoint)
         }

--- a/src/main/java/com/keeper/homepage/domain/game/application/GameFindService.kt
+++ b/src/main/java/com/keeper/homepage/domain/game/application/GameFindService.kt
@@ -1,0 +1,20 @@
+package com.keeper.homepage.domain.game.application
+
+import com.keeper.homepage.domain.game.dao.GameRepository
+import com.keeper.homepage.domain.game.entity.Game
+import com.keeper.homepage.domain.member.entity.Member
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
+
+@Service
+@Transactional
+class GameFindService(private val gameRepository: GameRepository) {
+
+    fun findByMemberOrInit(member: Member): Game {
+        return gameRepository.findByMemberAndPlayDate(member, LocalDate.now())
+            .orElseGet { initWhenNotExistGameMemberInfo(member) }
+    }
+
+    private fun initWhenNotExistGameMemberInfo(member: Member) = gameRepository.save(Game.newInstance(member))
+}

--- a/src/main/java/com/keeper/homepage/domain/game/dao/GameRepository.java
+++ b/src/main/java/com/keeper/homepage/domain/game/dao/GameRepository.java
@@ -1,8 +1,11 @@
 package com.keeper.homepage.domain.game.dao;
 
 import com.keeper.homepage.domain.game.entity.Game;
+import com.keeper.homepage.domain.member.entity.Member;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface GameRepository extends JpaRepository<Game, Long> {
 
+  Optional<Game> findAllByMember(Member member);
 }

--- a/src/main/java/com/keeper/homepage/domain/game/dao/GameRepository.java
+++ b/src/main/java/com/keeper/homepage/domain/game/dao/GameRepository.java
@@ -7,5 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface GameRepository extends JpaRepository<Game, Long> {
 
-  Optional<Game> findAllByMember(Member member);
+  Optional<Game> findByMember(Member member);
 }

--- a/src/main/java/com/keeper/homepage/domain/game/dao/GameRepository.java
+++ b/src/main/java/com/keeper/homepage/domain/game/dao/GameRepository.java
@@ -2,10 +2,11 @@ package com.keeper.homepage.domain.game.dao;
 
 import com.keeper.homepage.domain.game.entity.Game;
 import com.keeper.homepage.domain.member.entity.Member;
+import java.time.LocalDate;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface GameRepository extends JpaRepository<Game, Long> {
 
-  Optional<Game> findByMember(Member member);
+  Optional<Game> findByMemberAndPlayDate(Member member, LocalDate playDate);
 }

--- a/src/main/java/com/keeper/homepage/domain/game/dto/BaseballResult.kt
+++ b/src/main/java/com/keeper/homepage/domain/game/dto/BaseballResult.kt
@@ -1,15 +1,54 @@
 package com.keeper.homepage.domain.game.dto
 
+import com.keeper.homepage.domain.game.application.GUESS_NUMBER_LENGTH
+import com.keeper.homepage.domain.game.application.TRY_COUNT
+import com.keeper.homepage.domain.game.support.BaseballSupport
 import java.time.LocalDateTime
+
+const val SECOND_PER_GAME = 32 // 시간제한: 30s, 모달 띄워주는시간: 2s
 
 class BaseballResult(
     val correctNumber: String,
-    val bettingPoint: Long,
-    val results: MutableList<StrikeBall> = mutableListOf()
+    val bettingPoint: Int,
+    val results: MutableList<StrikeBall?> = mutableListOf()
 ) {
-
-    var finalGetPoint: Long = 0
     var lastGuessTime: LocalDateTime = LocalDateTime.now()
 
+    /**
+     * @return: 4스트라이크나 timeout으로 게임이 끝났는지 여부
+     */
+    fun update(guessNumber: String): End {
+        BaseballSupport.updateTimeoutGames(results, lastGuessTime)
+        lastGuessTime = LocalDateTime.now()
+        if (results.size >= TRY_COUNT) {
+            return End.TIMEOUT
+        }
+        BaseballSupport.updateResults(results, correctNumber, guessNumber)
+        return End.get(results.last())
+    }
+
     class StrikeBall(val strike: Int, val ball: Int)
+    enum class End {
+        CORRECT {
+            override fun getEarnedPoint(bettingPoint: Int): Int {
+                // TODO 정답 시 포인트 부여 어떻게 할 지 기획 나오면 다시 로직 작성
+                return bettingPoint * 2
+            }
+        },
+        TIMEOUT {
+            override fun getEarnedPoint(bettingPoint: Int): Int = 0
+        },
+        MISMATCH {
+            override fun getEarnedPoint(bettingPoint: Int): Int = 0
+        };
+
+        abstract fun getEarnedPoint(bettingPoint: Int): Int
+
+        companion object {
+            fun get(last: StrikeBall?): End =
+                if (last == null) TIMEOUT
+                else if (last.strike == GUESS_NUMBER_LENGTH) CORRECT
+                else MISMATCH
+        }
+    }
 }

--- a/src/main/java/com/keeper/homepage/domain/game/dto/BaseballResult.kt
+++ b/src/main/java/com/keeper/homepage/domain/game/dto/BaseballResult.kt
@@ -3,6 +3,7 @@ package com.keeper.homepage.domain.game.dto
 import java.time.LocalDateTime
 
 class BaseballResult(
+    val correctNumber: String,
     val bettingPoint: Long,
     val results: MutableList<StrikeBall> = mutableListOf()
 ) {

--- a/src/main/java/com/keeper/homepage/domain/game/dto/BaseballResult.kt
+++ b/src/main/java/com/keeper/homepage/domain/game/dto/BaseballResult.kt
@@ -1,0 +1,14 @@
+package com.keeper.homepage.domain.game.dto
+
+import java.time.LocalDateTime
+
+class BaseballResult(
+    val bettingPoint: Long,
+    val results: MutableList<StrikeBall> = mutableListOf()
+) {
+
+    var finalGetPoint: Long = 0
+    var lastGuessTime: LocalDateTime = LocalDateTime.now()
+
+    class StrikeBall(val strike: Int, val ball: Int)
+}

--- a/src/main/java/com/keeper/homepage/domain/game/dto/req/BaseballGuessRequest.kt
+++ b/src/main/java/com/keeper/homepage/domain/game/dto/req/BaseballGuessRequest.kt
@@ -1,0 +1,9 @@
+package com.keeper.homepage.domain.game.dto.req
+
+import com.keeper.homepage.domain.game.application.GUESS_NUMBER_LENGTH
+import org.hibernate.validator.constraints.Length
+
+data class BaseballGuessRequest(
+    @field:Length(min = GUESS_NUMBER_LENGTH, max = GUESS_NUMBER_LENGTH)
+    val guessNumber: String,
+)

--- a/src/main/java/com/keeper/homepage/domain/game/dto/req/BaseballGuessResponse.kt
+++ b/src/main/java/com/keeper/homepage/domain/game/dto/req/BaseballGuessResponse.kt
@@ -1,0 +1,9 @@
+package com.keeper.homepage.domain.game.dto.req
+
+import com.keeper.homepage.domain.game.dto.BaseballResult
+
+data class BaseballGuessResponse(
+    val guessNumber: String,
+    val result: List<BaseballResult.StrikeBall?>,
+    val earnedPoint: Int,
+)

--- a/src/main/java/com/keeper/homepage/domain/game/dto/req/BaseballStartRequest.kt
+++ b/src/main/java/com/keeper/homepage/domain/game/dto/req/BaseballStartRequest.kt
@@ -8,5 +8,5 @@ const val MAX_TITLE_LENGTH = 10000L
 data class BaseballStartRequest(
     @field:Positive
     @field:Max(MAX_TITLE_LENGTH)
-    val bettingPoint: Long,
+    val bettingPoint: Int,
 )

--- a/src/main/java/com/keeper/homepage/domain/game/dto/req/BaseballStartRequest.kt
+++ b/src/main/java/com/keeper/homepage/domain/game/dto/req/BaseballStartRequest.kt
@@ -1,0 +1,12 @@
+package com.keeper.homepage.domain.game.dto.req
+
+import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.Positive
+
+const val MAX_TITLE_LENGTH = 10000L
+
+data class BaseballStartRequest(
+    @field:Positive
+    @field:Max(MAX_TITLE_LENGTH)
+    val bettingPoint: Long,
+)

--- a/src/main/java/com/keeper/homepage/domain/game/entity/Game.java
+++ b/src/main/java/com/keeper/homepage/domain/game/entity/Game.java
@@ -1,26 +1,31 @@
 package com.keeper.homepage.domain.game.entity;
 
+import com.keeper.homepage.domain.game.entity.embedded.Baseball;
 import com.keeper.homepage.domain.game.entity.embedded.Dice;
 import com.keeper.homepage.domain.game.entity.embedded.Lotto;
 import com.keeper.homepage.domain.game.entity.embedded.Roulette;
 import com.keeper.homepage.domain.member.entity.Member;
-import jakarta.persistence.*;
-
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
 
 @DynamicInsert
 @DynamicUpdate
-@Getter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
 @Table(name = "game_member_info")
 @Entity
 public class Game {
@@ -46,6 +51,26 @@ public class Game {
   @Embedded
   private Roulette roulette;
 
+  @Embedded
+  private Baseball baseball;
+
+  public Game(Long id, Member member, LocalDateTime lastPlayTime, Dice dice, Lotto lotto, Roulette roulette,
+      Baseball baseball) {
+    this.id = id;
+    this.member = member;
+    this.lastPlayTime = lastPlayTime;
+    this.dice = dice;
+    this.lotto = lotto;
+    this.roulette = roulette;
+    this.baseball = baseball;
+  }
+
+  public static Game newInstance(Member member) {
+    return new Game(null, member, null,
+        Dice.from(0, 0), Lotto.from(0, 0),
+        Roulette.from(0, 0), Baseball.from(0, 0));
+  }
+
   public Game reset() {
     dice.resetDicePerDay();
     dice.resetDiceDayPoint();
@@ -53,6 +78,36 @@ public class Game {
     lotto.resetLottoDayPoint();
     roulette.resetRoulettePerDay();
     roulette.resetRouletteDayPoint();
+    baseball.resetBaseballPerDay();
+    baseball.resetBaseballDayPoint();
     return this;
+  }
+
+  public Long getId() {
+    return id;
+  }
+
+  public Member getMember() {
+    return member;
+  }
+
+  public LocalDateTime getLastPlayTime() {
+    return lastPlayTime;
+  }
+
+  public Dice getDice() {
+    return dice;
+  }
+
+  public Lotto getLotto() {
+    return lotto;
+  }
+
+  public Roulette getRoulette() {
+    return roulette;
+  }
+
+  public Baseball getBaseball() {
+    return baseball;
   }
 }

--- a/src/main/java/com/keeper/homepage/domain/game/entity/Game.java
+++ b/src/main/java/com/keeper/homepage/domain/game/entity/Game.java
@@ -15,6 +15,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -39,6 +40,9 @@ public class Game {
   @JoinColumn(name = "member_id", nullable = false)
   private Member member;
 
+  @Column(name = "play_date", nullable = false)
+  private LocalDate playDate;
+
   @Column(name = "last_play_time")
   private LocalDateTime lastPlayTime;
 
@@ -54,10 +58,11 @@ public class Game {
   @Embedded
   private Baseball baseball;
 
-  public Game(Long id, Member member, LocalDateTime lastPlayTime, Dice dice, Lotto lotto, Roulette roulette,
+  public Game(Long id, Member member, LocalDate playDate, LocalDateTime lastPlayTime, Dice dice, Lotto lotto, Roulette roulette,
       Baseball baseball) {
     this.id = id;
     this.member = member;
+    this.playDate = playDate;
     this.lastPlayTime = lastPlayTime;
     this.dice = dice;
     this.lotto = lotto;
@@ -66,7 +71,7 @@ public class Game {
   }
 
   public static Game newInstance(Member member) {
-    return new Game(null, member, null,
+    return new Game(null, member, LocalDate.now(), null,
         Dice.from(0, 0), Lotto.from(0, 0),
         Roulette.from(0, 0), Baseball.from(0, 0));
   }

--- a/src/main/java/com/keeper/homepage/domain/game/entity/embedded/Baseball.java
+++ b/src/main/java/com/keeper/homepage/domain/game/entity/embedded/Baseball.java
@@ -1,0 +1,45 @@
+package com.keeper.homepage.domain.game.entity.embedded;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@AllArgsConstructor(access = AccessLevel.PUBLIC)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Embeddable
+public class Baseball {
+
+  private static final int BASEBALL_MAX_PLAYTIME = 1;
+
+  @Column(name = "baseball_per_day", nullable = false)
+  private Integer baseballPerDay;
+
+  @Column(name = "baseball_day_point", nullable = false)
+  private Integer baseballDayPoint;
+
+  public static Baseball from(Integer baseballPerDay, Integer baseballDayPoint) {
+    return new Baseball(baseballPerDay, baseballPerDay);
+  }
+
+  public boolean isAlreadyPlayed() {
+    return baseballPerDay >= BASEBALL_MAX_PLAYTIME;
+  }
+
+  public void increaseBaseballTimes() {
+    this.baseballPerDay += 1;
+  }
+
+  public void resetBaseballPerDay() {
+    this.baseballPerDay = 0;
+  }
+
+  public void resetBaseballDayPoint() {
+    this.baseballDayPoint = 0;
+  }
+}

--- a/src/main/java/com/keeper/homepage/domain/game/entity/embedded/Baseball.java
+++ b/src/main/java/com/keeper/homepage/domain/game/entity/embedded/Baseball.java
@@ -9,7 +9,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Builder
-@Getter
 @AllArgsConstructor(access = AccessLevel.PUBLIC)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Embeddable
@@ -25,6 +24,18 @@ public class Baseball {
 
   public static Baseball from(Integer baseballPerDay, Integer baseballDayPoint) {
     return new Baseball(baseballPerDay, baseballPerDay);
+  }
+
+  public Integer getBaseballPerDay() {
+    return baseballPerDay;
+  }
+
+  public Integer getBaseballDayPoint() {
+    return baseballDayPoint;
+  }
+
+  public void setBaseballDayPoint(Integer baseballDayPoint) {
+    this.baseballDayPoint = baseballDayPoint;
   }
 
   public boolean isAlreadyPlayed() {

--- a/src/main/java/com/keeper/homepage/domain/game/entity/embedded/Baseball.java
+++ b/src/main/java/com/keeper/homepage/domain/game/entity/embedded/Baseball.java
@@ -23,7 +23,7 @@ public class Baseball {
   private Integer baseballDayPoint;
 
   public static Baseball from(Integer baseballPerDay, Integer baseballDayPoint) {
-    return new Baseball(baseballPerDay, baseballPerDay);
+    return new Baseball(baseballPerDay, baseballDayPoint);
   }
 
   public Integer getBaseballPerDay() {

--- a/src/main/java/com/keeper/homepage/domain/game/support/BaseballSupport.kt
+++ b/src/main/java/com/keeper/homepage/domain/game/support/BaseballSupport.kt
@@ -1,0 +1,47 @@
+package com.keeper.homepage.domain.game.support
+
+import com.keeper.homepage.domain.game.application.GUESS_NUMBER_LENGTH
+import com.keeper.homepage.domain.game.application.TRY_COUNT
+import com.keeper.homepage.domain.game.dto.BaseballResult
+import com.keeper.homepage.domain.game.dto.SECOND_PER_GAME
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+
+class BaseballSupport {
+    companion object {
+        fun updateTimeoutGames(results: MutableList<BaseballResult.StrikeBall?>, lastGuessTime: LocalDateTime) {
+            val now = LocalDateTime.now()
+            val passedSecond =
+                now.toEpochSecond(ZoneOffset.UTC) - lastGuessTime.toEpochSecond(ZoneOffset.UTC) - 1 // RTT 넉넉하게 1s
+            // 마지막으로 플레이 한 시간이 너무 오래 지나 list에 너무 많은 값이 들어가는걸 방지
+            println("${now.toEpochSecond(ZoneOffset.UTC)}, ${lastGuessTime.toEpochSecond(ZoneOffset.UTC)}, $passedSecond")
+            val passedGameCount =
+                if (passedSecond / SECOND_PER_GAME < TRY_COUNT) (passedSecond / SECOND_PER_GAME).toInt() else TRY_COUNT
+            if (passedSecond > SECOND_PER_GAME) {
+                (1..passedGameCount).forEach { _ -> results.add(null) }
+            }
+        }
+
+        fun updateResults(
+            results: MutableList<BaseballResult.StrikeBall?>,
+            correctNumber: String,
+            guessNumber: String
+        ) {
+            if (guessNumber.length != GUESS_NUMBER_LENGTH) {
+                results.add(BaseballResult.StrikeBall(0, 0))
+                return
+            }
+            results.add(guess(correctNumber, guessNumber))
+        }
+
+        private fun guess(correctNumber: String, guessNumber: String): BaseballResult.StrikeBall {
+            var strike = 0
+            var ball = 0
+            for (i in guessNumber.indices) {
+                if (correctNumber[i] == guessNumber[i]) strike++
+                else if (correctNumber.contains(guessNumber[i])) ball++
+            }
+            return BaseballResult.StrikeBall(strike, ball)
+        }
+    }
+}

--- a/src/main/java/com/keeper/homepage/domain/member/entity/Member.java
+++ b/src/main/java/com/keeper/homepage/domain/member/entity/Member.java
@@ -12,6 +12,7 @@ import static com.keeper.homepage.domain.thumbnail.entity.Thumbnail.DefaultThumb
 import static jakarta.persistence.CascadeType.*;
 
 import com.keeper.homepage.domain.attendance.entity.Attendance;
+import com.keeper.homepage.domain.comment.entity.Comment;
 import com.keeper.homepage.domain.library.entity.Book;
 import com.keeper.homepage.domain.library.entity.BookBorrowInfo;
 import com.keeper.homepage.domain.library.entity.BookBorrowStatus;
@@ -29,7 +30,6 @@ import com.keeper.homepage.domain.member.entity.post.MemberHasPostLike;
 import com.keeper.homepage.domain.member.entity.rank.MemberRank;
 import com.keeper.homepage.domain.member.entity.type.MemberType;
 import com.keeper.homepage.domain.post.entity.Post;
-import com.keeper.homepage.domain.comment.entity.Comment;
 import com.keeper.homepage.domain.study.entity.Study;
 import com.keeper.homepage.domain.study.entity.StudyHasMember;
 import com.keeper.homepage.domain.thumbnail.entity.Thumbnail;
@@ -46,7 +46,6 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
-
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -279,6 +278,18 @@ public class Member {
 
   public String getNickname() {
     return this.profile.getNickname().get();
+  }
+
+  public Integer getPoint() {
+    return this.point;
+  }
+
+  public void addPoint(int point) {
+    this.point += point;
+  }
+
+  public void minusPoint(int point) {
+    this.point -= point;
   }
 
   public String getThumbnailPath() {

--- a/src/main/java/com/keeper/homepage/global/config/security/filter/RefreshTokenFilter.java
+++ b/src/main/java/com/keeper/homepage/global/config/security/filter/RefreshTokenFilter.java
@@ -61,7 +61,7 @@ public class RefreshTokenFilter extends GenericFilterBean {
 
   private boolean isTokenInRedis(TokenValidationResultDto refreshTokenDto) {
     long authId = jwtTokenProvider.getAuthId(refreshTokenDto.getToken());
-    Optional<String> tokenInRedis = redisUtil.getData(String.valueOf(authId));
+    Optional<String> tokenInRedis = redisUtil.getData(String.valueOf(authId), String.class);
     return tokenInRedis.isPresent() && tokenInRedis.get().equals(refreshTokenDto.getToken());
   }
 

--- a/src/main/java/com/keeper/homepage/global/error/ErrorCode.java
+++ b/src/main/java/com/keeper/homepage/global/error/ErrorCode.java
@@ -53,6 +53,10 @@ public enum ErrorCode {
   // STUDY
   STUDY_NOT_FOUND("존재하지 않는 스터디입니다.", HttpStatus.NOT_FOUND),
   STUDY_CANNOT_ACCESSIBLE("스터디에 접근할 권한이 없습니다.", HttpStatus.FORBIDDEN),
+  // GAME
+  IS_ALREADY_PLAYED("이미 게임 플레이 가능 횟수만큼 플레이 하였습니다.", HttpStatus.BAD_REQUEST),
+  NOT_ENOUGH_POINT("베팅 포인트는 보유한 포인트보다 많을 수 없습니다.", HttpStatus.BAD_REQUEST),
+  POINT_MUST_BE_POSITIVE("베팅 포인트는 양수여야 합니다.", HttpStatus.BAD_REQUEST),
   ;
 
   private final String message;

--- a/src/main/java/com/keeper/homepage/global/error/ErrorCode.java
+++ b/src/main/java/com/keeper/homepage/global/error/ErrorCode.java
@@ -57,6 +57,7 @@ public enum ErrorCode {
   IS_ALREADY_PLAYED("이미 게임 플레이 가능 횟수만큼 플레이 하였습니다.", HttpStatus.BAD_REQUEST),
   NOT_ENOUGH_POINT("베팅 포인트는 보유한 포인트보다 많을 수 없습니다.", HttpStatus.BAD_REQUEST),
   POINT_MUST_BE_POSITIVE("베팅 포인트는 양수여야 합니다.", HttpStatus.BAD_REQUEST),
+  NOT_PLAYED_YET("아직 게임을 시작하지 않았습니다.", HttpStatus.BAD_REQUEST),
   ;
 
   private final String message;

--- a/src/main/java/com/keeper/homepage/global/util/redis/RedisUtil.java
+++ b/src/main/java/com/keeper/homepage/global/util/redis/RedisUtil.java
@@ -43,4 +43,8 @@ public class RedisUtil {
   public void deleteData(String key) {
     redisTemplate.delete(key);
   }
+
+  public void flushAll() {
+    redisTemplate.getConnectionFactory().getConnection().flushAll();
+  }
 }

--- a/src/main/java/com/keeper/homepage/global/util/redis/RedisUtil.java
+++ b/src/main/java/com/keeper/homepage/global/util/redis/RedisUtil.java
@@ -1,6 +1,8 @@
 package com.keeper.homepage.global.util.redis;
 
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Duration;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -13,16 +15,29 @@ import org.springframework.stereotype.Component;
 public class RedisUtil {
 
   private final StringRedisTemplate redisTemplate;
+  private final ObjectMapper objectMapper;
 
-  public Optional<String> getData(String key) {
+  public <T> Optional<T> getData(String key, Class<T> classType) {
     ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
-    return Optional.ofNullable(valueOperations.get(key));
+    String value = valueOperations.get(key);
+    if (value == null) {
+      return Optional.empty();
+    }
+    try {
+      return Optional.ofNullable(objectMapper.readValue(value, classType));
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException(e);
+    }
   }
 
-  public void setDataExpire(String key, String value, long durationMillis) {
+  public <T> void setDataExpire(String key, T value, long durationMillis) {
     ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
     Duration expireDuration = Duration.ofMillis(durationMillis);
-    valueOperations.set(key, value, expireDuration);
+    try {
+      valueOperations.set(key, objectMapper.writeValueAsString(value), expireDuration);
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   public void deleteData(String key) {

--- a/src/test/java/com/keeper/homepage/IntegrationTest.java
+++ b/src/test/java/com/keeper/homepage/IntegrationTest.java
@@ -26,6 +26,7 @@ import com.keeper.homepage.domain.comment.application.CommentService;
 import com.keeper.homepage.domain.comment.dao.CommentRepository;
 import com.keeper.homepage.domain.file.dao.FileRepository;
 import com.keeper.homepage.domain.game.GameTestHelper;
+import com.keeper.homepage.domain.game.application.BaseballService;
 import com.keeper.homepage.domain.game.dao.GameRepository;
 import com.keeper.homepage.domain.library.BookBorrowInfoTestHelper;
 import com.keeper.homepage.domain.library.BookTestHelper;
@@ -61,7 +62,6 @@ import com.keeper.homepage.domain.seminar.dao.SeminarAttendanceStatusRepository;
 import com.keeper.homepage.domain.seminar.dao.SeminarRepository;
 import com.keeper.homepage.domain.study.StudyTestHelper;
 import com.keeper.homepage.domain.study.application.StudyService;
-import com.keeper.homepage.domain.study.application.convenience.StudyFindService;
 import com.keeper.homepage.domain.study.dao.StudyHasMemberRepository;
 import com.keeper.homepage.domain.study.dao.StudyRepository;
 import com.keeper.homepage.domain.survey.SurveyMemberReplyTestHelper;
@@ -253,6 +253,9 @@ public class IntegrationTest {
 
   @SpyBean
   protected StudyService studyService;
+
+  @SpyBean
+  protected BaseballService baseballService;
 
   /******* Helper *******/
   @SpyBean

--- a/src/test/java/com/keeper/homepage/IntegrationTest.java
+++ b/src/test/java/com/keeper/homepage/IntegrationTest.java
@@ -27,6 +27,7 @@ import com.keeper.homepage.domain.comment.dao.CommentRepository;
 import com.keeper.homepage.domain.file.dao.FileRepository;
 import com.keeper.homepage.domain.game.GameTestHelper;
 import com.keeper.homepage.domain.game.application.BaseballService;
+import com.keeper.homepage.domain.game.application.GameFindService;
 import com.keeper.homepage.domain.game.dao.GameRepository;
 import com.keeper.homepage.domain.library.BookBorrowInfoTestHelper;
 import com.keeper.homepage.domain.library.BookTestHelper;
@@ -256,6 +257,9 @@ public class IntegrationTest {
 
   @SpyBean
   protected BaseballService baseballService;
+
+  @SpykBean
+  protected GameFindService gameFindService;
 
   /******* Helper *******/
   @SpyBean

--- a/src/test/java/com/keeper/homepage/domain/auth/api/SignOutControllerTest.java
+++ b/src/test/java/com/keeper/homepage/domain/auth/api/SignOutControllerTest.java
@@ -51,7 +51,7 @@ class SignOutControllerTest extends IntegrationTest {
                   cookieWithName(REFRESH_TOKEN.getTokenName()).description("REFRESH TOKEN")
               )));
 
-      assertThat(redisUtil.getData(String.valueOf(member.getId()))).isEmpty();
+      assertThat(redisUtil.getData(String.valueOf(member.getId()), String.class)).isEmpty();
     }
   }
 }

--- a/src/test/java/com/keeper/homepage/domain/auth/api/test/AuthTestControllerTest.java
+++ b/src/test/java/com/keeper/homepage/domain/auth/api/test/AuthTestControllerTest.java
@@ -199,7 +199,7 @@ class AuthTestControllerTest extends IntegrationTest {
 
         jwtTokenProvider.getAuthId(newAccessToken);
         assertThat(newRefreshToken).isNotEqualTo(refreshCookie.getValue());
-        assertThat(redisUtil.getData("0")).isNotEmpty();
+        assertThat(redisUtil.getData("0", String.class)).isNotEmpty();
       }
 
       @Test

--- a/src/test/java/com/keeper/homepage/domain/game/GameTestHelper.java
+++ b/src/test/java/com/keeper/homepage/domain/game/GameTestHelper.java
@@ -9,6 +9,7 @@ import com.keeper.homepage.domain.game.entity.embedded.Roulette;
 import com.keeper.homepage.domain.member.MemberTestHelper;
 import com.keeper.homepage.domain.member.entity.Member;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -33,6 +34,7 @@ public class GameTestHelper {
   public final class GameBuilder {
 
     private Member member;
+    private LocalDate playDate;
     private LocalDateTime lastPlayTime;
     private Dice dice;
     private Lotto lotto;
@@ -44,6 +46,11 @@ public class GameTestHelper {
 
     public GameBuilder member(Member member) {
       this.member = member;
+      return this;
+    }
+
+    public GameBuilder playDate(LocalDate playDate) {
+      this.playDate = playDate;
       return this;
     }
 
@@ -70,6 +77,7 @@ public class GameTestHelper {
     public Game build() {
       return gameRepository.save(
           Game.builder().member(member != null ? member : memberTestHelper.generate())
+              .playDate(playDate != null ? playDate : LocalDate.now())
               .lastPlayTime(null)
               .dice(dice != null ? dice : Dice.from(0, 0))
               .lotto(lotto != null ? lotto : Lotto.from(0, 0))

--- a/src/test/java/com/keeper/homepage/domain/game/GameTestHelper.java
+++ b/src/test/java/com/keeper/homepage/domain/game/GameTestHelper.java
@@ -2,6 +2,7 @@ package com.keeper.homepage.domain.game;
 
 import com.keeper.homepage.domain.game.dao.GameRepository;
 import com.keeper.homepage.domain.game.entity.Game;
+import com.keeper.homepage.domain.game.entity.embedded.Baseball;
 import com.keeper.homepage.domain.game.entity.embedded.Dice;
 import com.keeper.homepage.domain.game.entity.embedded.Lotto;
 import com.keeper.homepage.domain.game.entity.embedded.Roulette;
@@ -36,6 +37,7 @@ public class GameTestHelper {
     private Dice dice;
     private Lotto lotto;
     private Roulette roulette;
+    private Baseball baseball;
 
     private GameBuilder() {
     }
@@ -72,6 +74,7 @@ public class GameTestHelper {
               .dice(dice != null ? dice : Dice.from(0, 0))
               .lotto(lotto != null ? lotto : Lotto.from(0, 0))
               .roulette(roulette != null ? roulette : Roulette.from(0, 0))
+              .baseball(baseball != null ? baseball : Baseball.from(0, 0))
               .build());
     }
   }

--- a/src/test/java/com/keeper/homepage/domain/game/api/GameApiTestHelper.kt
+++ b/src/test/java/com/keeper/homepage/domain/game/api/GameApiTestHelper.kt
@@ -1,0 +1,48 @@
+package com.keeper.homepage.domain.game.api
+
+import com.keeper.homepage.IntegrationTest
+import com.keeper.homepage.domain.game.dto.req.BaseballStartRequest
+import com.keeper.homepage.domain.member.entity.Member
+import com.keeper.homepage.domain.member.entity.job.MemberJob
+import jakarta.servlet.http.Cookie
+import org.junit.jupiter.api.BeforeEach
+import org.springframework.http.MediaType.APPLICATION_JSON
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post
+import org.springframework.test.web.servlet.ResultActions
+
+const val GAME_URL = "/game"
+
+class GameApiTestHelper : IntegrationTest() {
+
+    lateinit var player: Member
+    lateinit var playerCookies: Array<Cookie>
+
+    @BeforeEach
+    fun setUp() {
+        player = memberTestHelper.generate()
+        player.assignJob(MemberJob.MemberJobType.ROLE_회원)
+        playerCookies = memberTestHelper.getTokenCookies(player)
+    }
+
+    fun callBaseballIsAlreadyPlayed(
+        accessCookies: Array<Cookie> = playerCookies
+    ): ResultActions {
+        return mockMvc.perform(
+            get("$GAME_URL/baseball/is-already-played")
+                .cookie(*accessCookies)
+        )
+    }
+
+    fun callBaseballStart(
+        bettingPoint: Long,
+        accessCookies: Array<Cookie> = playerCookies
+    ): ResultActions {
+        return mockMvc.perform(
+            post("$GAME_URL/baseball/start")
+                .content(asJsonString(BaseballStartRequest(bettingPoint)))
+                .contentType(APPLICATION_JSON)
+                .cookie(*accessCookies)
+        )
+    }
+}

--- a/src/test/java/com/keeper/homepage/domain/game/api/GameControllerTest.kt
+++ b/src/test/java/com/keeper/homepage/domain/game/api/GameControllerTest.kt
@@ -1,7 +1,9 @@
 package com.keeper.homepage.domain.game.api
 
+import com.keeper.homepage.domain.game.application.GUESS_NUMBER_LENGTH
 import com.keeper.homepage.domain.game.application.REDIS_KEY_PREFIX
 import com.keeper.homepage.domain.game.dto.BaseballResult
+import com.keeper.homepage.domain.game.dto.BaseballResult.StrikeBall
 import com.keeper.homepage.global.config.security.data.JwtType
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
@@ -10,8 +12,7 @@ import org.junit.jupiter.api.TestInstance
 import org.springframework.restdocs.cookies.CookieDocumentation.cookieWithName
 import org.springframework.restdocs.cookies.CookieDocumentation.requestCookies
 import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document
-import org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath
-import org.springframework.restdocs.payload.PayloadDocumentation.requestFields
+import org.springframework.restdocs.payload.PayloadDocumentation.*
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
@@ -63,7 +64,6 @@ class GameControllerTest : GameApiTestHelper() {
             assertThat(data.get().correctNumber).hasSize(4)
             assertThat(data.get().correctNumber).containsOnlyDigits()
             assertThat(data.get().bettingPoint).isEqualTo(1000)
-            assertThat(data.get().finalGetPoint).isEqualTo(0)
             assertThat(data.get().results).isEmpty()
             assertThat(data.get().lastGuessTime).isBefore(LocalDateTime.now())
 
@@ -97,6 +97,91 @@ class GameControllerTest : GameApiTestHelper() {
             memberRepository.save(player)
             callBaseballStart(2000)
                 .andExpect(status().isBadRequest)
+        }
+
+        @Test
+        fun `valid한 request면 guess는 성공해야 한다`() {
+            baseballService.initWhenNotExistGameMemberInfo(player)
+
+            val result = callBaseballGuess(
+                guessNumber = "1234", correctNumber = "1234", bettingPoint = 1000,
+                results = mutableListOf(StrikeBall(0, 0), StrikeBall(2, 2), StrikeBall(3, 0))
+            ).andExpect(status().isOk)
+                .andExpect(jsonPath("$.guessNumber").value("1234"))
+                .andExpect(jsonPath("$.result").isArray)
+                .andExpect(jsonPath("$.result[0]").exists())
+                .andExpect(jsonPath("$.earnedPoint").isNumber)
+
+            result.andDo(
+                document(
+                    "baseball-guess",
+                    requestCookies(
+                        cookieWithName(JwtType.ACCESS_TOKEN.tokenName).description("ACCESS TOKEN"),
+                        cookieWithName(JwtType.REFRESH_TOKEN.tokenName).description("REFRESH TOKEN")
+                    ),
+                    requestFields(
+                        fieldWithPath("guessNumber").description("추측한 숫자 (반드시 ${GUESS_NUMBER_LENGTH}자 여야 합니다)"),
+                    ),
+                    responseFields(
+                        fieldWithPath("guessNumber").description("사용자가 입력한 추측 숫자"),
+                        fieldWithPath("result").description("타임아웃난 round는 null"),
+                        fieldWithPath("result[].strike").description("strike"),
+                        fieldWithPath("result[].ball").description("ball"),
+                        fieldWithPath("earnedPoint").description("획득한 포인트 (마지막 게임이 아니면 0)"),
+                    ),
+                )
+            )
+        }
+
+        @Test
+        fun `guessNumber가 4자가 아니면 guess는 실패한다`() {
+            baseballService.initWhenNotExistGameMemberInfo(player)
+            callBaseballGuess(guessNumber = "123", correctNumber = "1234", bettingPoint = 1000)
+                .andExpect(status().isBadRequest)
+            callBaseballGuess(guessNumber = "12345", correctNumber = "1234", bettingPoint = 1000)
+                .andExpect(status().isBadRequest)
+        }
+
+        @Test
+        fun `맞췄으면 guess는 포인트를 부여해야 한다`() {
+            baseballService.initWhenNotExistGameMemberInfo(player)
+            val beforePlayerPoint = player.point
+
+            callBaseballGuess(
+                guessNumber = "1234", correctNumber = "1234", bettingPoint = 1000,
+                results = mutableListOf(StrikeBall(2, 2), null, StrikeBall(3, 0))
+            ).andExpect(status().isOk)
+
+            assertThat(beforePlayerPoint + 2000).isEqualTo(player.point)
+        }
+
+        @Test
+        fun `이미 맞췄으면 guess는 더이상 포인트 부여를 하지 않는다`() {
+            baseballService.initWhenNotExistGameMemberInfo(player)
+            val beforePlayerPoint = player.point
+
+            callBaseballGuess(
+                guessNumber = "1234", correctNumber = "1234", bettingPoint = 1000,
+                results = mutableListOf(StrikeBall(2, 2), null, StrikeBall(4, 0))
+            ).andExpect(status().isOk)
+
+            assertThat(beforePlayerPoint).isEqualTo(player.point)
+        }
+
+        @Test
+        fun `시도 회수를 초과했을 경우 guess는 더이상 포인트 부여를 하지 않는다`() {
+            baseballService.initWhenNotExistGameMemberInfo(player)
+            val beforePlayerPoint = player.point
+
+            callBaseballGuess(
+                guessNumber = "1234", correctNumber = "1234", bettingPoint = 1000,
+                results = mutableListOf(
+                    StrikeBall(2, 2), null, StrikeBall(4, 0),
+                    null, null, null, null, null, null
+                )
+            ).andExpect(status().isOk)
+
+            assertThat(beforePlayerPoint).isEqualTo(player.point)
         }
     }
 }

--- a/src/test/java/com/keeper/homepage/domain/game/api/GameControllerTest.kt
+++ b/src/test/java/com/keeper/homepage/domain/game/api/GameControllerTest.kt
@@ -39,7 +39,7 @@ class GameControllerTest : GameApiTestHelper() {
                     )
                 )
 
-            gameRepository.findAllByMember(player)
+            gameRepository.findByMember(player)
                 .get()
                 .baseball
                 .increaseBaseballTimes()
@@ -57,7 +57,7 @@ class GameControllerTest : GameApiTestHelper() {
             val result = callBaseballStart(1000)
                 .andExpect(status().isNoContent)
 
-            val baseball = gameRepository.findAllByMember(player).get().baseball
+            val baseball = gameRepository.findByMember(player).get().baseball
             assertThat(baseball.isAlreadyPlayed).isTrue() // 게임을 시작하면 play count가 증가한다.
             val data = redisUtil.getData(REDIS_KEY_PREFIX + player.id.toString(), BaseballResult::class.java)
             assertThat(data).isNotEmpty

--- a/src/test/java/com/keeper/homepage/domain/game/api/GameControllerTest.kt
+++ b/src/test/java/com/keeper/homepage/domain/game/api/GameControllerTest.kt
@@ -1,0 +1,100 @@
+package com.keeper.homepage.domain.game.api
+
+import com.keeper.homepage.domain.game.application.REDIS_KEY_PREFIX
+import com.keeper.homepage.domain.game.dto.BaseballResult
+import com.keeper.homepage.global.config.security.data.JwtType
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.springframework.restdocs.cookies.CookieDocumentation.cookieWithName
+import org.springframework.restdocs.cookies.CookieDocumentation.requestCookies
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document
+import org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath
+import org.springframework.restdocs.payload.PayloadDocumentation.requestFields
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.time.LocalDateTime
+
+class GameControllerTest : GameApiTestHelper() {
+
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    @Nested
+    inner class `야구 게임` {
+        @Test
+        fun `야구게임을 오늘 했으면 true 아니면 false가 나와야 한다`() {
+            callBaseballIsAlreadyPlayed()
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$").value(false))
+                .andDo(
+                    document(
+                        "baseball-is-already-played",
+                        requestCookies(
+                            cookieWithName(JwtType.ACCESS_TOKEN.tokenName).description("ACCESS TOKEN"),
+                            cookieWithName(JwtType.REFRESH_TOKEN.tokenName).description("REFRESH TOKEN")
+                        ),
+                    )
+                )
+
+            gameRepository.findAllByMember(player)
+                .get()
+                .baseball
+                .increaseBaseballTimes()
+
+            callBaseballIsAlreadyPlayed()
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$").value(true))
+        }
+
+        @Test
+        fun `베팅 포인트가 양수면 게임이 시작된다`() {
+            player.addPoint(1000)
+            memberRepository.save(player)
+
+            val result = callBaseballStart(1000)
+                .andExpect(status().isNoContent)
+
+            val baseball = gameRepository.findAllByMember(player).get().baseball
+            assertThat(baseball.isAlreadyPlayed).isTrue() // 게임을 시작하면 play count가 증가한다.
+            val data = redisUtil.getData(REDIS_KEY_PREFIX + player.id.toString(), BaseballResult::class.java)
+            assertThat(data).isNotEmpty
+            assertThat(data.get().bettingPoint).isEqualTo(1000)
+            assertThat(data.get().finalGetPoint).isEqualTo(0)
+            assertThat(data.get().results).isEmpty()
+            assertThat(data.get().lastGuessTime).isBefore(LocalDateTime.now())
+
+            result.andDo(
+                document(
+                    "baseball-start",
+                    requestCookies(
+                        cookieWithName(JwtType.ACCESS_TOKEN.tokenName).description("ACCESS TOKEN"),
+                        cookieWithName(JwtType.REFRESH_TOKEN.tokenName).description("REFRESH TOKEN")
+                    ),
+                    requestFields(
+                        fieldWithPath("bettingPoint").description("베팅을 할 포인트"),
+                    ),
+                )
+            )
+        }
+
+        @Test
+        fun `베팅 포인트가 음수거나 0이면 게임을 플레이 할 수 없다`() {
+            player.addPoint(1000)
+            memberRepository.save(player)
+            callBaseballStart(-1000)
+                .andExpect(status().isBadRequest)
+            callBaseballStart(0)
+                .andExpect(status().isBadRequest)
+        }
+
+        @Test
+        fun `베팅 포인트가 가지고 있는 포인트보다 적으면 플레이 할 수 없다`() {
+            player.addPoint(1000)
+            memberRepository.save(player)
+            callBaseballStart(2000)
+                .andExpect(status().isBadRequest)
+        }
+    }
+}

--- a/src/test/java/com/keeper/homepage/domain/game/api/GameControllerTest.kt
+++ b/src/test/java/com/keeper/homepage/domain/game/api/GameControllerTest.kt
@@ -60,6 +60,8 @@ class GameControllerTest : GameApiTestHelper() {
             assertThat(baseball.isAlreadyPlayed).isTrue() // 게임을 시작하면 play count가 증가한다.
             val data = redisUtil.getData(REDIS_KEY_PREFIX + player.id.toString(), BaseballResult::class.java)
             assertThat(data).isNotEmpty
+            assertThat(data.get().correctNumber).hasSize(4)
+            assertThat(data.get().correctNumber).containsOnlyDigits()
             assertThat(data.get().bettingPoint).isEqualTo(1000)
             assertThat(data.get().finalGetPoint).isEqualTo(0)
             assertThat(data.get().results).isEmpty()

--- a/src/test/java/com/keeper/homepage/domain/game/support/BaseballSupportTest.kt
+++ b/src/test/java/com/keeper/homepage/domain/game/support/BaseballSupportTest.kt
@@ -1,0 +1,101 @@
+package com.keeper.homepage.domain.game.support
+
+import com.keeper.homepage.domain.game.dto.BaseballResult
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import java.time.LocalDateTime
+import java.util.stream.Stream
+
+class BaseballSupportTest {
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    @Nested
+    inner class `timeout 테스트` {
+        @Test
+        fun `시간안에 플레이 했으면 null인 게임은 없어야 한다`() {
+            val results: MutableList<BaseballResult.StrikeBall?> = mutableListOf()
+            val lastGuessTime = LocalDateTime.now().minusSeconds(15)
+            BaseballSupport.updateTimeoutGames(results, lastGuessTime)
+            assertThat(results).hasSize(0)
+        }
+
+        @Test
+        fun `34초가 지난 후면 1게임은 null이 되어야 한다`() {
+            val results: MutableList<BaseballResult.StrikeBall?> = mutableListOf()
+            val lastGuessTime = LocalDateTime.now().minusSeconds(34)
+            BaseballSupport.updateTimeoutGames(results, lastGuessTime)
+            assertThat(results).hasSize(1)
+            assertThat(results[0]).isNull()
+        }
+
+        @Test
+        fun `100초가 지난 후면 3게임은 null이 되어야 한다`() {
+            val results: MutableList<BaseballResult.StrikeBall?> = mutableListOf()
+            val lastGuessTime = LocalDateTime.now().minusSeconds(100)
+            BaseballSupport.updateTimeoutGames(results, lastGuessTime)
+            assertThat(results).hasSize(3)
+            assertThat(results).containsExactly(null, null, null)
+        }
+
+        @Test
+        fun `300초가 지난 후면 9게임은 null이 되어야 한다`() {
+            val results: MutableList<BaseballResult.StrikeBall?> = mutableListOf()
+            val lastGuessTime = LocalDateTime.now().minusSeconds(300)
+            BaseballSupport.updateTimeoutGames(results, lastGuessTime)
+            assertThat(results).hasSize(9)
+            assertThat(results).containsExactly(null, null, null, null, null, null, null, null, null)
+        }
+
+        @Test
+        fun `1000초가 지났더라도 9게임만 null이 되어야 한다`() {
+            val results: MutableList<BaseballResult.StrikeBall?> = mutableListOf()
+            val lastGuessTime = LocalDateTime.now().minusSeconds(1000)
+            BaseballSupport.updateTimeoutGames(results, lastGuessTime)
+            assertThat(results).hasSize(9)
+            assertThat(results).containsExactly(null, null, null, null, null, null, null, null, null)
+        }
+    }
+
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    @Nested
+    inner class `guess 테스트` {
+        @ParameterizedTest
+        @MethodSource
+        fun `시간안에 플레이 했으면 null인 게임은 없어야 한다`(
+            correctNumber: String,
+            guessNumber: String,
+            expectedStrike: Int,
+            expectedBall: Int
+        ) {
+            val results: MutableList<BaseballResult.StrikeBall?> = mutableListOf()
+            BaseballSupport.updateResults(results, correctNumber, guessNumber)
+            assertThat(results).hasSize(1)
+            assertThat(results.last()!!.strike).isEqualTo(expectedStrike)
+            assertThat(results.last()!!.ball).isEqualTo(expectedBall)
+        }
+
+        fun `시간안에 플레이 했으면 null인 게임은 없어야 한다`() = Stream.of(
+            Arguments.arguments("1234", "1234", 4, 0),
+            Arguments.arguments("1234", "1256", 2, 0),
+            Arguments.arguments("1234", "4321", 0, 4),
+            Arguments.arguments("1234", "1432", 2, 2),
+            Arguments.arguments("1234", "9328", 0, 2),
+            Arguments.arguments("1234", "1423", 1, 3),
+            Arguments.arguments("1234", "5678", 0, 0),
+            Arguments.arguments("1234", "1567", 1, 0),
+        )
+
+        @Test
+        fun `guessNumber 길이가 4가 아니면 무의미한 결과를 줘야 한다`() {
+            val results: MutableList<BaseballResult.StrikeBall?> = mutableListOf()
+            BaseballSupport.updateResults(results, "1234", "456")
+            assertThat(results).hasSize(1)
+            assertThat(results.last()!!.strike).isEqualTo(0)
+            assertThat(results.last()!!.ball).isEqualTo(0)
+        }
+    }
+}

--- a/src/test/java/com/keeper/homepage/global/util/redis/RedisUtilTest.java
+++ b/src/test/java/com/keeper/homepage/global/util/redis/RedisUtilTest.java
@@ -1,0 +1,62 @@
+package com.keeper.homepage.global.util.redis;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.keeper.homepage.IntegrationTest;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class RedisUtilTest extends IntegrationTest {
+
+  @Test
+  @DisplayName("직렬화, 역직렬화가 잘 동작해야 한다.")
+  void should_serializeAndDeserializeIsOk() {
+    TestDto testDto = new TestDto(1, "AA");
+    redisUtil.setDataExpire("0", testDto, 10000);
+
+    Optional<TestDto> getTestDto = redisUtil.getData("0", TestDto.class);
+    assertThat(getTestDto).isNotEmpty();
+    assertThat(getTestDto.get().a).isEqualTo(1);
+    assertThat(getTestDto.get().b).isEqualTo("AA");
+
+    testDto.a = 2;
+    testDto.b = "BB";
+    redisUtil.setDataExpire("0", testDto, 10000); // testDto 갱신
+
+    Optional<TestDto> newTestDto = redisUtil.getData("0", TestDto.class);
+    assertThat(newTestDto).isNotEmpty();
+    assertThat(newTestDto.get().a).isEqualTo(2);
+    assertThat(newTestDto.get().b).isEqualTo("BB");
+  }
+
+  private static class TestDto {
+
+    private int a;
+    private String b;
+
+    private TestDto() {
+    }
+
+    public TestDto(int a, String b) {
+      this.a = a;
+      this.b = b;
+    }
+
+    public int getA() {
+      return a;
+    }
+
+    public String getB() {
+      return b;
+    }
+
+    public void setA(int a) {
+      this.a = a;
+    }
+
+    public void setB(String b) {
+      this.b = b;
+    }
+  }
+}

--- a/src/test/java/com/keeper/homepage/global/util/redis/RedisUtilTest.java
+++ b/src/test/java/com/keeper/homepage/global/util/redis/RedisUtilTest.java
@@ -17,8 +17,7 @@ class RedisUtilTest extends IntegrationTest {
 
     Optional<TestDto> getTestDto = redisUtil.getData("0", TestDto.class);
     assertThat(getTestDto).isNotEmpty();
-    assertThat(getTestDto.get().a).isEqualTo(1);
-    assertThat(getTestDto.get().b).isEqualTo("AA");
+    assertThat(getTestDto.get()).usingRecursiveComparison().isEqualTo(testDto);
 
     testDto.a = 2;
     testDto.b = "BB";


### PR DESCRIPTION
## 🔥 Related Issue

close: #179

## 📝 Description

프론트 사이드 프로젝트인 야구 게임을 위한 API를 추가해봤습니다.

한 게임마다 그 게임이 끝나기 전까진 계속해서 상태를 유지해야 하는데, 
우리 서버가 stateless한 구조를 가지고 있어서 어쩔 수 없이 야구 게임에 대한 유저 세션 정보는 레디스로 관리하도록 했습니당.

## ⭐️ Review

![image](https://github.com/KEEPER31337/Homepage-Back-R2/assets/26597702/0b307045-eeea-480e-9c08-fcd26a3ef67c)
