### PR TITLE
Feature/#189 baseball response 스펙 변경

### DIFF
--- a/src/docs/asciidoc/game/baseball.adoc
+++ b/src/docs/asciidoc/game/baseball.adoc
@@ -88,12 +88,11 @@ NOTE: 타임아웃이 난 round가 있으면 아래와 같이 results 에 null�
 [source,json,options="nowrap"]
 ----
 {
-  "guessNumber" : "1234",
   "result" : [
-        {"strike" : 0, "ball" : 0},
+        { "guessNumber" : "1234", "strike" : 0, "ball" : 0 },
         null,
         null,
-        { "strike" : 4, "ball" : 0 }
+        { "guessNumber" : "5678", "strike" : 4, "ball" : 0 }
   ],
   "earnedPoint" : 2000
 }

--- a/src/main/java/com/keeper/homepage/domain/game/application/BaseballService.kt
+++ b/src/main/java/com/keeper/homepage/domain/game/application/BaseballService.kt
@@ -80,7 +80,7 @@ class BaseballService(
 
         val gameEntity = gameFindService.findByMemberOrInit(requestMember)
         if (baseballResult.results.size >= TRY_COUNT || isAlreadyCorrect(baseballResult)) {
-            return BaseballGuessResponse(guessNumber, baseballResult.results, gameEntity.baseball.baseballDayPoint)
+            return BaseballGuessResponse(baseballResult.results, gameEntity.baseball.baseballDayPoint)
         }
 
         val end = baseballResult.update(guessNumber)
@@ -90,7 +90,7 @@ class BaseballService(
         requestMember.addPoint(earnedPoint)
         gameEntity.baseball.baseballDayPoint = earnedPoint
 
-        return BaseballGuessResponse(guessNumber, baseballResult.results, earnedPoint)
+        return BaseballGuessResponse(baseballResult.results, earnedPoint)
     }
 
     private fun isAlreadyCorrect(baseballResult: BaseballResult): Boolean {
@@ -115,6 +115,6 @@ class BaseballService(
         baseballResult.updateTimeoutGames()
 
         val gameEntity = gameFindService.findByMemberOrInit(requestMember)
-        return BaseballGuessResponse("", baseballResult.results, gameEntity.baseball.baseballDayPoint)
+        return BaseballGuessResponse(baseballResult.results, gameEntity.baseball.baseballDayPoint)
     }
 }

--- a/src/main/java/com/keeper/homepage/domain/game/dto/BaseballResult.kt
+++ b/src/main/java/com/keeper/homepage/domain/game/dto/BaseballResult.kt
@@ -10,7 +10,7 @@ const val SECOND_PER_GAME = 30 // 시간제한: 30s
 class BaseballResult(
     val correctNumber: String,
     val bettingPoint: Int,
-    val results: MutableList<StrikeBall?> = mutableListOf()
+    val results: MutableList<GuessResult?> = mutableListOf()
 ) {
     var lastGuessTime: LocalDateTime = LocalDateTime.now()
 
@@ -29,7 +29,7 @@ class BaseballResult(
         return End.get(results.last())
     }
 
-    data class StrikeBall(val strike: Int, val ball: Int)
+    data class GuessResult(val guessNumber: String, val strike: Int, val ball: Int)
     enum class End {
         CORRECT {
             override fun getEarnedPoint(bettingPoint: Int): Int {
@@ -47,7 +47,7 @@ class BaseballResult(
         abstract fun getEarnedPoint(bettingPoint: Int): Int
 
         companion object {
-            fun get(last: StrikeBall?): End =
+            fun get(last: GuessResult?): End =
                 if (last == null) TIMEOUT
                 else if (last.strike == GUESS_NUMBER_LENGTH) CORRECT
                 else MISMATCH

--- a/src/main/java/com/keeper/homepage/domain/game/dto/req/BaseballGuessResponse.kt
+++ b/src/main/java/com/keeper/homepage/domain/game/dto/req/BaseballGuessResponse.kt
@@ -3,11 +3,10 @@ package com.keeper.homepage.domain.game.dto.req
 import com.keeper.homepage.domain.game.dto.BaseballResult
 
 data class BaseballGuessResponse(
-    val guessNumber: String,
-    val result: List<BaseballResult.StrikeBall?>,
+    val result: List<BaseballResult.GuessResult?>,
     val earnedPoint: Int,
 ) {
     companion object {
-        val EMPTY = BaseballGuessResponse("", listOf(), 0)
+        val EMPTY = BaseballGuessResponse(listOf(), 0)
     }
 }

--- a/src/main/java/com/keeper/homepage/domain/game/support/BaseballSupport.kt
+++ b/src/main/java/com/keeper/homepage/domain/game/support/BaseballSupport.kt
@@ -10,7 +10,7 @@ import java.time.ZoneOffset.UTC
 class BaseballSupport {
     companion object {
         fun updateTimeoutGames(
-            results: MutableList<BaseballResult.StrikeBall?>,
+            results: MutableList<BaseballResult.GuessResult?>,
             lastGuessTime: LocalDateTime,
         ) {
             val now = LocalDateTime.now()
@@ -24,25 +24,25 @@ class BaseballSupport {
         }
 
         fun updateResults(
-            results: MutableList<BaseballResult.StrikeBall?>,
+            results: MutableList<BaseballResult.GuessResult?>,
             correctNumber: String,
             guessNumber: String
         ) {
             if (guessNumber.length != GUESS_NUMBER_LENGTH) {
-                results.add(BaseballResult.StrikeBall(0, 0))
+                results.add(BaseballResult.GuessResult(guessNumber, 0, 0))
                 return
             }
             results.add(guess(correctNumber, guessNumber))
         }
 
-        private fun guess(correctNumber: String, guessNumber: String): BaseballResult.StrikeBall {
+        private fun guess(correctNumber: String, guessNumber: String): BaseballResult.GuessResult {
             var strike = 0
             var ball = 0
             for (i in guessNumber.indices) {
                 if (correctNumber[i] == guessNumber[i]) strike++
                 else if (correctNumber.contains(guessNumber[i])) ball++
             }
-            return BaseballResult.StrikeBall(strike, ball)
+            return BaseballResult.GuessResult(guessNumber, strike, ball)
         }
     }
 }

--- a/src/test/java/com/keeper/homepage/domain/game/api/GameApiTestHelper.kt
+++ b/src/test/java/com/keeper/homepage/domain/game/api/GameApiTestHelper.kt
@@ -58,7 +58,7 @@ class GameApiTestHelper : IntegrationTest() {
         guessNumber: String,
         correctNumber: String,
         bettingPoint: Int,
-        results: MutableList<BaseballResult.StrikeBall?> = mutableListOf(),
+        results: MutableList<BaseballResult.GuessResult?> = mutableListOf(),
         accessCookies: Array<Cookie> = playerCookies
     ): ResultActions {
         baseballService.saveBaseballResultInRedis(player.id, BaseballResult(correctNumber, bettingPoint, results))
@@ -71,7 +71,7 @@ class GameApiTestHelper : IntegrationTest() {
     }
 
     fun callGetBaseballResult(
-        results: MutableList<BaseballResult.StrikeBall?> = mutableListOf(),
+        results: MutableList<BaseballResult.GuessResult?> = mutableListOf(),
         accessCookies: Array<Cookie> = playerCookies
     ): ResultActions {
         baseballService.saveBaseballResultInRedis(player.id, BaseballResult("1234", 1000, results))

--- a/src/test/java/com/keeper/homepage/domain/game/support/BaseballSupportTest.kt
+++ b/src/test/java/com/keeper/homepage/domain/game/support/BaseballSupportTest.kt
@@ -1,6 +1,6 @@
 package com.keeper.homepage.domain.game.support
 
-import com.keeper.homepage.domain.game.dto.BaseballResult.StrikeBall
+import com.keeper.homepage.domain.game.dto.BaseballResult.GuessResult
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -17,7 +17,7 @@ class BaseballSupportTest {
     inner class `timeout 테스트` {
         @Test
         fun `시간안에 플레이 했으면 null인 게임은 없어야 한다`() {
-            val results: MutableList<StrikeBall?> = mutableListOf()
+            val results: MutableList<GuessResult?> = mutableListOf()
             val lastGuessTime = LocalDateTime.now().minusSeconds(15)
             BaseballSupport.updateTimeoutGames(results, lastGuessTime)
             assertThat(results).hasSize(0)
@@ -25,7 +25,7 @@ class BaseballSupportTest {
 
         @Test
         fun `34초가 지난 후면 1게임은 null이 되어야 한다`() {
-            val results: MutableList<StrikeBall?> = mutableListOf()
+            val results: MutableList<GuessResult?> = mutableListOf()
             val lastGuessTime = LocalDateTime.now().minusSeconds(34)
             BaseballSupport.updateTimeoutGames(results, lastGuessTime)
             assertThat(results).hasSize(1)
@@ -34,7 +34,7 @@ class BaseballSupportTest {
 
         @Test
         fun `90초가 지난 후면 3게임은 null이 되어야 한다`() {
-            val results: MutableList<StrikeBall?> = mutableListOf()
+            val results: MutableList<GuessResult?> = mutableListOf()
             val lastGuessTime = LocalDateTime.now().minusSeconds(90)
             BaseballSupport.updateTimeoutGames(results, lastGuessTime)
             assertThat(results).hasSize(3)
@@ -43,7 +43,7 @@ class BaseballSupportTest {
 
         @Test
         fun `92초가 지난 후면 3게임은 null이 되어야 한다`() {
-            val results: MutableList<StrikeBall?> = mutableListOf()
+            val results: MutableList<GuessResult?> = mutableListOf()
             val lastGuessTime = LocalDateTime.now().minusSeconds(92)
             BaseballSupport.updateTimeoutGames(results, lastGuessTime)
             assertThat(results).hasSize(3)
@@ -52,7 +52,7 @@ class BaseballSupportTest {
 
         @Test
         fun `300초가 지난 후면 9게임은 null이 되어야 한다`() {
-            val results: MutableList<StrikeBall?> = mutableListOf()
+            val results: MutableList<GuessResult?> = mutableListOf()
             val lastGuessTime = LocalDateTime.now().minusSeconds(300)
             BaseballSupport.updateTimeoutGames(results, lastGuessTime)
             assertThat(results).hasSize(9)
@@ -61,7 +61,7 @@ class BaseballSupportTest {
 
         @Test
         fun `1000초가 지났더라도 9게임만 null이 되어야 한다`() {
-            val results: MutableList<StrikeBall?> = mutableListOf()
+            val results: MutableList<GuessResult?> = mutableListOf()
             val lastGuessTime = LocalDateTime.now().minusSeconds(1000)
             BaseballSupport.updateTimeoutGames(results, lastGuessTime)
             assertThat(results).hasSize(9)
@@ -70,13 +70,13 @@ class BaseballSupportTest {
 
         @Test
         fun `기존에 플레이 하던 게임에서 1000초가 지났더라도 나머지 게임만 null이 되어야 한다`() {
-            val results: MutableList<StrikeBall?> = mutableListOf(StrikeBall(1, 2), StrikeBall(3, 1))
+            val results: MutableList<GuessResult?> = mutableListOf(GuessResult("1234", 1, 2), GuessResult("5678", 3, 1))
             val lastGuessTime = LocalDateTime.now().minusSeconds(1000)
             BaseballSupport.updateTimeoutGames(results, lastGuessTime)
             assertThat(results).hasSize(9)
             assertThat(results).containsExactly(
-                StrikeBall(1, 2),
-                StrikeBall(3, 1),
+                GuessResult("1234", 1, 2),
+                GuessResult("5678", 3, 1),
                 null, null, null, null,
                 null, null, null
             )
@@ -94,7 +94,7 @@ class BaseballSupportTest {
             expectedStrike: Int,
             expectedBall: Int
         ) {
-            val results: MutableList<StrikeBall?> = mutableListOf()
+            val results: MutableList<GuessResult?> = mutableListOf()
             BaseballSupport.updateResults(results, correctNumber, guessNumber)
             assertThat(results).hasSize(1)
             assertThat(results.last()!!.strike).isEqualTo(expectedStrike)
@@ -114,7 +114,7 @@ class BaseballSupportTest {
 
         @Test
         fun `guessNumber 길이가 4가 아니면 무의미한 결과를 줘야 한다`() {
-            val results: MutableList<StrikeBall?> = mutableListOf()
+            val results: MutableList<GuessResult?> = mutableListOf()
             BaseballSupport.updateResults(results, "1234", "456")
             assertThat(results).hasSize(1)
             assertThat(results.last()!!.strike).isEqualTo(0)


### PR DESCRIPTION
## 🔥 Related Issue

close: #189

## 📝 Description

guess number를 기록하고 싶다는 요청이 있어서 추가

마지막 `guessNumber`만 저장하던 response에서 매 guess 마다 `guessNumber`를 함께 저장

### AS-IS
```json
{
  "guessNumber" : "1234",
  "result" : [ {
    "strike" : 2,
    "ball" : 2
  },
     null,
  {
    "strike" : 1,
    "ball" : 0
  },
     null,
     null,
  {
    "strike" : 3,
    "ball" : 0
  } ],
  "earnedPoint" : 0
}
```

### TO-BE
```json
{
  "result" : [ {
    "guessNumber" : "1234",
    "strike" : 2,
    "ball" : 2
  },
     null,
  {
    "guessNumber" : "5678",
    "strike" : 1,
    "ball" : 0
  },
     null,
     null,
  {
    "guessNumber" : "1239",
    "strike" : 3,
    "ball" : 0
  } ],
  "earnedPoint" : 0
}
```

## ⭐️ Review

response 스펙만 봐주세용, guessNumber와 strike, ball은 맞지 않을 수도 있습니다 ㅎㅎ...