### PR TITLE
Feature/도서 대여 목록 조회 api

### DIFF
--- a/src/docs/asciidoc/library/book.adoc
+++ b/src/docs/asciidoc/library/book.adoc
@@ -60,3 +60,27 @@ include::{snippets}/request-book-borrow/path-parameters.adoc[]
 ==== Response
 
 include::{snippets}/request-book-borrow/http-response.adoc[]
+
+== *도서 대여 목록 조회*
+
+NOTE: 회원이 빌린 책 중 ``대출중``인 도서와 ``반납대기중``인 도서 대여 목록을 불러옵니다.
+
+=== 요청
+
+==== Request
+
+include::{snippets}/get-book-borrows/http-request.adoc[]
+
+==== Request Cookies
+
+include::{snippets}/get-book-borrows/request-cookies.adoc[]
+
+=== 응답
+
+==== Response
+
+include::{snippets}/get-book-borrows/http-response.adoc[]
+
+==== Response Fields
+
+include::{snippets}/get-book-borrows/response-fields.adoc[]

--- a/src/main/java/com/keeper/homepage/domain/library/api/BookController.java
+++ b/src/main/java/com/keeper/homepage/domain/library/api/BookController.java
@@ -2,9 +2,9 @@ package com.keeper.homepage.domain.library.api;
 
 import com.keeper.homepage.domain.library.application.BookService;
 import com.keeper.homepage.domain.library.dto.resp.BookResponse;
+import com.keeper.homepage.domain.library.dto.resp.BookBorrowResponse;
 import com.keeper.homepage.domain.member.entity.Member;
 import com.keeper.homepage.global.config.security.annotation.LoginMember;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PositiveOrZero;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -46,5 +46,14 @@ public class BookController {
     bookService.requestBorrow(member, bookId);
     return ResponseEntity.status(HttpStatus.CREATED)
         .build();
+  }
+
+  @GetMapping("/book-borrows")
+  public ResponseEntity<Page<BookBorrowResponse>> getBookBorrows(
+      @LoginMember Member member,
+      @RequestParam(defaultValue = "0") @PositiveOrZero int page,
+      @RequestParam(defaultValue = "10") @PositiveOrZero int size
+  ) {
+    return ResponseEntity.ok(bookService.getBookBorrows(member, PageRequest.of(page, size)));
   }
 }

--- a/src/main/java/com/keeper/homepage/domain/library/api/BookController.java
+++ b/src/main/java/com/keeper/homepage/domain/library/api/BookController.java
@@ -27,12 +27,13 @@ public class BookController {
 
   @GetMapping
   public ResponseEntity<Page<BookResponse>> getBooks(
+      @LoginMember Member member,
       @RequestParam(required = false) String searchType,
       @RequestParam(required = false) String search,
       @RequestParam(defaultValue = "0") @PositiveOrZero int page,
       @RequestParam(defaultValue = "10") @PositiveOrZero int size
   ) {
-    Page<BookResponse> listResponse = bookService.getBooks(searchType, search,
+    Page<BookResponse> listResponse = bookService.getBooks(member, searchType, search,
         PageRequest.of(page, size));
     return ResponseEntity.ok(listResponse);
   }

--- a/src/main/java/com/keeper/homepage/domain/library/application/BookService.java
+++ b/src/main/java/com/keeper/homepage/domain/library/application/BookService.java
@@ -13,6 +13,7 @@ import com.keeper.homepage.domain.library.dao.BookRepository;
 import com.keeper.homepage.domain.library.dto.resp.BookResponse;
 import com.keeper.homepage.domain.library.entity.Book;
 import com.keeper.homepage.domain.library.entity.BookBorrowInfo;
+import com.keeper.homepage.domain.library.dto.resp.BookBorrowResponse;
 import com.keeper.homepage.domain.member.entity.Member;
 import com.keeper.homepage.global.error.BusinessException;
 import java.util.Optional;
@@ -83,5 +84,10 @@ public class BookService {
     if (bookBorrowInfo.isPresent()) {
       throw new BusinessException(bookBorrowInfo.get().getId(), "bookBorrowInfoId", BORROW_REQUEST_ALREADY);
     }
+  }
+
+  public Page<BookBorrowResponse> getBookBorrows(Member member, PageRequest pageable) {
+    return bookBorrowInfoRepository.findAllByMemberAndInBorrowing(member, pageable)
+        .map(BookBorrowResponse::from);
   }
 }

--- a/src/main/java/com/keeper/homepage/domain/library/application/BookService.java
+++ b/src/main/java/com/keeper/homepage/domain/library/application/BookService.java
@@ -66,7 +66,7 @@ public class BookService {
 
   private void checkCountInBorrowing(Member member) {
     long countInBorrowing = member.getCountInBorrowing();
-    if (countInBorrowing == MAX_BORROWING_COUNT) {
+    if (countInBorrowing >= MAX_BORROWING_COUNT) {
       throw new BusinessException(countInBorrowing, "countInBorrowing", BOOK_BORROWING_COUNT_OVER);
     }
   }

--- a/src/main/java/com/keeper/homepage/domain/library/dao/BookBorrowInfoRepository.java
+++ b/src/main/java/com/keeper/homepage/domain/library/dao/BookBorrowInfoRepository.java
@@ -26,4 +26,12 @@ public interface BookBorrowInfoRepository extends JpaRepository<BookBorrowInfo, 
   Optional<BookBorrowInfo> findByMemberAndBook(Member member, Book book);
 
   Optional<BookBorrowInfo> findByMemberAndBookAndBorrowStatus(Member member, Book book, BookBorrowStatus borrowStatus);
+
+  @Query(value = "SELECT borrow "
+      + "FROM BookBorrowInfo borrow "
+      + "WHERE (borrow.borrowStatus.id = 3 " // 대출승인
+      + "OR borrow.borrowStatus.id = 4) " // 반납대기중
+      + "AND borrow.member = :member ")
+  Page<BookBorrowInfo> findAllByMemberAndInBorrowing(@Param("member") Member member, Pageable pageable);
+
 }

--- a/src/main/java/com/keeper/homepage/domain/library/dto/resp/BookBorrowResponse.java
+++ b/src/main/java/com/keeper/homepage/domain/library/dto/resp/BookBorrowResponse.java
@@ -1,0 +1,39 @@
+package com.keeper.homepage.domain.library.dto.resp;
+
+import static lombok.AccessLevel.PRIVATE;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.keeper.homepage.domain.library.entity.BookBorrowInfo;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = PRIVATE)
+public class BookBorrowResponse {
+
+  private Long borrowInfoId;
+  private String title;
+  private String author;
+  private boolean overdue;
+
+  @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+  private LocalDateTime borrowDate;
+
+  @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+  private LocalDateTime expireDate;
+
+  public static BookBorrowResponse from(BookBorrowInfo bookBorrowInfo) {
+    LocalDateTime now = LocalDateTime.now();
+    return BookBorrowResponse.builder()
+        .borrowInfoId(bookBorrowInfo.getId())
+        .title(bookBorrowInfo.getBook().getTitle())
+        .author(bookBorrowInfo.getBook().getAuthor())
+        .overdue(bookBorrowInfo.getExpireDate().isBefore(now))
+        .borrowDate(bookBorrowInfo.getBorrowDate())
+        .expireDate(bookBorrowInfo.getExpireDate())
+        .build();
+  }
+}

--- a/src/main/java/com/keeper/homepage/domain/library/dto/resp/BookResponse.java
+++ b/src/main/java/com/keeper/homepage/domain/library/dto/resp/BookResponse.java
@@ -27,7 +27,7 @@ public class BookResponse {
         .author(book.getAuthor())
         .currentQuantity(book.getCurrentQuantity())
         .totalQuantity(book.getTotalQuantity())
-        .canBorrow(book.getCurrentQuantity() != 0L && canBorrow)
+        .canBorrow(canBorrow)
         .build();
   }
 }

--- a/src/main/java/com/keeper/homepage/domain/library/dto/resp/BookResponse.java
+++ b/src/main/java/com/keeper/homepage/domain/library/dto/resp/BookResponse.java
@@ -17,8 +17,9 @@ public class BookResponse {
   private String author;
   private Long currentQuantity;
   private Long totalQuantity;
+  private boolean canBorrow;
 
-  public static BookResponse from(Book book) {
+  public static BookResponse of(Book book, boolean canBorrow) {
     return BookResponse.builder()
         .bookId(book.getId())
         .thumbnailPath(book.getThumbnailPath())
@@ -26,6 +27,7 @@ public class BookResponse {
         .author(book.getAuthor())
         .currentQuantity(book.getCurrentQuantity())
         .totalQuantity(book.getTotalQuantity())
+        .canBorrow(book.getCurrentQuantity() != 0L && canBorrow)
         .build();
   }
 }

--- a/src/test/java/com/keeper/homepage/domain/library/api/BookApiTestHelper.java
+++ b/src/test/java/com/keeper/homepage/domain/library/api/BookApiTestHelper.java
@@ -37,4 +37,22 @@ public class BookApiTestHelper extends IntegrationTest {
     return mockMvc.perform(post("/books/{bookId}/request-borrow", bookId)
         .cookie(new Cookie(ACCESS_TOKEN.getTokenName(), accessToken)));
   }
+
+  ResultActions callGetBorrowBooksApi(String accessToken, MultiValueMap<String, String> params)
+      throws Exception {
+    return mockMvc.perform(get("/books/book-borrows")
+        .params(params)
+        .cookie(new Cookie(ACCESS_TOKEN.getTokenName(), accessToken)));
+  }
+
+  FieldDescriptor[] getBorrowBooksResponse() {
+    return new FieldDescriptor[]{
+        fieldWithPath("borrowInfoId").description("빌린 전보 ID"),
+        fieldWithPath("title").description("빌린 책 이름"),
+        fieldWithPath("author").description("빌린 책 저자"),
+        fieldWithPath("overdue").description("연체 여부"),
+        fieldWithPath("borrowDate").description("빌린 날짜"),
+        fieldWithPath("expireDate").description("반납 날짜")
+    };
+  }
 }

--- a/src/test/java/com/keeper/homepage/domain/library/api/BookApiTestHelper.java
+++ b/src/test/java/com/keeper/homepage/domain/library/api/BookApiTestHelper.java
@@ -27,7 +27,8 @@ public class BookApiTestHelper extends IntegrationTest {
         fieldWithPath("title").description("책 이름"),
         fieldWithPath("author").description("책 저자"),
         fieldWithPath("currentQuantity").description("책 현재 수량"),
-        fieldWithPath("totalQuantity").description("책 전체 수량")
+        fieldWithPath("totalQuantity").description("책 전체 수량"),
+        fieldWithPath("canBorrow").description("책 대여 가능 여부")
     };
   }
 

--- a/src/test/java/com/keeper/homepage/domain/library/api/BookControllerTest.java
+++ b/src/test/java/com/keeper/homepage/domain/library/api/BookControllerTest.java
@@ -66,7 +66,8 @@ public class BookControllerTest extends BookApiTestHelper {
               ),
               queryParameters(
                   parameterWithName("searchType")
-                      .description("검색 타입 (title: 제목, author: 저자, all: 제목 + 저자, null : 전체 도서 목록 조회)")
+                      .attributes(new Attribute("format", "title: 제목, author: 저자, all: 제목 + 저자, null : 전체 도서 목록 조회"))
+                      .description("검색 타입")
                       .optional(),
                   parameterWithName("search").description("검색할 단어")
                       .optional(),

--- a/src/test/java/com/keeper/homepage/domain/library/application/BookServiceTest.java
+++ b/src/test/java/com/keeper/homepage/domain/library/application/BookServiceTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.keeper.homepage.IntegrationTest;
+import com.keeper.homepage.domain.library.dto.resp.BookResponse;
 import com.keeper.homepage.domain.library.entity.Book;
 import com.keeper.homepage.domain.member.entity.Member;
 import com.keeper.homepage.global.error.BusinessException;
@@ -16,9 +17,62 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 
 
 public class BookServiceTest extends IntegrationTest {
+
+  @Nested
+  @DisplayName("도서 목록 조회")
+  class GetBooks {
+
+    private Member member;
+    private Book book;
+
+    @BeforeEach
+    void setUp() {
+      member = memberTestHelper.generate();
+      book = bookTestHelper.generate();
+    }
+
+    @Test
+    @DisplayName("현재수량이 0이 아니고, 회원이 빌린 책의 개수가 5권 미만이면 도서 대여 가능 응답을 해야 한다.")
+    public void 현재수량이_0이_아니고_회원이_빌린_책의_개수가_5권_미만이면_도서_대여_가능_응답을_해야_한다() throws Exception {
+      Page<BookResponse> books = bookService.getBooks(member, null, null, PageRequest.of(0, 5));
+
+      assertThat(books.getContent().get(0).isCanBorrow()).isTrue();
+    }
+
+    @Test
+    @DisplayName("현재수량이 0이라면 도서 대여 불가능 응답을 해야 한다.")
+    public void 현재수량이_0이라면_도서_대여_불가능_응답을_해야_한다() throws Exception {
+      bookBorrowInfoTestHelper.builder().book(book).borrowStatus(getBookBorrowStatusBy(대출승인)).build();
+
+      Page<BookResponse> books = bookService.getBooks(member, null, null, PageRequest.of(0, 5));
+
+      assertThat(books.getContent().get(0).isCanBorrow()).isFalse();
+    }
+
+    @Test
+    @DisplayName("회원이 빌린 책의 개수가 5권이라면 도서 대여 불가능 응답을 해야 한다.")
+    public void 회원이_빌린_책의_개수가_5권이라면_도서_대여_불가능_응답을_해야_한다() throws Exception {
+      for (int i = 0; i < 5; i++) {
+        bookBorrowInfoTestHelper.builder()
+            .member(member)
+            .book(book)
+            .borrowStatus(getBookBorrowStatusBy(대출승인))
+            .build();
+      }
+      em.flush();
+      em.clear();
+      member = memberRepository.findById(member.getId()).get();
+
+      Page<BookResponse> books = bookService.getBooks(member, null, null, PageRequest.of(0, 5));
+
+      assertThat(books.getContent().get(0).isCanBorrow()).isFalse();
+    }
+  }
 
   @Nested
   @DisplayName("도서 대출 신청")

--- a/src/test/java/com/keeper/homepage/global/restdocs/RestDocsHelper.java
+++ b/src/test/java/com/keeper/homepage/global/restdocs/RestDocsHelper.java
@@ -57,7 +57,7 @@ public class RestDocsHelper {
     descriptorList.add(field("sort.sorted", "정렬이 되었는지"));
     descriptorList.add(field("sort.unsorted", "정렬이 되지 않았는지"));
     descriptorList.add(field("totalPages", "총 페이지 수"));
-    descriptorList.add(field("totalElements", "총 페이지 수"));
+    descriptorList.add(field("totalElements", "총 요소 수"));
     descriptorList.add(field("size", "한 페이지당 데이터 개수"));
     return descriptorList.toArray(new FieldDescriptor[0]);
   }


### PR DESCRIPTION
## 🔥 Related Issue

close: #194
close: #195

## 📝 Description

1. 도서 목록 조회 api의 응답으로 `canBorrow` 를 추가하였습니다!

<img width="877" alt="image" src="https://github.com/KEEPER31337/Homepage-Back-R2/assets/92802207/05fc4a37-d58d-4c5a-98ab-99582116549e">

요구사항을 보면 현재 책의 수량이 0인 경우 or 회원이 빌린 책의 개수가 5권일 경우는 false를 응답해야 합니다!

2. 도서 대여 목록 조회 api를 개발했습니다!

<img width="569" alt="image" src="https://github.com/KEEPER31337/Homepage-Back-R2/assets/92802207/02ca9bd7-c2cb-4f95-8caa-1c194d59c061">

api는 위 처럼 사용됩니다! 회원이 빌린 책의 개수 정보도 이 api에서 얻을 수 있습니다!