### PR TITLE
fix: api 문서 html 파일 안보이는 문제 해결

### DIFF
--- a/src/docs/asciidoc/keeper.adoc
+++ b/src/docs/asciidoc/keeper.adoc
@@ -35,7 +35,7 @@ link:seminar/seminar.html[API 문서 보기]
 
 == *LIBRARY API*
 
-link:library/book-manage[API 문서 보기]
+link:library/book-manage.html[API 문서 보기]
 
 == *STUDY API*
 

--- a/src/docs/asciidoc/seminar/seminar.adoc
+++ b/src/docs/asciidoc/seminar/seminar.adoc
@@ -181,4 +181,4 @@ include::{snippets}/delete-seminar/http-response.adoc[]
 
 == *세미나 출석*
 
-link:seminar-attendance.adoc[API 문서 보기]
+link:seminar-attendance.html[API 문서 보기]


### PR DESCRIPTION
## 🔥 Related Issue

close: 없음

## 📝 Description

api 문서의 html 파일이 안보이던 문제를 해결했습니다!

## ⭐️ Review

앞으로 문서 작성하실 때 요 부분 주의하시면 될 것 같아요 ㅎㅎ