### PR TITLE
야구게임 추가요청사항 반영

### DIFF
--- a/src/docs/asciidoc/game/baseball.adoc
+++ b/src/docs/asciidoc/game/baseball.adoc
@@ -117,7 +117,7 @@ NOTE: 타임아웃이 난 round가 있으면 아래와 같이 results 에 null�
         null,
         { "guessNumber" : "5678", "strike" : 4, "ball" : 0 }
   ],
-  "earnedPoint" : 2000
+  "earnablePoints" : 2000
 }
 ----
 

--- a/src/docs/asciidoc/game/baseball.adoc
+++ b/src/docs/asciidoc/game/baseball.adoc
@@ -13,6 +13,28 @@ endif::[]
 
 link:./game.html[GAME API 목록으로 돌아가기]
 
+== *야구 게임 정보*
+
+=== 요청
+
+==== Request
+
+include::{snippets}/baseball-game-info/http-request.adoc[]
+
+==== Request Cookies
+
+include::{snippets}/baseball-game-info/request-cookies.adoc[]
+
+=== 응답
+
+==== Response
+
+include::{snippets}/baseball-game-info/http-response.adoc[]
+
+==== Response Fields
+
+include::{snippets}/baseball-game-info/response-fields.adoc[]
+
 == *플레이 했는지 확인하기*
 
 === 요청
@@ -85,6 +107,7 @@ include::{snippets}/baseball-guess/http-response.adoc[]
 include::{snippets}/baseball-guess/response-fields.adoc[]
 
 NOTE: 타임아웃이 난 round가 있으면 아래와 같이 results 에 null이 들어갑니다.
+
 [source,json,options="nowrap"]
 ----
 {

--- a/src/docs/asciidoc/game/baseball.adoc
+++ b/src/docs/asciidoc/game/baseball.adoc
@@ -111,7 +111,7 @@ NOTE: 타임아웃이 난 round가 있으면 아래와 같이 results 에 null�
 [source,json,options="nowrap"]
 ----
 {
-  "result" : [
+  "results" : [
         { "guessNumber" : "1234", "strike" : 0, "ball" : 0 },
         null,
         null,
@@ -127,18 +127,18 @@ NOTE: 타임아웃이 난 round가 있으면 아래와 같이 results 에 null�
 
 ==== Request
 
-include::{snippets}/get-baseball-result/http-request.adoc[]
+include::{snippets}/get-baseball-results/http-request.adoc[]
 
 ==== Request Cookies
 
-include::{snippets}/get-baseball-result/request-cookies.adoc[]
+include::{snippets}/get-baseball-results/request-cookies.adoc[]
 
 === 응답
 
 ==== Response
 
-include::{snippets}/get-baseball-result/http-response.adoc[]
+include::{snippets}/get-baseball-results/http-response.adoc[]
 
 ==== Response Fields
 
-include::{snippets}/get-baseball-result/response-fields.adoc[]
+include::{snippets}/get-baseball-results/response-fields.adoc[]

--- a/src/main/java/com/keeper/homepage/domain/game/api/GameController.kt
+++ b/src/main/java/com/keeper/homepage/domain/game/api/GameController.kt
@@ -2,8 +2,8 @@ package com.keeper.homepage.domain.game.api
 
 import com.keeper.homepage.domain.game.application.BaseballService
 import com.keeper.homepage.domain.game.dto.req.BaseballGuessRequest
-import com.keeper.homepage.domain.game.dto.res.BaseballGuessResponse
 import com.keeper.homepage.domain.game.dto.req.BaseballStartRequest
+import com.keeper.homepage.domain.game.dto.res.BaseballGuessResponse
 import com.keeper.homepage.domain.game.dto.res.GameInfoByMemberResponse
 import com.keeper.homepage.domain.member.entity.Member
 import com.keeper.homepage.global.config.security.annotation.LoginMember
@@ -40,13 +40,19 @@ class GameController(
         @LoginMember requestMember: Member,
         @RequestBody @Valid request: BaseballGuessRequest
     ): ResponseEntity<BaseballGuessResponse> {
-        return ResponseEntity.ok(baseballService.guess(requestMember, request.guessNumber))
+        val (results, earnablePoints) = baseballService.guess(requestMember, request.guessNumber)
+        return ResponseEntity.ok(BaseballGuessResponse(results.map { i ->
+            if (i == null) null else BaseballGuessResponse.GuessResultResponse(i)
+        }, earnablePoints))
     }
 
     @GetMapping("/baseball/result")
     fun getBaseballResult(
         @LoginMember requestMember: Member
     ): ResponseEntity<BaseballGuessResponse> {
-        return ResponseEntity.ok(baseballService.getResult(requestMember))
+        val (results, earnablePoints) = baseballService.getResult(requestMember)
+        return ResponseEntity.ok(BaseballGuessResponse(results.map { i ->
+            if (i == null) null else BaseballGuessResponse.GuessResultResponse(i)
+        }, earnablePoints))
     }
 }

--- a/src/main/java/com/keeper/homepage/domain/game/api/GameController.kt
+++ b/src/main/java/com/keeper/homepage/domain/game/api/GameController.kt
@@ -4,6 +4,7 @@ import com.keeper.homepage.domain.game.application.BaseballService
 import com.keeper.homepage.domain.game.dto.req.BaseballGuessRequest
 import com.keeper.homepage.domain.game.dto.req.BaseballGuessResponse
 import com.keeper.homepage.domain.game.dto.req.BaseballStartRequest
+import com.keeper.homepage.domain.game.dto.res.GameInfoByMemberResponse
 import com.keeper.homepage.domain.member.entity.Member
 import com.keeper.homepage.global.config.security.annotation.LoginMember
 import jakarta.validation.Valid
@@ -15,6 +16,11 @@ import org.springframework.web.bind.annotation.*
 class GameController(
     private val baseballService: BaseballService
 ) {
+    @GetMapping("/baseball/game-info")
+    fun baseballGameInfoByMember(): ResponseEntity<GameInfoByMemberResponse> {
+        return ResponseEntity.ok(baseballService.getBaseballGameInfoByMember())
+    }
+
     @GetMapping("/baseball/is-already-played")
     fun baseballIsAlreadyPlayed(@LoginMember requestMember: Member): ResponseEntity<Boolean> {
         return ResponseEntity.ok(baseballService.isAlreadyPlayed(requestMember))

--- a/src/main/java/com/keeper/homepage/domain/game/api/GameController.kt
+++ b/src/main/java/com/keeper/homepage/domain/game/api/GameController.kt
@@ -2,7 +2,7 @@ package com.keeper.homepage.domain.game.api
 
 import com.keeper.homepage.domain.game.application.BaseballService
 import com.keeper.homepage.domain.game.dto.req.BaseballGuessRequest
-import com.keeper.homepage.domain.game.dto.req.BaseballGuessResponse
+import com.keeper.homepage.domain.game.dto.res.BaseballGuessResponse
 import com.keeper.homepage.domain.game.dto.req.BaseballStartRequest
 import com.keeper.homepage.domain.game.dto.res.GameInfoByMemberResponse
 import com.keeper.homepage.domain.member.entity.Member

--- a/src/main/java/com/keeper/homepage/domain/game/api/GameController.kt
+++ b/src/main/java/com/keeper/homepage/domain/game/api/GameController.kt
@@ -3,7 +3,7 @@ package com.keeper.homepage.domain.game.api
 import com.keeper.homepage.domain.game.application.BaseballService
 import com.keeper.homepage.domain.game.dto.req.BaseballGuessRequest
 import com.keeper.homepage.domain.game.dto.req.BaseballStartRequest
-import com.keeper.homepage.domain.game.dto.res.BaseballGuessResponse
+import com.keeper.homepage.domain.game.dto.res.BaseballResponse
 import com.keeper.homepage.domain.game.dto.res.GameInfoByMemberResponse
 import com.keeper.homepage.domain.member.entity.Member
 import com.keeper.homepage.global.config.security.annotation.LoginMember
@@ -39,20 +39,20 @@ class GameController(
     fun baseballGuess(
         @LoginMember requestMember: Member,
         @RequestBody @Valid request: BaseballGuessRequest
-    ): ResponseEntity<BaseballGuessResponse> {
+    ): ResponseEntity<BaseballResponse> {
         val (results, earnablePoints) = baseballService.guess(requestMember, request.guessNumber)
-        return ResponseEntity.ok(BaseballGuessResponse(results.map { i ->
-            if (i == null) null else BaseballGuessResponse.GuessResultResponse(i)
+        return ResponseEntity.ok(BaseballResponse(results.map { i ->
+            if (i == null) null else BaseballResponse.GuessResultResponse(i)
         }, earnablePoints))
     }
 
     @GetMapping("/baseball/result")
     fun getBaseballResult(
         @LoginMember requestMember: Member
-    ): ResponseEntity<BaseballGuessResponse> {
+    ): ResponseEntity<BaseballResponse> {
         val (results, earnablePoints) = baseballService.getResult(requestMember)
-        return ResponseEntity.ok(BaseballGuessResponse(results.map { i ->
-            if (i == null) null else BaseballGuessResponse.GuessResultResponse(i)
+        return ResponseEntity.ok(BaseballResponse(results.map { i ->
+            if (i == null) null else BaseballResponse.GuessResultResponse(i)
         }, earnablePoints))
     }
 }

--- a/src/main/java/com/keeper/homepage/domain/game/application/BaseballService.kt
+++ b/src/main/java/com/keeper/homepage/domain/game/application/BaseballService.kt
@@ -1,7 +1,7 @@
 package com.keeper.homepage.domain.game.application
 
 import com.keeper.homepage.domain.game.dto.BaseballResult
-import com.keeper.homepage.domain.game.dto.req.BaseballGuessResponse
+import com.keeper.homepage.domain.game.dto.res.BaseballGuessResponse
 import com.keeper.homepage.domain.game.dto.res.GameInfoByMemberResponse
 import com.keeper.homepage.domain.member.entity.Member
 import com.keeper.homepage.global.error.BusinessException

--- a/src/main/java/com/keeper/homepage/domain/game/application/BaseballService.kt
+++ b/src/main/java/com/keeper/homepage/domain/game/application/BaseballService.kt
@@ -15,6 +15,8 @@ import java.time.temporal.ChronoUnit
 const val REDIS_KEY_PREFIX = "baseball_"
 const val GUESS_NUMBER_LENGTH = 4
 const val TRY_COUNT = 9
+const val MAX_BETTING_POINT = 1000L
+const val MIN_BETTING_POINT = 10L
 
 @Service
 @Transactional(readOnly = true)

--- a/src/main/java/com/keeper/homepage/domain/game/application/BaseballService.kt
+++ b/src/main/java/com/keeper/homepage/domain/game/application/BaseballService.kt
@@ -57,7 +57,8 @@ class BaseballService(
 
         val baseballResult = BaseballResult(
             correctNumber = generateDistinctRandomNumber(GUESS_NUMBER_LENGTH),
-            bettingPoint = bettingPoint
+            bettingPoint = bettingPoint,
+            earnablePoints = bettingPoint * 2 // TODO: 포인트 획득 전략 정해지면 다시 구현 (우선 처음엔 베팅포인트 * 2)
         )
         saveBaseballResultInRedis(requestMember.id, baseballResult)
     }
@@ -94,10 +95,10 @@ class BaseballService(
             return BaseballGuessResponse(baseballResult.results, gameEntity.baseball.baseballDayPoint)
         }
 
-        val end = baseballResult.update(guessNumber)
+        baseballResult.update(guessNumber)
         saveBaseballResultInRedis(requestMember.id, baseballResult)
 
-        val earnablePoints = end.getEarnablePoints(baseballResult.bettingPoint)
+        val earnablePoints = baseballResult.earnablePoints
         requestMember.addPoint(earnablePoints)
         gameEntity.baseball.baseballDayPoint = earnablePoints
 

--- a/src/main/java/com/keeper/homepage/domain/game/application/BaseballService.kt
+++ b/src/main/java/com/keeper/homepage/domain/game/application/BaseballService.kt
@@ -97,11 +97,11 @@ class BaseballService(
         val end = baseballResult.update(guessNumber)
         saveBaseballResultInRedis(requestMember.id, baseballResult)
 
-        val earnedPoint = end.getEarnedPoint(baseballResult.bettingPoint)
-        requestMember.addPoint(earnedPoint)
-        gameEntity.baseball.baseballDayPoint = earnedPoint
+        val earnablePoints = end.getEarnablePoints(baseballResult.bettingPoint)
+        requestMember.addPoint(earnablePoints)
+        gameEntity.baseball.baseballDayPoint = earnablePoints
 
-        return BaseballGuessResponse(baseballResult.results, earnedPoint)
+        return BaseballGuessResponse(baseballResult.results, earnablePoints)
     }
 
     private fun isAlreadyCorrect(baseballResult: BaseballResult): Boolean {

--- a/src/main/java/com/keeper/homepage/domain/game/application/BaseballService.kt
+++ b/src/main/java/com/keeper/homepage/domain/game/application/BaseballService.kt
@@ -2,6 +2,7 @@ package com.keeper.homepage.domain.game.application
 
 import com.keeper.homepage.domain.game.dto.BaseballResult
 import com.keeper.homepage.domain.game.dto.req.BaseballGuessResponse
+import com.keeper.homepage.domain.game.dto.res.GameInfoByMemberResponse
 import com.keeper.homepage.domain.member.entity.Member
 import com.keeper.homepage.global.error.BusinessException
 import com.keeper.homepage.global.error.ErrorCode
@@ -24,6 +25,14 @@ class BaseballService(
     val redisUtil: RedisUtil,
     val gameFindService: GameFindService
 ) {
+    fun getBaseballGameInfoByMember(): GameInfoByMemberResponse =
+        GameInfoByMemberResponse(
+            guessNumberLength = GUESS_NUMBER_LENGTH,
+            tryCount = TRY_COUNT,
+            maxBettingPoint = MAX_BETTING_POINT,
+            minBettingPoint = MIN_BETTING_POINT,
+        )
+
     fun isAlreadyPlayed(requestMember: Member): Boolean {
         return gameFindService.findByMemberOrInit(requestMember)
             .baseball

--- a/src/main/java/com/keeper/homepage/domain/game/application/BaseballService.kt
+++ b/src/main/java/com/keeper/homepage/domain/game/application/BaseballService.kt
@@ -1,6 +1,5 @@
 package com.keeper.homepage.domain.game.application
 
-import com.keeper.homepage.domain.game.dto.res.BaseballGuessResponse
 import com.keeper.homepage.domain.game.dto.res.GameInfoByMemberResponse
 import com.keeper.homepage.domain.game.entity.redis.BaseballResultEntity
 import com.keeper.homepage.domain.member.entity.Member

--- a/src/main/java/com/keeper/homepage/domain/game/application/BaseballService.kt
+++ b/src/main/java/com/keeper/homepage/domain/game/application/BaseballService.kt
@@ -90,7 +90,7 @@ class BaseballService(
         ).orElseThrow { throw BusinessException(requestMember.id, "memberId", ErrorCode.NOT_PLAYED_YET) }
 
         val gameEntity = gameFindService.findByMemberOrInit(requestMember)
-        if (baseballResultEntity.results.size >= TRY_COUNT || isAlreadyCorrect(baseballResultEntity)) {
+        if (baseballResultEntity.results.size >= TRY_COUNT || baseballResultEntity.isAlreadyCorrect()) {
             return Pair(baseballResultEntity.results, gameEntity.baseball.baseballDayPoint)
         }
 
@@ -102,16 +102,6 @@ class BaseballService(
         gameEntity.baseball.baseballDayPoint = earnablePoints
 
         return Pair(baseballResultEntity.results, earnablePoints)
-    }
-
-    private fun isAlreadyCorrect(baseballResultEntity: BaseballResultEntity): Boolean {
-        if (baseballResultEntity.results.isEmpty()) {
-            return false
-        }
-        if (baseballResultEntity.results.last() == null) {
-            return false
-        }
-        return baseballResultEntity.results.last()!!.strike == GUESS_NUMBER_LENGTH
     }
 
     fun getResult(requestMember: Member): Pair<List<BaseballResultEntity.GuessResultEntity?>, Int> {

--- a/src/main/java/com/keeper/homepage/domain/game/dto/BaseballResult.kt
+++ b/src/main/java/com/keeper/homepage/domain/game/dto/BaseballResult.kt
@@ -1,5 +1,6 @@
 package com.keeper.homepage.domain.game.dto
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import com.keeper.homepage.domain.game.application.GUESS_NUMBER_LENGTH
 import com.keeper.homepage.domain.game.application.TRY_COUNT
 import com.keeper.homepage.domain.game.support.BaseballSupport
@@ -10,47 +11,51 @@ const val SECOND_PER_GAME = 30 // 시간제한: 30s
 class BaseballResult(
     val correctNumber: String,
     val bettingPoint: Int,
-    val results: MutableList<GuessResult?> = mutableListOf()
+    val results: MutableList<GuessResult?> = mutableListOf(),
+    var earnablePoints: Int,
 ) {
     var lastGuessTime: LocalDateTime = LocalDateTime.now()
 
-    fun updateTimeoutGames() = BaseballSupport.updateTimeoutGames(results, lastGuessTime)
-
-    /**
-     * @return: 4스트라이크나 timeout으로 게임이 끝났는지 여부
-     */
-    fun update(guessNumber: String): End {
-        updateTimeoutGames()
-        lastGuessTime = LocalDateTime.now()
-        if (results.size >= TRY_COUNT) {
-            return End.TIMEOUT
-        }
-        BaseballSupport.updateResults(results, correctNumber, guessNumber)
-        return End.get(results.last())
+    fun updateTimeoutGames() {
+        val passedGameCount = BaseballSupport.getPassedGameCount(results.size, lastGuessTime)
+        (1..passedGameCount).forEach { _ -> if (results.size < TRY_COUNT) results.add(null) }
+        updateEarnablePointsByTimeoutGames(passedGameCount)
     }
 
-    data class GuessResult(val guessNumber: String, val strike: Int, val ball: Int)
-    enum class End {
-        CORRECT {
-            override fun getEarnablePoints(bettingPoint: Int): Int {
-                // TODO 정답 시 포인트 부여 어떻게 할 지 기획 나오면 다시 로직 작성
-                return bettingPoint * 2
-            }
-        },
-        TIMEOUT {
-            override fun getEarnablePoints(bettingPoint: Int): Int = 0
-        },
-        MISMATCH {
-            override fun getEarnablePoints(bettingPoint: Int): Int = 0
-        };
-
-        abstract fun getEarnablePoints(bettingPoint: Int): Int
-
-        companion object {
-            fun get(last: GuessResult?): End =
-                if (last == null) TIMEOUT
-                else if (last.strike == GUESS_NUMBER_LENGTH) CORRECT
-                else MISMATCH
+    private fun updateEarnablePointsByTimeoutGames(passedGameCount: Int) {
+        (1..passedGameCount).forEach { _ ->
+            // TODO: 포인트 획득 전략 정해지면 다시 구현
+            this.earnablePoints -= this.earnablePoints / 10
         }
+    }
+
+    fun update(guessNumber: String) {
+        if (isAlreadyCorrect()) {
+            return
+        }
+        updateTimeoutGames()
+        if (results.size >= TRY_COUNT) {
+            return
+        }
+        lastGuessTime = LocalDateTime.now()
+        val result = BaseballSupport.guessAndGetResult(correctNumber, guessNumber)
+        updateEarnedPointsByResult(result)
+        results.add(result)
+    }
+
+    private fun isAlreadyCorrect(): Boolean {
+        return results.isNotEmpty() && results.last() != null && results.last()!!.isCorrect()
+    }
+
+    private fun updateEarnedPointsByResult(result: GuessResult) {
+        if (result.isCorrect()) {
+            return
+        }
+        this.earnablePoints -= this.earnablePoints / 10
+    }
+
+    data class GuessResult(val guessNumber: String, val strike: Int, val ball: Int) {
+        @JsonIgnore
+        fun isCorrect() = this.strike == GUESS_NUMBER_LENGTH
     }
 }

--- a/src/main/java/com/keeper/homepage/domain/game/dto/BaseballResult.kt
+++ b/src/main/java/com/keeper/homepage/domain/game/dto/BaseballResult.kt
@@ -32,19 +32,19 @@ class BaseballResult(
     data class GuessResult(val guessNumber: String, val strike: Int, val ball: Int)
     enum class End {
         CORRECT {
-            override fun getEarnedPoint(bettingPoint: Int): Int {
+            override fun getEarnablePoints(bettingPoint: Int): Int {
                 // TODO 정답 시 포인트 부여 어떻게 할 지 기획 나오면 다시 로직 작성
                 return bettingPoint * 2
             }
         },
         TIMEOUT {
-            override fun getEarnedPoint(bettingPoint: Int): Int = 0
+            override fun getEarnablePoints(bettingPoint: Int): Int = 0
         },
         MISMATCH {
-            override fun getEarnedPoint(bettingPoint: Int): Int = 0
+            override fun getEarnablePoints(bettingPoint: Int): Int = 0
         };
 
-        abstract fun getEarnedPoint(bettingPoint: Int): Int
+        abstract fun getEarnablePoints(bettingPoint: Int): Int
 
         companion object {
             fun get(last: GuessResult?): End =

--- a/src/main/java/com/keeper/homepage/domain/game/dto/req/BaseballGuessResponse.kt
+++ b/src/main/java/com/keeper/homepage/domain/game/dto/req/BaseballGuessResponse.kt
@@ -4,7 +4,7 @@ import com.keeper.homepage.domain.game.dto.BaseballResult
 
 data class BaseballGuessResponse(
     val result: List<BaseballResult.GuessResult?>,
-    val earnedPoint: Int,
+    val earnablePoints: Int,
 ) {
     companion object {
         val EMPTY = BaseballGuessResponse(listOf(), 0)

--- a/src/main/java/com/keeper/homepage/domain/game/dto/req/BaseballStartRequest.kt
+++ b/src/main/java/com/keeper/homepage/domain/game/dto/req/BaseballStartRequest.kt
@@ -1,12 +1,15 @@
 package com.keeper.homepage.domain.game.dto.req
 
 import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.Positive
 
-const val MAX_TITLE_LENGTH = 10000L
+const val MAX_BETTING_POINT = 1000L
+const val MIN_BETTING_POINT = 10L
 
 data class BaseballStartRequest(
     @field:Positive
-    @field:Max(MAX_TITLE_LENGTH)
+    @field:Max(MAX_BETTING_POINT)
+    @field:Min(MIN_BETTING_POINT)
     val bettingPoint: Int,
 )

--- a/src/main/java/com/keeper/homepage/domain/game/dto/req/BaseballStartRequest.kt
+++ b/src/main/java/com/keeper/homepage/domain/game/dto/req/BaseballStartRequest.kt
@@ -1,11 +1,10 @@
 package com.keeper.homepage.domain.game.dto.req
 
+import com.keeper.homepage.domain.game.application.MAX_BETTING_POINT
+import com.keeper.homepage.domain.game.application.MIN_BETTING_POINT
 import jakarta.validation.constraints.Max
 import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.Positive
-
-const val MAX_BETTING_POINT = 1000L
-const val MIN_BETTING_POINT = 10L
 
 data class BaseballStartRequest(
     @field:Positive

--- a/src/main/java/com/keeper/homepage/domain/game/dto/res/BaseballGuessResponse.kt
+++ b/src/main/java/com/keeper/homepage/domain/game/dto/res/BaseballGuessResponse.kt
@@ -1,4 +1,4 @@
-package com.keeper.homepage.domain.game.dto.req
+package com.keeper.homepage.domain.game.dto.res
 
 import com.keeper.homepage.domain.game.dto.BaseballResult
 

--- a/src/main/java/com/keeper/homepage/domain/game/dto/res/BaseballGuessResponse.kt
+++ b/src/main/java/com/keeper/homepage/domain/game/dto/res/BaseballGuessResponse.kt
@@ -3,10 +3,14 @@ package com.keeper.homepage.domain.game.dto.res
 import com.keeper.homepage.domain.game.entity.redis.BaseballResultEntity
 
 data class BaseballGuessResponse(
-    val result: List<BaseballResultEntity.GuessResult?>,
+    val result: List<GuessResultResponse?>,
     val earnablePoints: Int,
 ) {
-    companion object {
-        val EMPTY = BaseballGuessResponse(listOf(), 0)
+    data class GuessResultResponse(val guessNumber: String, val strike: Int, val ball: Int) {
+        constructor(guessResultEntity: BaseballResultEntity.GuessResultEntity) : this(
+            guessNumber = guessResultEntity.guessNumber,
+            strike = guessResultEntity.strike,
+            ball = guessResultEntity.ball,
+        )
     }
 }

--- a/src/main/java/com/keeper/homepage/domain/game/dto/res/BaseballGuessResponse.kt
+++ b/src/main/java/com/keeper/homepage/domain/game/dto/res/BaseballGuessResponse.kt
@@ -1,9 +1,9 @@
 package com.keeper.homepage.domain.game.dto.res
 
-import com.keeper.homepage.domain.game.dto.BaseballResult
+import com.keeper.homepage.domain.game.entity.redis.BaseballResultEntity
 
 data class BaseballGuessResponse(
-    val result: List<BaseballResult.GuessResult?>,
+    val result: List<BaseballResultEntity.GuessResult?>,
     val earnablePoints: Int,
 ) {
     companion object {

--- a/src/main/java/com/keeper/homepage/domain/game/dto/res/BaseballResponse.kt
+++ b/src/main/java/com/keeper/homepage/domain/game/dto/res/BaseballResponse.kt
@@ -2,8 +2,8 @@ package com.keeper.homepage.domain.game.dto.res
 
 import com.keeper.homepage.domain.game.entity.redis.BaseballResultEntity
 
-data class BaseballGuessResponse(
-    val result: List<GuessResultResponse?>,
+data class BaseballResponse(
+    val results: List<GuessResultResponse?>,
     val earnablePoints: Int,
 ) {
     data class GuessResultResponse(val guessNumber: String, val strike: Int, val ball: Int) {

--- a/src/main/java/com/keeper/homepage/domain/game/dto/res/GameInfoByMemberResponse.kt
+++ b/src/main/java/com/keeper/homepage/domain/game/dto/res/GameInfoByMemberResponse.kt
@@ -1,0 +1,8 @@
+package com.keeper.homepage.domain.game.dto.res
+
+data class GameInfoByMemberResponse(
+    val guessNumberLength: Int,
+    val tryCount: Int,
+    val maxBettingPoint: Long,
+    val minBettingPoint: Long,
+)

--- a/src/main/java/com/keeper/homepage/domain/game/entity/redis/BaseballResultEntity.kt
+++ b/src/main/java/com/keeper/homepage/domain/game/entity/redis/BaseballResultEntity.kt
@@ -1,4 +1,4 @@
-package com.keeper.homepage.domain.game.dto
+package com.keeper.homepage.domain.game.entity.redis
 
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.keeper.homepage.domain.game.application.GUESS_NUMBER_LENGTH
@@ -8,7 +8,7 @@ import java.time.LocalDateTime
 
 const val SECOND_PER_GAME = 30 // 시간제한: 30s
 
-class BaseballResult(
+class BaseballResultEntity(
     val correctNumber: String,
     val bettingPoint: Int,
     val results: MutableList<GuessResult?> = mutableListOf(),

--- a/src/main/java/com/keeper/homepage/domain/game/entity/redis/BaseballResultEntity.kt
+++ b/src/main/java/com/keeper/homepage/domain/game/entity/redis/BaseballResultEntity.kt
@@ -43,7 +43,7 @@ class BaseballResultEntity(
         results.add(result)
     }
 
-    private fun isAlreadyCorrect(): Boolean {
+    fun isAlreadyCorrect(): Boolean {
         return results.isNotEmpty() && results.last() != null && results.last()!!.isCorrect()
     }
 

--- a/src/main/java/com/keeper/homepage/domain/game/entity/redis/BaseballResultEntity.kt
+++ b/src/main/java/com/keeper/homepage/domain/game/entity/redis/BaseballResultEntity.kt
@@ -11,7 +11,7 @@ const val SECOND_PER_GAME = 30 // 시간제한: 30s
 class BaseballResultEntity(
     val correctNumber: String,
     val bettingPoint: Int,
-    val results: MutableList<GuessResult?> = mutableListOf(),
+    val results: MutableList<GuessResultEntity?> = mutableListOf(),
     var earnablePoints: Int,
 ) {
     var lastGuessTime: LocalDateTime = LocalDateTime.now()
@@ -47,15 +47,14 @@ class BaseballResultEntity(
         return results.isNotEmpty() && results.last() != null && results.last()!!.isCorrect()
     }
 
-    private fun updateEarnedPointsByResult(result: GuessResult) {
+    private fun updateEarnedPointsByResult(result: GuessResultEntity) {
         if (result.isCorrect()) {
             return
         }
         this.earnablePoints -= this.earnablePoints / 10
     }
 
-    data class GuessResult(val guessNumber: String, val strike: Int, val ball: Int) {
-        @JsonIgnore
+    data class GuessResultEntity(val guessNumber: String, val strike: Int, val ball: Int) {
         fun isCorrect() = this.strike == GUESS_NUMBER_LENGTH
     }
 }

--- a/src/main/java/com/keeper/homepage/domain/game/support/BaseballSupport.kt
+++ b/src/main/java/com/keeper/homepage/domain/game/support/BaseballSupport.kt
@@ -2,8 +2,8 @@ package com.keeper.homepage.domain.game.support
 
 import com.keeper.homepage.domain.game.application.GUESS_NUMBER_LENGTH
 import com.keeper.homepage.domain.game.application.TRY_COUNT
-import com.keeper.homepage.domain.game.dto.BaseballResult
-import com.keeper.homepage.domain.game.dto.SECOND_PER_GAME
+import com.keeper.homepage.domain.game.entity.redis.BaseballResultEntity
+import com.keeper.homepage.domain.game.entity.redis.SECOND_PER_GAME
 import java.time.LocalDateTime
 import java.time.ZoneOffset.UTC
 
@@ -27,21 +27,21 @@ class BaseballSupport {
         fun guessAndGetResult(
             correctNumber: String,
             guessNumber: String
-        ): BaseballResult.GuessResult {
+        ): BaseballResultEntity.GuessResult {
             if (guessNumber.length != GUESS_NUMBER_LENGTH) {
-                return BaseballResult.GuessResult(guessNumber, 0, 0)
+                return BaseballResultEntity.GuessResult(guessNumber, 0, 0)
             }
             return guess(correctNumber, guessNumber)
         }
 
-        private fun guess(correctNumber: String, guessNumber: String): BaseballResult.GuessResult {
+        private fun guess(correctNumber: String, guessNumber: String): BaseballResultEntity.GuessResult {
             var strike = 0
             var ball = 0
             for (i in guessNumber.indices) {
                 if (correctNumber[i] == guessNumber[i]) strike++
                 else if (correctNumber.contains(guessNumber[i])) ball++
             }
-            return BaseballResult.GuessResult(guessNumber, strike, ball)
+            return BaseballResultEntity.GuessResult(guessNumber, strike, ball)
         }
     }
 }

--- a/src/main/java/com/keeper/homepage/domain/game/support/BaseballSupport.kt
+++ b/src/main/java/com/keeper/homepage/domain/game/support/BaseballSupport.kt
@@ -9,30 +9,29 @@ import java.time.ZoneOffset.UTC
 
 class BaseballSupport {
     companion object {
-        fun updateTimeoutGames(
-            results: MutableList<BaseballResult.GuessResult?>,
+        fun getPassedGameCount(
+            playedRoundCount: Int,
             lastGuessTime: LocalDateTime,
-        ) {
+        ): Int {
             val now = LocalDateTime.now()
             val passedSecond = now.toEpochSecond(UTC) - lastGuessTime.toEpochSecond(UTC)
             // 마지막으로 플레이 한 시간이 너무 오래 지나 list에 너무 많은 값이 들어가는걸 방지
             val passedGameCount = passedSecond / SECOND_PER_GAME
-            val finallyPassedGameCount = if (passedGameCount < TRY_COUNT) passedGameCount.toInt() else TRY_COUNT
-            if (passedSecond > SECOND_PER_GAME) {
-                (1..finallyPassedGameCount).forEach { _ -> if (results.size < TRY_COUNT) results.add(null) }
+            return if (passedGameCount < TRY_COUNT - playedRoundCount) {
+                passedGameCount.toInt()
+            } else {
+                TRY_COUNT - playedRoundCount
             }
         }
 
-        fun updateResults(
-            results: MutableList<BaseballResult.GuessResult?>,
+        fun guessAndGetResult(
             correctNumber: String,
             guessNumber: String
-        ) {
+        ): BaseballResult.GuessResult {
             if (guessNumber.length != GUESS_NUMBER_LENGTH) {
-                results.add(BaseballResult.GuessResult(guessNumber, 0, 0))
-                return
+                return BaseballResult.GuessResult(guessNumber, 0, 0)
             }
-            results.add(guess(correctNumber, guessNumber))
+            return guess(correctNumber, guessNumber)
         }
 
         private fun guess(correctNumber: String, guessNumber: String): BaseballResult.GuessResult {

--- a/src/main/java/com/keeper/homepage/domain/game/support/BaseballSupport.kt
+++ b/src/main/java/com/keeper/homepage/domain/game/support/BaseballSupport.kt
@@ -27,21 +27,21 @@ class BaseballSupport {
         fun guessAndGetResult(
             correctNumber: String,
             guessNumber: String
-        ): BaseballResultEntity.GuessResult {
+        ): BaseballResultEntity.GuessResultEntity {
             if (guessNumber.length != GUESS_NUMBER_LENGTH) {
-                return BaseballResultEntity.GuessResult(guessNumber, 0, 0)
+                return BaseballResultEntity.GuessResultEntity(guessNumber, 0, 0)
             }
             return guess(correctNumber, guessNumber)
         }
 
-        private fun guess(correctNumber: String, guessNumber: String): BaseballResultEntity.GuessResult {
+        private fun guess(correctNumber: String, guessNumber: String): BaseballResultEntity.GuessResultEntity {
             var strike = 0
             var ball = 0
             for (i in guessNumber.indices) {
                 if (correctNumber[i] == guessNumber[i]) strike++
                 else if (correctNumber.contains(guessNumber[i])) ball++
             }
-            return BaseballResultEntity.GuessResult(guessNumber, strike, ball)
+            return BaseballResultEntity.GuessResultEntity(guessNumber, strike, ball)
         }
     }
 }

--- a/src/test/java/com/keeper/homepage/domain/game/api/GameApiTestHelper.kt
+++ b/src/test/java/com/keeper/homepage/domain/game/api/GameApiTestHelper.kt
@@ -68,9 +68,10 @@ class GameApiTestHelper : IntegrationTest() {
         correctNumber: String,
         bettingPoint: Int,
         results: MutableList<BaseballResult.GuessResult?> = mutableListOf(),
+        earnablePoints: Int = 1000,
         accessCookies: Array<Cookie> = playerCookies
     ): ResultActions {
-        baseballService.saveBaseballResultInRedis(player.id, BaseballResult(correctNumber, bettingPoint, results))
+        baseballService.saveBaseballResultInRedis(player.id, BaseballResult(correctNumber, bettingPoint, results, earnablePoints))
         return mockMvc.perform(
             post("$GAME_URL/baseball/guess")
                 .content(asJsonString(BaseballGuessRequest(guessNumber)))
@@ -81,9 +82,10 @@ class GameApiTestHelper : IntegrationTest() {
 
     fun callGetBaseballResult(
         results: MutableList<BaseballResult.GuessResult?> = mutableListOf(),
+        earnablePoints: Int = 1000,
         accessCookies: Array<Cookie> = playerCookies
     ): ResultActions {
-        baseballService.saveBaseballResultInRedis(player.id, BaseballResult("1234", 1000, results))
+        baseballService.saveBaseballResultInRedis(player.id, BaseballResult("1234", 1000, results, earnablePoints))
         return mockMvc.perform(
             get("$GAME_URL/baseball/result")
                 .cookie(*accessCookies)

--- a/src/test/java/com/keeper/homepage/domain/game/api/GameApiTestHelper.kt
+++ b/src/test/java/com/keeper/homepage/domain/game/api/GameApiTestHelper.kt
@@ -67,7 +67,7 @@ class GameApiTestHelper : IntegrationTest() {
         guessNumber: String,
         correctNumber: String,
         bettingPoint: Int,
-        results: MutableList<BaseballResultEntity.GuessResult?> = mutableListOf(),
+        results: MutableList<BaseballResultEntity.GuessResultEntity?> = mutableListOf(),
         earnablePoints: Int = 1000,
         accessCookies: Array<Cookie> = playerCookies
     ): ResultActions {
@@ -81,7 +81,7 @@ class GameApiTestHelper : IntegrationTest() {
     }
 
     fun callGetBaseballResult(
-        results: MutableList<BaseballResultEntity.GuessResult?> = mutableListOf(),
+        results: MutableList<BaseballResultEntity.GuessResultEntity?> = mutableListOf(),
         earnablePoints: Int = 1000,
         accessCookies: Array<Cookie> = playerCookies
     ): ResultActions {

--- a/src/test/java/com/keeper/homepage/domain/game/api/GameApiTestHelper.kt
+++ b/src/test/java/com/keeper/homepage/domain/game/api/GameApiTestHelper.kt
@@ -1,7 +1,7 @@
 package com.keeper.homepage.domain.game.api
 
 import com.keeper.homepage.IntegrationTest
-import com.keeper.homepage.domain.game.dto.BaseballResult
+import com.keeper.homepage.domain.game.entity.redis.BaseballResultEntity
 import com.keeper.homepage.domain.game.dto.req.BaseballGuessRequest
 import com.keeper.homepage.domain.game.dto.req.BaseballStartRequest
 import com.keeper.homepage.domain.member.entity.Member
@@ -67,11 +67,11 @@ class GameApiTestHelper : IntegrationTest() {
         guessNumber: String,
         correctNumber: String,
         bettingPoint: Int,
-        results: MutableList<BaseballResult.GuessResult?> = mutableListOf(),
+        results: MutableList<BaseballResultEntity.GuessResult?> = mutableListOf(),
         earnablePoints: Int = 1000,
         accessCookies: Array<Cookie> = playerCookies
     ): ResultActions {
-        baseballService.saveBaseballResultInRedis(player.id, BaseballResult(correctNumber, bettingPoint, results, earnablePoints))
+        baseballService.saveBaseballResultInRedis(player.id, BaseballResultEntity(correctNumber, bettingPoint, results, earnablePoints))
         return mockMvc.perform(
             post("$GAME_URL/baseball/guess")
                 .content(asJsonString(BaseballGuessRequest(guessNumber)))
@@ -81,11 +81,11 @@ class GameApiTestHelper : IntegrationTest() {
     }
 
     fun callGetBaseballResult(
-        results: MutableList<BaseballResult.GuessResult?> = mutableListOf(),
+        results: MutableList<BaseballResultEntity.GuessResult?> = mutableListOf(),
         earnablePoints: Int = 1000,
         accessCookies: Array<Cookie> = playerCookies
     ): ResultActions {
-        baseballService.saveBaseballResultInRedis(player.id, BaseballResult("1234", 1000, results, earnablePoints))
+        baseballService.saveBaseballResultInRedis(player.id, BaseballResultEntity("1234", 1000, results, earnablePoints))
         return mockMvc.perform(
             get("$GAME_URL/baseball/result")
                 .cookie(*accessCookies)

--- a/src/test/java/com/keeper/homepage/domain/game/api/GameApiTestHelper.kt
+++ b/src/test/java/com/keeper/homepage/domain/game/api/GameApiTestHelper.kt
@@ -33,6 +33,15 @@ class GameApiTestHelper : IntegrationTest() {
         redisUtil.flushAll()
     }
 
+    fun callBaseballGameInfo(
+        accessCookies: Array<Cookie> = playerCookies
+    ): ResultActions {
+        return mockMvc.perform(
+            get("$GAME_URL/baseball/game-info")
+                .cookie(*accessCookies)
+        )
+    }
+
     fun callBaseballIsAlreadyPlayed(
         accessCookies: Array<Cookie> = playerCookies
     ): ResultActions {

--- a/src/test/java/com/keeper/homepage/domain/game/api/GameControllerTest.kt
+++ b/src/test/java/com/keeper/homepage/domain/game/api/GameControllerTest.kt
@@ -146,10 +146,14 @@ class GameControllerTest : GameApiTestHelper() {
         fun `valid한 request면 guess는 성공해야 한다`() {
             val result = callBaseballGuess(
                 guessNumber = "1234", correctNumber = "1234", bettingPoint = 1000,
-                results = mutableListOf(GuessResultEntity("1357", 0, 0), GuessResultEntity("2468", 2, 2), GuessResultEntity("7890", 3, 0))
+                results = mutableListOf(
+                    GuessResultEntity("1357", 0, 0),
+                    GuessResultEntity("2468", 2, 2),
+                    GuessResultEntity("7890", 3, 0)
+                )
             ).andExpect(status().isOk)
-                .andExpect(jsonPath("$.result").isArray)
-                .andExpect(jsonPath("$.result[0]").exists())
+                .andExpect(jsonPath("$.results").isArray)
+                .andExpect(jsonPath("$.results[0]").exists())
                 .andExpect(jsonPath("$.earnablePoints").isNumber)
 
             result.andDo(
@@ -163,10 +167,10 @@ class GameControllerTest : GameApiTestHelper() {
                         fieldWithPath("guessNumber").description("추측한 숫자 (반드시 ${GUESS_NUMBER_LENGTH}자 여야 합니다)"),
                     ),
                     responseFields(
-                        fieldWithPath("result").description("타임아웃난 round는 null"),
-                        fieldWithPath("result[].guessNumber").description("해당 라운드에 사용자가 입력한 추측 숫자"),
-                        fieldWithPath("result[].strike").description("strike"),
-                        fieldWithPath("result[].ball").description("ball"),
+                        fieldWithPath("results").description("타임아웃난 round는 null"),
+                        fieldWithPath("results[].guessNumber").description("해당 라운드에 사용자가 입력한 추측 숫자"),
+                        fieldWithPath("results[].strike").description("strike"),
+                        fieldWithPath("results[].ball").description("ball"),
                         fieldWithPath("earnablePoints").description("획득한 포인트 (마지막 게임이 아니면 0)"),
                     ),
                 )
@@ -234,7 +238,7 @@ class GameControllerTest : GameApiTestHelper() {
             ).andDo(MockMvcResultHandlers.print())
                 .andExpect(status().isOk)
                 .andExpect(
-                    jsonPath("$.result[0]").value(
+                    jsonPath("$.results[0]").value(
                         linkedMapOf(
                             "guessNumber" to "1234",
                             "strike" to 2,
@@ -242,9 +246,9 @@ class GameControllerTest : GameApiTestHelper() {
                         )
                     )
                 )
-                .andExpect(jsonPath("$.result[1]").value(null))
+                .andExpect(jsonPath("$.results[1]").value(null))
                 .andExpect(
-                    jsonPath("$.result[2]").value(
+                    jsonPath("$.results[2]").value(
                         linkedMapOf(
                             "guessNumber" to "3456",
                             "strike" to 1,
@@ -252,10 +256,10 @@ class GameControllerTest : GameApiTestHelper() {
                         )
                     )
                 )
-                .andExpect(jsonPath("$.result[3]").value(null))
-                .andExpect(jsonPath("$.result[4]").value(null))
+                .andExpect(jsonPath("$.results[3]").value(null))
+                .andExpect(jsonPath("$.results[4]").value(null))
                 .andExpect(
-                    jsonPath("$.result[5]").value(
+                    jsonPath("$.results[5]").value(
                         linkedMapOf(
                             "guessNumber" to "5678",
                             "strike" to 3,
@@ -266,13 +270,13 @@ class GameControllerTest : GameApiTestHelper() {
                 .andExpect(jsonPath("$.earnablePoints").value(0))
                 .andDo(
                     document(
-                        "get-baseball-result",
+                        "get-baseball-results",
                         requestCookies(
                             cookieWithName(JwtType.ACCESS_TOKEN.tokenName).description("ACCESS TOKEN"),
                             cookieWithName(JwtType.REFRESH_TOKEN.tokenName).description("REFRESH TOKEN")
                         ),
                         responseFields(
-                            subsectionWithPath("result").description("타임아웃난 round는 null"),
+                            subsectionWithPath("results").description("타임아웃난 round는 null"),
                             fieldWithPath("earnablePoints").description("획득한 포인트 (오늘 끝낸 게임이 아니면 0)"),
                         ),
                     )

--- a/src/test/java/com/keeper/homepage/domain/game/api/GameControllerTest.kt
+++ b/src/test/java/com/keeper/homepage/domain/game/api/GameControllerTest.kt
@@ -1,11 +1,11 @@
 package com.keeper.homepage.domain.game.api
 
 import com.keeper.homepage.domain.game.application.GUESS_NUMBER_LENGTH
+import com.keeper.homepage.domain.game.application.MAX_BETTING_POINT
+import com.keeper.homepage.domain.game.application.MIN_BETTING_POINT
 import com.keeper.homepage.domain.game.application.REDIS_KEY_PREFIX
 import com.keeper.homepage.domain.game.dto.BaseballResult
 import com.keeper.homepage.domain.game.dto.BaseballResult.GuessResult
-import com.keeper.homepage.domain.game.application.MAX_BETTING_POINT
-import com.keeper.homepage.domain.game.application.MIN_BETTING_POINT
 import com.keeper.homepage.global.config.security.data.JwtType
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
@@ -25,6 +25,32 @@ class GameControllerTest : GameApiTestHelper() {
     @TestInstance(TestInstance.Lifecycle.PER_CLASS)
     @Nested
     inner class `야구 게임` {
+        @Test
+        fun `야구게임 정보를 불러온다`() {
+            callBaseballGameInfo()
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.guessNumberLength").value(4))
+                .andExpect(jsonPath("$.tryCount").value(9))
+                .andExpect(jsonPath("$.maxBettingPoint").value(1000L))
+                .andExpect(jsonPath("$.minBettingPoint").value(10L))
+                .andDo(
+                    document(
+                        "baseball-game-info",
+                        requestCookies(
+                            cookieWithName(JwtType.ACCESS_TOKEN.tokenName).description("ACCESS TOKEN"),
+                            cookieWithName(JwtType.REFRESH_TOKEN.tokenName).description("REFRESH TOKEN")
+                        ),
+                        responseFields(
+                            fieldWithPath("guessNumberLength").description("추측할 숫자 길이"),
+                            fieldWithPath("tryCount").description("라운드 수"),
+                            fieldWithPath("maxBettingPoint").description("최대 베팅 포인트"),
+                            fieldWithPath("minBettingPoint").description("최소 베팅 포인트"),
+
+                            )
+                    )
+                )
+        }
+
         @Test
         fun `야구게임을 오늘 안했으면 false가 나와야 한다`() {
             callBaseballIsAlreadyPlayed()

--- a/src/test/java/com/keeper/homepage/domain/game/api/GameControllerTest.kt
+++ b/src/test/java/com/keeper/homepage/domain/game/api/GameControllerTest.kt
@@ -4,8 +4,8 @@ import com.keeper.homepage.domain.game.application.GUESS_NUMBER_LENGTH
 import com.keeper.homepage.domain.game.application.REDIS_KEY_PREFIX
 import com.keeper.homepage.domain.game.dto.BaseballResult
 import com.keeper.homepage.domain.game.dto.BaseballResult.GuessResult
-import com.keeper.homepage.domain.game.dto.req.MAX_BETTING_POINT
-import com.keeper.homepage.domain.game.dto.req.MIN_BETTING_POINT
+import com.keeper.homepage.domain.game.application.MAX_BETTING_POINT
+import com.keeper.homepage.domain.game.application.MIN_BETTING_POINT
 import com.keeper.homepage.global.config.security.data.JwtType
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested

--- a/src/test/java/com/keeper/homepage/domain/game/api/GameControllerTest.kt
+++ b/src/test/java/com/keeper/homepage/domain/game/api/GameControllerTest.kt
@@ -5,7 +5,7 @@ import com.keeper.homepage.domain.game.application.MAX_BETTING_POINT
 import com.keeper.homepage.domain.game.application.MIN_BETTING_POINT
 import com.keeper.homepage.domain.game.application.REDIS_KEY_PREFIX
 import com.keeper.homepage.domain.game.entity.redis.BaseballResultEntity
-import com.keeper.homepage.domain.game.entity.redis.BaseballResultEntity.GuessResult
+import com.keeper.homepage.domain.game.entity.redis.BaseballResultEntity.GuessResultEntity
 import com.keeper.homepage.global.config.security.data.JwtType
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
@@ -146,7 +146,7 @@ class GameControllerTest : GameApiTestHelper() {
         fun `valid한 request면 guess는 성공해야 한다`() {
             val result = callBaseballGuess(
                 guessNumber = "1234", correctNumber = "1234", bettingPoint = 1000,
-                results = mutableListOf(GuessResult("1357", 0, 0), GuessResult("2468", 2, 2), GuessResult("7890", 3, 0))
+                results = mutableListOf(GuessResultEntity("1357", 0, 0), GuessResultEntity("2468", 2, 2), GuessResultEntity("7890", 3, 0))
             ).andExpect(status().isOk)
                 .andExpect(jsonPath("$.result").isArray)
                 .andExpect(jsonPath("$.result[0]").exists())
@@ -188,7 +188,7 @@ class GameControllerTest : GameApiTestHelper() {
 
             callBaseballGuess(
                 guessNumber = "1234", correctNumber = "1234", bettingPoint = 1000, earnablePoints = earnablePoints,
-                results = mutableListOf(GuessResult("1234", 2, 2), null, GuessResult("5678", 3, 0))
+                results = mutableListOf(GuessResultEntity("1234", 2, 2), null, GuessResultEntity("5678", 3, 0))
             ).andExpect(status().isOk)
 
             assertThat(beforePlayerPoint + earnablePoints).isEqualTo(player.point)
@@ -200,7 +200,7 @@ class GameControllerTest : GameApiTestHelper() {
 
             callBaseballGuess(
                 guessNumber = "1234", correctNumber = "1234", bettingPoint = 1000,
-                results = mutableListOf(GuessResult("1234", 2, 2), null, GuessResult("5678", 4, 0))
+                results = mutableListOf(GuessResultEntity("1234", 2, 2), null, GuessResultEntity("5678", 4, 0))
             ).andExpect(status().isOk)
 
             assertThat(beforePlayerPoint).isEqualTo(player.point)
@@ -213,7 +213,7 @@ class GameControllerTest : GameApiTestHelper() {
             callBaseballGuess(
                 guessNumber = "1234", correctNumber = "1234", bettingPoint = 1000,
                 results = mutableListOf(
-                    GuessResult("1234", 2, 2), null, GuessResult("5678", 4, 0),
+                    GuessResultEntity("1234", 2, 2), null, GuessResultEntity("5678", 4, 0),
                     null, null, null, null, null, null
                 )
             ).andExpect(status().isOk)
@@ -227,9 +227,9 @@ class GameControllerTest : GameApiTestHelper() {
 
             callGetBaseballResult(
                 results = mutableListOf(
-                    GuessResult("1234", 2, 2),
-                    null, GuessResult("3456", 1, 0),
-                    null, null, GuessResult("5678", 3, 0)
+                    GuessResultEntity("1234", 2, 2),
+                    null, GuessResultEntity("3456", 1, 0),
+                    null, null, GuessResultEntity("5678", 3, 0)
                 )
             ).andDo(MockMvcResultHandlers.print())
                 .andExpect(status().isOk)

--- a/src/test/java/com/keeper/homepage/domain/game/api/GameControllerTest.kt
+++ b/src/test/java/com/keeper/homepage/domain/game/api/GameControllerTest.kt
@@ -182,15 +182,16 @@ class GameControllerTest : GameApiTestHelper() {
         }
 
         @Test
-        fun `맞췄으면 guess는 포인트를 부여해야 한다`() {
+        fun `맞췄으면 guess는 earnablePoints만큼 포인트를 부여해야 한다`() {
             val beforePlayerPoint = player.point
+            val earnablePoints = 3000
 
             callBaseballGuess(
-                guessNumber = "1234", correctNumber = "1234", bettingPoint = 1000,
+                guessNumber = "1234", correctNumber = "1234", bettingPoint = 1000, earnablePoints = earnablePoints,
                 results = mutableListOf(GuessResult("1234", 2, 2), null, GuessResult("5678", 3, 0))
             ).andExpect(status().isOk)
 
-            assertThat(beforePlayerPoint + 2000).isEqualTo(player.point)
+            assertThat(beforePlayerPoint + earnablePoints).isEqualTo(player.point)
         }
 
         @Test

--- a/src/test/java/com/keeper/homepage/domain/game/api/GameControllerTest.kt
+++ b/src/test/java/com/keeper/homepage/domain/game/api/GameControllerTest.kt
@@ -150,7 +150,7 @@ class GameControllerTest : GameApiTestHelper() {
             ).andExpect(status().isOk)
                 .andExpect(jsonPath("$.result").isArray)
                 .andExpect(jsonPath("$.result[0]").exists())
-                .andExpect(jsonPath("$.earnedPoint").isNumber)
+                .andExpect(jsonPath("$.earnablePoints").isNumber)
 
             result.andDo(
                 document(
@@ -167,7 +167,7 @@ class GameControllerTest : GameApiTestHelper() {
                         fieldWithPath("result[].guessNumber").description("해당 라운드에 사용자가 입력한 추측 숫자"),
                         fieldWithPath("result[].strike").description("strike"),
                         fieldWithPath("result[].ball").description("ball"),
-                        fieldWithPath("earnedPoint").description("획득한 포인트 (마지막 게임이 아니면 0)"),
+                        fieldWithPath("earnablePoints").description("획득한 포인트 (마지막 게임이 아니면 0)"),
                     ),
                 )
             )
@@ -262,7 +262,7 @@ class GameControllerTest : GameApiTestHelper() {
                         )
                     )
                 )
-                .andExpect(jsonPath("$.earnedPoint").value(0))
+                .andExpect(jsonPath("$.earnablePoints").value(0))
                 .andDo(
                     document(
                         "get-baseball-result",
@@ -272,7 +272,7 @@ class GameControllerTest : GameApiTestHelper() {
                         ),
                         responseFields(
                             subsectionWithPath("result").description("타임아웃난 round는 null"),
-                            fieldWithPath("earnedPoint").description("획득한 포인트 (오늘 끝낸 게임이 아니면 0)"),
+                            fieldWithPath("earnablePoints").description("획득한 포인트 (오늘 끝낸 게임이 아니면 0)"),
                         ),
                     )
                 )

--- a/src/test/java/com/keeper/homepage/domain/game/api/GameControllerTest.kt
+++ b/src/test/java/com/keeper/homepage/domain/game/api/GameControllerTest.kt
@@ -4,8 +4,8 @@ import com.keeper.homepage.domain.game.application.GUESS_NUMBER_LENGTH
 import com.keeper.homepage.domain.game.application.MAX_BETTING_POINT
 import com.keeper.homepage.domain.game.application.MIN_BETTING_POINT
 import com.keeper.homepage.domain.game.application.REDIS_KEY_PREFIX
-import com.keeper.homepage.domain.game.dto.BaseballResult
-import com.keeper.homepage.domain.game.dto.BaseballResult.GuessResult
+import com.keeper.homepage.domain.game.entity.redis.BaseballResultEntity
+import com.keeper.homepage.domain.game.entity.redis.BaseballResultEntity.GuessResult
 import com.keeper.homepage.global.config.security.data.JwtType
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
@@ -87,7 +87,7 @@ class GameControllerTest : GameApiTestHelper() {
 
             val baseball = gameFindService.findByMemberOrInit(player).baseball
             assertThat(baseball.isAlreadyPlayed).isTrue() // 게임을 시작하면 play count가 증가한다.
-            val data = redisUtil.getData(REDIS_KEY_PREFIX + player.id.toString(), BaseballResult::class.java)
+            val data = redisUtil.getData(REDIS_KEY_PREFIX + player.id.toString(), BaseballResultEntity::class.java)
             assertThat(data).isNotEmpty
             assertThat(data.get().correctNumber).hasSize(4)
             assertThat(data.get().correctNumber).containsOnlyDigits()

--- a/src/test/java/com/keeper/homepage/domain/game/support/BaseballSupportTest.kt
+++ b/src/test/java/com/keeper/homepage/domain/game/support/BaseballSupportTest.kt
@@ -1,6 +1,6 @@
 package com.keeper.homepage.domain.game.support
 
-import com.keeper.homepage.domain.game.entity.redis.BaseballResultEntity.GuessResult
+import com.keeper.homepage.domain.game.entity.redis.BaseballResultEntity.GuessResultEntity
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -59,7 +59,7 @@ class BaseballSupportTest {
 
         @Test
         fun `2게임을 플레이했으면 1000초가 지났더라도 7 게임만 pass 되어야 한다`() {
-            val results: MutableList<GuessResult?> = mutableListOf(GuessResult("1234", 1, 2), GuessResult("5678", 3, 1))
+            val results: MutableList<GuessResultEntity?> = mutableListOf(GuessResultEntity("1234", 1, 2), GuessResultEntity("5678", 3, 1))
             val lastGuessTime = LocalDateTime.now().minusSeconds(1000)
             val passedGameCount = BaseballSupport.getPassedGameCount(results.size, lastGuessTime)
             assertThat(passedGameCount).isEqualTo(7)

--- a/src/test/java/com/keeper/homepage/domain/game/support/BaseballSupportTest.kt
+++ b/src/test/java/com/keeper/homepage/domain/game/support/BaseballSupportTest.kt
@@ -1,6 +1,6 @@
 package com.keeper.homepage.domain.game.support
 
-import com.keeper.homepage.domain.game.dto.BaseballResult.GuessResult
+import com.keeper.homepage.domain.game.entity.redis.BaseballResultEntity.GuessResult
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test

--- a/src/test/java/com/keeper/homepage/domain/game/support/BaseballSupportTest.kt
+++ b/src/test/java/com/keeper/homepage/domain/game/support/BaseballSupportTest.kt
@@ -16,70 +16,53 @@ class BaseballSupportTest {
     @Nested
     inner class `timeout 테스트` {
         @Test
-        fun `시간안에 플레이 했으면 null인 게임은 없어야 한다`() {
-            val results: MutableList<GuessResult?> = mutableListOf()
+        fun `시간안에 플레이 했으면 pass한 게임은 없어야 한다`() {
             val lastGuessTime = LocalDateTime.now().minusSeconds(15)
-            BaseballSupport.updateTimeoutGames(results, lastGuessTime)
-            assertThat(results).hasSize(0)
+            val passedGameCount = BaseballSupport.getPassedGameCount(0, lastGuessTime)
+            assertThat(passedGameCount).isEqualTo(0)
         }
 
         @Test
-        fun `34초가 지난 후면 1게임은 null이 되어야 한다`() {
-            val results: MutableList<GuessResult?> = mutableListOf()
+        fun `34초가 지난 후면 1게임은 pass한 게임이어야 한다`() {
             val lastGuessTime = LocalDateTime.now().minusSeconds(34)
-            BaseballSupport.updateTimeoutGames(results, lastGuessTime)
-            assertThat(results).hasSize(1)
-            assertThat(results[0]).isNull()
+            val passedGameCount = BaseballSupport.getPassedGameCount(0, lastGuessTime)
+            assertThat(passedGameCount).isEqualTo(1)
         }
 
         @Test
-        fun `90초가 지난 후면 3게임은 null이 되어야 한다`() {
-            val results: MutableList<GuessResult?> = mutableListOf()
+        fun `90초가 지난 후면 3게임은 pass한 게임이어야 한다`() {
             val lastGuessTime = LocalDateTime.now().minusSeconds(90)
-            BaseballSupport.updateTimeoutGames(results, lastGuessTime)
-            assertThat(results).hasSize(3)
-            assertThat(results).containsExactly(null, null, null)
+            val passedGameCount = BaseballSupport.getPassedGameCount(0, lastGuessTime)
+            assertThat(passedGameCount).isEqualTo(3)
         }
 
         @Test
-        fun `92초가 지난 후면 3게임은 null이 되어야 한다`() {
-            val results: MutableList<GuessResult?> = mutableListOf()
+        fun `92초가 지난 후면 3게임은 pass한 게임이어야 한다`() {
             val lastGuessTime = LocalDateTime.now().minusSeconds(92)
-            BaseballSupport.updateTimeoutGames(results, lastGuessTime)
-            assertThat(results).hasSize(3)
-            assertThat(results).containsExactly(null, null, null)
+            val passedGameCount = BaseballSupport.getPassedGameCount(0, lastGuessTime)
+            assertThat(passedGameCount).isEqualTo(3)
         }
 
         @Test
-        fun `300초가 지난 후면 9게임은 null이 되어야 한다`() {
-            val results: MutableList<GuessResult?> = mutableListOf()
+        fun `300초가 지난 후면 9게임은 pass한 게임이어야 한다`() {
             val lastGuessTime = LocalDateTime.now().minusSeconds(300)
-            BaseballSupport.updateTimeoutGames(results, lastGuessTime)
-            assertThat(results).hasSize(9)
-            assertThat(results).containsExactly(null, null, null, null, null, null, null, null, null)
+            val passedGameCount = BaseballSupport.getPassedGameCount(0, lastGuessTime)
+            assertThat(passedGameCount).isEqualTo(9)
         }
 
         @Test
-        fun `1000초가 지났더라도 9게임만 null이 되어야 한다`() {
-            val results: MutableList<GuessResult?> = mutableListOf()
+        fun `1000초가 지났더라도 9게임만 pass한 게임이어야 한다`() {
             val lastGuessTime = LocalDateTime.now().minusSeconds(1000)
-            BaseballSupport.updateTimeoutGames(results, lastGuessTime)
-            assertThat(results).hasSize(9)
-            assertThat(results).containsExactly(null, null, null, null, null, null, null, null, null)
+            val passedGameCount = BaseballSupport.getPassedGameCount(0, lastGuessTime)
+            assertThat(passedGameCount).isEqualTo(9)
         }
 
         @Test
-        fun `기존에 플레이 하던 게임에서 1000초가 지났더라도 나머지 게임만 null이 되어야 한다`() {
+        fun `2게임을 플레이했으면 1000초가 지났더라도 7 게임만 pass 되어야 한다`() {
             val results: MutableList<GuessResult?> = mutableListOf(GuessResult("1234", 1, 2), GuessResult("5678", 3, 1))
             val lastGuessTime = LocalDateTime.now().minusSeconds(1000)
-            BaseballSupport.updateTimeoutGames(results, lastGuessTime)
-            assertThat(results).hasSize(9)
-            assertThat(results).containsExactly(
-                GuessResult("1234", 1, 2),
-                GuessResult("5678", 3, 1),
-                null, null, null, null,
-                null, null, null
-            )
+            val passedGameCount = BaseballSupport.getPassedGameCount(results.size, lastGuessTime)
+            assertThat(passedGameCount).isEqualTo(7)
         }
     }
 
@@ -88,20 +71,18 @@ class BaseballSupportTest {
     inner class `guess 테스트` {
         @ParameterizedTest
         @MethodSource
-        fun `시간안에 플레이 했으면 null인 게임은 없어야 한다`(
+        fun `같은 숫자면 ball, 같은 위치이면 strike를 올려야 한다`(
             correctNumber: String,
             guessNumber: String,
             expectedStrike: Int,
             expectedBall: Int
         ) {
-            val results: MutableList<GuessResult?> = mutableListOf()
-            BaseballSupport.updateResults(results, correctNumber, guessNumber)
-            assertThat(results).hasSize(1)
-            assertThat(results.last()!!.strike).isEqualTo(expectedStrike)
-            assertThat(results.last()!!.ball).isEqualTo(expectedBall)
+            val result = BaseballSupport.guessAndGetResult(correctNumber, guessNumber)
+            assertThat(result.strike).isEqualTo(expectedStrike)
+            assertThat(result.ball).isEqualTo(expectedBall)
         }
 
-        fun `시간안에 플레이 했으면 null인 게임은 없어야 한다`() = Stream.of(
+        fun `같은 숫자면 ball, 같은 위치이면 strike를 올려야 한다`() = Stream.of(
             Arguments.arguments("1234", "1234", 4, 0),
             Arguments.arguments("1234", "1256", 2, 0),
             Arguments.arguments("1234", "4321", 0, 4),
@@ -114,11 +95,9 @@ class BaseballSupportTest {
 
         @Test
         fun `guessNumber 길이가 4가 아니면 무의미한 결과를 줘야 한다`() {
-            val results: MutableList<GuessResult?> = mutableListOf()
-            BaseballSupport.updateResults(results, "1234", "456")
-            assertThat(results).hasSize(1)
-            assertThat(results.last()!!.strike).isEqualTo(0)
-            assertThat(results.last()!!.ball).isEqualTo(0)
+            val result = BaseballSupport.guessAndGetResult("1234", "456")
+            assertThat(result.strike).isEqualTo(0)
+            assertThat(result.ball).isEqualTo(0)
         }
     }
 }


### PR DESCRIPTION
## 🔥 Related Issue

close: 없음

## 📝 Description

전체적인 코드 정리와 리팩토링을 진행했습니다.

### 리팩토링 사항
1. redis 도메인 layer의 Entity와 프레젠테이션 layer의 dto를 분리했습니다.
2. 변수명 가독성 있게 변경
3. 한 게임이 끝나면 얻을 수 있는 포인트를 계산하던 방식 -> 매 라운드마다 얻을 수 있는 포인트를 계산할 수 있도록 변경

### 도메인 변경사항
1. 베팅 포인트 제한 설정 (min 10, max: 1000)
2. 야구게임의 하드코딩된 정보들(추측할 숫자 길이, 라운드 수, 최대 베팅 포인트, 최소 베팅 포인트)을 가져오는 API 추가
3. API로 내려가는 필드명 변경
     - earnedPoint -> earnablePoints
     - 게임 결과를 의미하는 result -> results

## ⭐️ Review

굉장히 끔찍한 코드입니다 ㅠㅠ 조금 더 잘했으면 좋았을텐데...

**PR 머지 전에 프론트에 해당 사항 공유하기~!**