### PR TITLE
Feature/회원 조회(검색) 기능구현

### DIFF
--- a/src/docs/asciidoc/member/member.adoc
+++ b/src/docs/asciidoc/member/member.adoc
@@ -45,27 +45,27 @@ include::{snippets}/change-password/response-headers.adoc[]
 
 ==== Request
 
-include::{snippets}/get-members/http-request.adoc[]
+include::{snippets}/get-members-by-real-name/http-request.adoc[]
 
 ==== Request Cookies
 
-include::{snippets}/get-members/request-cookies.adoc[]
+include::{snippets}/get-members-by-real-name/request-cookies.adoc[]
 
 ==== Request Parameters
 
 NOTE: 실명 기준으로 검색됩니다.
 
-include::{snippets}/get-members/query-parameters.adoc[]
+include::{snippets}/get-members-by-real-name/query-parameters.adoc[]
 
 === 응답
 
 ==== Response
 
-include::{snippets}/get-members/http-response.adoc[]
+include::{snippets}/get-members-by-real-name/http-response.adoc[]
 
 ==== Response Fields
 
-include::{snippets}/get-members/response-fields.adoc[]
+include::{snippets}/get-members-by-real-name/response-fields.adoc[]
 
 == *포인트 랭킹 조회*
 

--- a/src/docs/asciidoc/member/member.adoc
+++ b/src/docs/asciidoc/member/member.adoc
@@ -39,6 +39,34 @@ include::{snippets}/change-password/http-response.adoc[]
 
 include::{snippets}/change-password/response-headers.adoc[]
 
+== *회원 목록 조회(검색)*
+
+=== 요청
+
+==== Request
+
+include::{snippets}/get-members/http-request.adoc[]
+
+==== Request Cookies
+
+include::{snippets}/get-members/request-cookies.adoc[]
+
+==== Request Parameters
+
+NOTE: 실명 기준으로 검색됩니다.
+
+include::{snippets}/get-members/query-parameters.adoc[]
+
+=== 응답
+
+==== Response
+
+include::{snippets}/get-members/http-response.adoc[]
+
+==== Response Fields
+
+include::{snippets}/get-members/response-fields.adoc[]
+
 == *포인트 랭킹 조회*
 
 === 요청

--- a/src/docs/asciidoc/study/study.adoc
+++ b/src/docs/asciidoc/study/study.adoc
@@ -15,6 +15,8 @@ link:../keeper.html[API 목록으로 돌아가기]
 
 == *스터디 생성*
 
+NOTE: 호출 시 스터디원으로 추가됩니다.
+
 === 요청
 
 ==== Request
@@ -26,6 +28,8 @@ include::{snippets}/create-study/http-request.adoc[]
 include::{snippets}/create-study/request-cookies.adoc[]
 
 ==== Query Parameters
+
+NOTE: 링크는 하나 이상 필수입니다.
 
 include::{snippets}/create-study/query-parameters.adoc[]
 
@@ -157,6 +161,8 @@ include::{snippets}/update-study/path-parameters.adoc[]
 
 ==== Request Fields
 
+NOTE: 링크는 하나 이상 필수입니다.
+
 include::{snippets}/update-study/request-fields.adoc[]
 
 === 응답
@@ -192,6 +198,8 @@ include::{snippets}/join-study/path-parameters.adoc[]
 include::{snippets}/join-study/http-response.adoc[]
 
 == *스터디원 삭제*
+
+NOTE: 스터디장은 삭제할 수 없습니다.
 
 === 요청
 

--- a/src/main/java/com/keeper/homepage/domain/member/api/MemberController.java
+++ b/src/main/java/com/keeper/homepage/domain/member/api/MemberController.java
@@ -8,7 +8,6 @@ import com.keeper.homepage.global.config.security.annotation.LoginMember;
 import jakarta.validation.Valid;
 import java.net.URI;
 import java.util.List;
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -40,10 +39,10 @@ public class MemberController {
   public void getMyProfile() {
   }
 
-  @GetMapping("")
-  public ResponseEntity<List<MemberResponse>> getMembers(
+  @GetMapping("/real-name")
+  public ResponseEntity<List<MemberResponse>> getMembersByRealName(
       @RequestParam(required = false) String searchName
   ) {
-    return ResponseEntity.ok(memberService.getMembers(searchName));
+    return ResponseEntity.ok(memberService.getMembersByRealName(searchName));
   }
 }

--- a/src/main/java/com/keeper/homepage/domain/member/api/MemberController.java
+++ b/src/main/java/com/keeper/homepage/domain/member/api/MemberController.java
@@ -2,16 +2,20 @@ package com.keeper.homepage.domain.member.api;
 
 import com.keeper.homepage.domain.member.application.MemberService;
 import com.keeper.homepage.domain.member.dto.request.ChangePasswordRequest;
+import com.keeper.homepage.domain.member.dto.response.MemberResponse;
 import com.keeper.homepage.domain.member.entity.Member;
 import com.keeper.homepage.global.config.security.annotation.LoginMember;
 import jakarta.validation.Valid;
 import java.net.URI;
+import java.util.List;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -34,5 +38,12 @@ public class MemberController {
   // TODO: 비밀번호 변경 후 redirect 용 API, 임시로 만들어 둠
   @GetMapping("/me")
   public void getMyProfile() {
+  }
+
+  @GetMapping("")
+  public ResponseEntity<List<MemberResponse>> getMembers(
+      @RequestParam(required = false) String searchName
+  ) {
+    return ResponseEntity.ok(memberService.getMembers(searchName));
   }
 }

--- a/src/main/java/com/keeper/homepage/domain/member/application/MemberService.java
+++ b/src/main/java/com/keeper/homepage/domain/member/application/MemberService.java
@@ -1,6 +1,11 @@
 package com.keeper.homepage.domain.member.application;
 
+import com.keeper.homepage.domain.member.application.convenience.MemberFindService;
+import com.keeper.homepage.domain.member.dao.MemberRepository;
+import com.keeper.homepage.domain.member.dto.response.MemberResponse;
 import com.keeper.homepage.domain.member.entity.Member;
+import com.keeper.homepage.domain.member.entity.embedded.RealName;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -10,8 +15,22 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class MemberService {
 
+  private final MemberRepository memberRepository;
+  private final MemberFindService memberFindService;
+
   @Transactional
   public void changePassword(Member me, String newPassword) {
     me.getProfile().changePassword(newPassword);
+  }
+
+  public List<MemberResponse> getMembers(String searchName) {
+    if (searchName == null) {
+      return memberFindService.findAll()
+          .map(MemberResponse::from)
+          .toList();
+    }
+    return memberFindService.findAllByRealName(RealName.from(searchName))
+        .map(MemberResponse::from)
+        .toList();
   }
 }

--- a/src/main/java/com/keeper/homepage/domain/member/application/MemberService.java
+++ b/src/main/java/com/keeper/homepage/domain/member/application/MemberService.java
@@ -23,7 +23,7 @@ public class MemberService {
     me.getProfile().changePassword(newPassword);
   }
 
-  public List<MemberResponse> getMembers(String searchName) {
+  public List<MemberResponse> getMembersByRealName(String searchName) {
     if (searchName == null) {
       return memberFindService.findAll()
           .map(MemberResponse::from)

--- a/src/main/java/com/keeper/homepage/domain/member/application/convenience/MemberFindService.java
+++ b/src/main/java/com/keeper/homepage/domain/member/application/convenience/MemberFindService.java
@@ -1,12 +1,12 @@
 package com.keeper.homepage.domain.member.application.convenience;
 
 import static com.keeper.homepage.global.error.ErrorCode.MEMBER_NOT_FOUND;
-import static com.keeper.homepage.global.error.ErrorCode.STUDY_NOT_FOUND;
 
 import com.keeper.homepage.domain.member.dao.MemberRepository;
 import com.keeper.homepage.domain.member.entity.Member;
-import com.keeper.homepage.domain.study.entity.Study;
+import com.keeper.homepage.domain.member.entity.embedded.RealName;
 import com.keeper.homepage.global.error.BusinessException;
+import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,5 +27,15 @@ public class MemberFindService {
   public Member findById(long memberId) {
     return memberRepository.findByIdAndIdNot(memberId, VIRTUAL_MEMBER_ID)
         .orElseThrow(() -> new BusinessException(memberId, "memberId", MEMBER_NOT_FOUND));
+  }
+
+  public Stream<Member> findAll() {
+    return memberRepository.findAllByIdNot(VIRTUAL_MEMBER_ID)
+        .stream();
+  }
+
+  public Stream<Member> findAllByRealName(RealName realName) {
+    return memberRepository.findAllByProfileRealNameAndIdNot(realName, VIRTUAL_MEMBER_ID)
+        .stream();
   }
 }

--- a/src/main/java/com/keeper/homepage/domain/member/dao/MemberRepository.java
+++ b/src/main/java/com/keeper/homepage/domain/member/dao/MemberRepository.java
@@ -3,8 +3,9 @@ package com.keeper.homepage.domain.member.dao;
 import com.keeper.homepage.domain.member.entity.Member;
 import com.keeper.homepage.domain.member.entity.embedded.EmailAddress;
 import com.keeper.homepage.domain.member.entity.embedded.LoginId;
+import com.keeper.homepage.domain.member.entity.embedded.RealName;
 import com.keeper.homepage.domain.member.entity.embedded.StudentId;
-import com.keeper.homepage.domain.post.entity.Post;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -27,5 +28,9 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
   Page<Member> findAllByIdIsNotOrderByPointDesc(long virtualId, Pageable pageable);
 
+  List<Member> findAllByIdNot(long virtualId);
+
   Optional<Member> findByIdAndIdNot(Long memberId, Long virtualId);
+
+  List<Member> findAllByProfileRealNameAndIdNot(RealName realName, long virtualId);
 }

--- a/src/main/java/com/keeper/homepage/domain/member/dto/response/MemberResponse.java
+++ b/src/main/java/com/keeper/homepage/domain/member/dto/response/MemberResponse.java
@@ -1,0 +1,26 @@
+package com.keeper.homepage.domain.member.dto.response;
+
+import static lombok.AccessLevel.PRIVATE;
+
+import com.keeper.homepage.domain.member.entity.Member;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = PRIVATE)
+public class MemberResponse {
+
+  private Long memberId;
+  private String memberName;
+  private Float generation;
+
+  public static MemberResponse from(Member member) {
+    return MemberResponse.builder()
+        .memberId(member.getId())
+        .memberName(member.getRealName())
+        .generation(member.getGeneration())
+        .build();
+  }
+}

--- a/src/main/java/com/keeper/homepage/domain/study/dto/response/StudyDetailResponse.java
+++ b/src/main/java/com/keeper/homepage/domain/study/dto/response/StudyDetailResponse.java
@@ -30,7 +30,7 @@ public class StudyDetailResponse {
             .map(Member::getRealName)
             .toList())
         .gitLink(study.getGitLink())
-        .noteLink(study.getNotionLink())
+        .noteLink(study.getNoteLink())
         .etcLink(study.getEtcLink())
         .build();
   }

--- a/src/main/java/com/keeper/homepage/domain/study/entity/Study.java
+++ b/src/main/java/com/keeper/homepage/domain/study/entity/Study.java
@@ -105,7 +105,7 @@ public class Study extends BaseEntity {
     return this.link.getGitLink().get();
   }
 
-  public String getNotionLink() {
+  public String getNoteLink() {
     return this.link.getNoteLink().get();
   }
 

--- a/src/main/java/com/keeper/homepage/domain/study/entity/embedded/Link.java
+++ b/src/main/java/com/keeper/homepage/domain/study/entity/embedded/Link.java
@@ -27,4 +27,8 @@ public class Link {
     this.noteLink = noteLink;
     this.etcLink = etcLink;
   }
+
+  public boolean isEmpty() {
+    return gitLink == null && noteLink == null && etcLink == null;
+  }
 }

--- a/src/main/java/com/keeper/homepage/global/error/ErrorCode.java
+++ b/src/main/java/com/keeper/homepage/global/error/ErrorCode.java
@@ -56,7 +56,9 @@ public enum ErrorCode {
   SURVEY_REPLY_TYPE_NOT_FOUND("존재하지 않는 응답 종류입니다.", HttpStatus.NOT_FOUND),
   // STUDY
   STUDY_NOT_FOUND("존재하지 않는 스터디입니다.", HttpStatus.NOT_FOUND),
-  STUDY_CANNOT_ACCESSIBLE("스터디에 접근할 권한이 없습니다.", HttpStatus.FORBIDDEN),
+  STUDY_INACCESSIBLE("스터디장만 접근할 수 있습니다.", HttpStatus.BAD_REQUEST),
+  STUDY_LINK_NEED("스터디 링크는 하나 이상 필수입니다.", HttpStatus.BAD_REQUEST),
+  STUDY_HEAD_MEMBER_CANNOT_LEAVE("스터디장은 스터디 탈퇴 할 수 없습니다.", HttpStatus.BAD_REQUEST),
   // GAME
   IS_ALREADY_PLAYED("이미 게임 플레이 가능 횟수만큼 플레이 하였습니다.", HttpStatus.BAD_REQUEST),
   NOT_ENOUGH_POINT("베팅 포인트는 보유한 포인트보다 많을 수 없습니다.", HttpStatus.BAD_REQUEST),

--- a/src/test/java/com/keeper/homepage/IntegrationTest.java
+++ b/src/test/java/com/keeper/homepage/IntegrationTest.java
@@ -39,6 +39,7 @@ import com.keeper.homepage.domain.library.dao.BookBorrowStatusRepository;
 import com.keeper.homepage.domain.library.dao.BookDepartmentRepository;
 import com.keeper.homepage.domain.library.dao.BookRepository;
 import com.keeper.homepage.domain.member.MemberTestHelper;
+import com.keeper.homepage.domain.member.application.MemberService;
 import com.keeper.homepage.domain.member.application.convenience.MemberFindService;
 import com.keeper.homepage.domain.member.dao.MemberRepository;
 import com.keeper.homepage.domain.member.dao.comment.MemberHasCommentDislikeRepository;
@@ -210,7 +211,16 @@ public class IntegrationTest {
   @SpyBean
   protected SurveyReplyExcuseRepository surveyReplyExcuseRepository;
 
+  @Autowired
+  protected FileRepository fileRepository;
+
+  @Autowired
+  protected ThumbnailRepository thumbnailRepository;
+
   /******* Service *******/
+  @SpyBean
+  protected MemberService memberService;
+
   @SpyBean
   protected EmailAuthService emailAuthService;
 
@@ -225,9 +235,6 @@ public class IntegrationTest {
 
   @SpyBean
   protected AuthCookieService authCookieService;
-
-  @SpyBean
-  protected MailUtil mailUtil;
 
   @Autowired
   protected StaticWriteService staticWriteService;
@@ -268,12 +275,6 @@ public class IntegrationTest {
   /******* Helper *******/
   @SpyBean
   protected StaticWriteTestHelper staticWriteTestHelper;
-
-  @Autowired
-  protected FileRepository fileRepository;
-
-  @Autowired
-  protected ThumbnailRepository thumbnailRepository;
 
   @Autowired
   protected MemberTestHelper memberTestHelper;
@@ -323,6 +324,9 @@ public class IntegrationTest {
 
   @SpyBean
   protected RedisUtil redisUtil;
+
+  @SpyBean
+  protected MailUtil mailUtil;
 
   protected PasswordEncoder passwordEncoder = PasswordFactory.getPasswordEncoder();
 

--- a/src/test/java/com/keeper/homepage/domain/member/api/MemberControllerTest.java
+++ b/src/test/java/com/keeper/homepage/domain/member/api/MemberControllerTest.java
@@ -90,13 +90,13 @@ class MemberControllerTest extends IntegrationTest {
     @DisplayName("유효한 요청일 경우 회원 목록 조회(검색)는 성공한다.")
     public void 유효한_요청일_경우_회원_목록_조회는_성공한다() throws Exception {
       assertThat(member.getGeneration()).isNotNull();
-      String securedValue = getSecuredValue(MemberController.class, "getMembers");
+      String securedValue = getSecuredValue(MemberController.class, "getMembersByRealName");
 
-      mockMvc.perform(get("/members")
+      mockMvc.perform(get("/members/real-name")
               .cookie(new Cookie(ACCESS_TOKEN.getTokenName(), memberToken))
               .contentType(MediaType.APPLICATION_JSON))
           .andExpect(status().isOk())
-          .andDo(document("get-members",
+          .andDo(document("get-members-by-real-name",
               requestCookies(
                   cookieWithName(ACCESS_TOKEN.getTokenName())
                       .description("ACCESS TOKEN %s".formatted(securedValue))

--- a/src/test/java/com/keeper/homepage/domain/member/api/MemberControllerTest.java
+++ b/src/test/java/com/keeper/homepage/domain/member/api/MemberControllerTest.java
@@ -1,28 +1,41 @@
 package com.keeper.homepage.domain.member.api;
 
+import static com.keeper.homepage.domain.member.entity.job.MemberJob.MemberJobType.ROLE_회원;
 import static com.keeper.homepage.global.config.security.data.JwtType.ACCESS_TOKEN;
 import static com.keeper.homepage.global.config.security.data.JwtType.REFRESH_TOKEN;
+import static com.keeper.homepage.global.restdocs.RestDocsHelper.getSecuredValue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.restdocs.cookies.CookieDocumentation.cookieWithName;
 import static org.springframework.restdocs.cookies.CookieDocumentation.requestCookies;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.responseHeaders;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.keeper.homepage.IntegrationTest;
 import com.keeper.homepage.domain.member.dto.request.ChangePasswordRequest;
 import com.keeper.homepage.domain.member.entity.Member;
+import com.keeper.homepage.domain.member.entity.embedded.Generation;
+import com.keeper.homepage.domain.study.api.StudyController;
 import jakarta.servlet.http.Cookie;
+import java.io.IOException;
+import java.time.LocalDate;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.restdocs.snippet.Attributes.Attribute;
 
 class MemberControllerTest extends IntegrationTest {
 
@@ -57,6 +70,47 @@ class MemberControllerTest extends IntegrationTest {
                   fieldWithPath("newPassword").description("새로운 패스워드")),
               responseHeaders(
                   headerWithName(HttpHeaders.LOCATION).description("비밀번호 변경한 리소스의 위치입니다."))));
+    }
+  }
+
+  @Nested
+  @DisplayName("회원 목록 조회")
+  class GetMembers {
+
+    private Member member;
+    private String memberToken;
+
+    @BeforeEach
+    void setUp() throws IOException {
+      member = memberTestHelper.builder().build();
+      memberToken = jwtTokenProvider.createAccessToken(ACCESS_TOKEN, member.getId(), ROLE_회원);
+    }
+
+    @Test
+    @DisplayName("유효한 요청일 경우 회원 목록 조회(검색)는 성공한다.")
+    public void 유효한_요청일_경우_회원_목록_조회는_성공한다() throws Exception {
+      assertThat(member.getGeneration()).isNotNull();
+      String securedValue = getSecuredValue(MemberController.class, "getMembers");
+
+      mockMvc.perform(get("/members")
+              .cookie(new Cookie(ACCESS_TOKEN.getTokenName(), memberToken))
+              .contentType(MediaType.APPLICATION_JSON))
+          .andExpect(status().isOk())
+          .andDo(document("get-members",
+              requestCookies(
+                  cookieWithName(ACCESS_TOKEN.getTokenName())
+                      .description("ACCESS TOKEN %s".formatted(securedValue))
+              ),
+              queryParameters(
+                  parameterWithName("searchName").description("회원 이름 검색어")
+                      .attributes(new Attribute("format", "null : 전체 목록 조회"))
+                      .optional()
+              ),
+              responseFields(
+                  fieldWithPath("[].memberId").description("회원 ID"),
+                  fieldWithPath("[].memberName").description("회원 실명"),
+                  fieldWithPath("[].generation").description("회원 기수")
+              )));
     }
   }
 }

--- a/src/test/java/com/keeper/homepage/domain/study/api/StudyControllerTest.java
+++ b/src/test/java/com/keeper/homepage/domain/study/api/StudyControllerTest.java
@@ -83,8 +83,10 @@ public class StudyControllerTest extends StudyApiTestHelper {
                       .attributes(new Attribute("format", "1: 1학기 2: 여름학기 3: 2학기 4: 겨울학기"))
                       .description("스터디 학기를 입력해주세요."),
                   parameterWithName("gitLink")
+                      .attributes(new Attribute("format", "\"https://github.com\"으로 시작"))
                       .description("스터디 깃허브 링크를 입력해주세요.").optional(),
                   parameterWithName("noteLink")
+                      .attributes(new Attribute("format", "\"https://www.notion.so\"으로 시작"))
                       .description("스터디 노트 링크를 입력해주세요.").optional(),
                   parameterWithName("etcLink")
                       .description("스터디 기타 링크를 입력해주세요.").optional()
@@ -162,7 +164,7 @@ public class StudyControllerTest extends StudyApiTestHelper {
     @DisplayName("스터디장이 아닐 경우 스터디 삭제는 실패한다.")
     public void 스터디장이_아닐_경우_스터디_삭제는_실패한다() throws Exception {
       callDeleteStudyApi(otherToken, studyId)
-          .andExpect(status().isForbidden());
+          .andExpect(status().isBadRequest());
     }
   }
 
@@ -239,6 +241,7 @@ public class StudyControllerTest extends StudyApiTestHelper {
           .information("자바 스터디 입니다.")
           .year(2023)
           .season(2)
+          .gitLink("https://github.com/KEEPER31337/Homepage-Back-R2")
           .build();
 
       callUpdateStudyApi(memberToken, studyId, request)
@@ -258,8 +261,10 @@ public class StudyControllerTest extends StudyApiTestHelper {
                   field("season", "스터디 학기")
                       .attributes(new Attribute("format", "1: 1학기 2: 여름학기 3: 2학기 4: 겨울학기")),
                   field("gitLink", "깃허브 링크")
+                      .attributes(new Attribute("format", "\"https://github.com\"으로 시작"))
                       .optional(),
                   field("noteLink", "노션 링크")
+                      .attributes(new Attribute("format", "\"https://www.notion.so\"으로 시작"))
                       .optional(),
                   field("etcLink", "기타 링크")
                       .optional()
@@ -298,7 +303,7 @@ public class StudyControllerTest extends StudyApiTestHelper {
     public void 스터디장이_아닐_경우_스터디_수정은_실패한다() throws Exception {
       MockMultipartFile newThumbnailFile = thumbnailTestHelper.getThumbnailFile();
       callUpdateStudyThumbnailApi(otherToken, studyId, newThumbnailFile)
-          .andExpect(status().isForbidden());
+          .andExpect(status().isBadRequest());
     }
   }
 
@@ -311,7 +316,7 @@ public class StudyControllerTest extends StudyApiTestHelper {
     public void 유효한_요청일_경우_스터디원_추가는_성공한다() throws Exception {
       String securedValue = getSecuredValue(StudyController.class, "joinStudy");
 
-      callJoinStudyApi(memberToken, studyId, member.getId())
+      callJoinStudyApi(memberToken, studyId, other.getId())
           .andExpect(status().isCreated())
           .andDo(document("join-study",
                   requestCookies(
@@ -336,7 +341,7 @@ public class StudyControllerTest extends StudyApiTestHelper {
     public void 유효한_요청일_경우_스터디원_삭제는_성공한다() throws Exception {
       String securedValue = getSecuredValue(StudyController.class, "leaveStudy");
 
-      callLeaveStudyApi(memberToken, studyId, member.getId())
+      callLeaveStudyApi(memberToken, studyId, other.getId())
           .andExpect(status().isNoContent())
           .andDo(document("leave-study",
                   requestCookies(

--- a/src/test/java/com/keeper/homepage/domain/study/application/StudyServiceTest.java
+++ b/src/test/java/com/keeper/homepage/domain/study/application/StudyServiceTest.java
@@ -1,16 +1,18 @@
 package com.keeper.homepage.domain.study.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.keeper.homepage.IntegrationTest;
 import com.keeper.homepage.domain.member.entity.Member;
 import com.keeper.homepage.domain.study.entity.Study;
+import com.keeper.homepage.domain.study.entity.embedded.Link;
+import com.keeper.homepage.global.error.BusinessException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.springframework.mock.web.MockMultipartFile;
 
 public class StudyServiceTest extends IntegrationTest {
 
@@ -21,6 +23,26 @@ public class StudyServiceTest extends IntegrationTest {
   void setUp() {
     member = memberTestHelper.generate();
     study = studyTestHelper.builder().headMember(member).build();
+  }
+
+  @Nested
+  @DisplayName("스터디 생성")
+  class CreateStudy {
+
+    @Test
+    @DisplayName("스터디 링크가 하나도 없을 경우 스터디 생성은 실패한다.")
+    public void 스터디_링크가_하나도_없을_경우_스터디_생성은_실패한다() throws Exception {
+      Study study = Study.builder()
+          .title("자바 스터디")
+          .information("자바 스터디 입니다.")
+          .year(2023)
+          .season(2)
+          .link(Link.builder().build())
+          .build();
+      assertThrows(BusinessException.class, () -> {
+        studyService.create(study, null);
+      });
+    }
   }
 
   @Nested
@@ -57,21 +79,23 @@ public class StudyServiceTest extends IntegrationTest {
   @DisplayName("스터디원 삭제")
   class DeleteStudyMember {
 
+    private Member other = memberTestHelper.generate();
+
     @BeforeEach
     void setUp() {
-      studyService.joinStudy(study.getId(), member.getId());
+      studyService.joinStudy(study.getId(), other.getId());
       em.flush();
       em.clear();
-      member = memberRepository.findById(member.getId()).get();
+      other = memberRepository.findById(other.getId()).get();
       study = studyRepository.findById(study.getId()).get();
     }
 
     @Test
     @DisplayName("스터디원 삭제는 성공해야 한다.")
     public void 스터디원_삭제는_성공해야_한다() throws Exception {
-      studyService.leaveStudy(study.getId(), member.getId());
+      studyService.leaveStudy(study.getId(), other.getId());
 
-      assertThat(studyHasMemberRepository.findByStudyAndMember(study, member)).isEmpty();
+      assertThat(studyHasMemberRepository.findByStudyAndMember(study, other)).isEmpty();
     }
   }
 }


### PR DESCRIPTION
## 🔥 Related Issue

close: #125

## 📝 Description

1. 스터디 로직 수정
- 스터디 개설 시 api 호출한 사람(스터디장)은 스터디원으로 등록됩니다.
- 스터디 링크는 1개 이상이어야 합니다.
- 스터디장은 스터디원 탈퇴가 불가합니다.

_[기획서](https://www.notion.so/B1-B8-496c3d967d3b40ee8e166c9687065d5c?pvs=4)를 꼼꼼히 보자_

2. 회원 목록 조회(검색) 기능 구현
- 스터디원을 추가할 때 필요한 회원 목록 조회 기능을 구현했습니다!
- 추후 확장 가능성이 있는 api 인 것 같습니다! (여러 곳에서 쓰일 것 같다...!)
   - `ResponseEntity<List<~>>`로 전달해도 필드가 하나면 상관 없다고 하더라구요!

## ⭐️ Review

`MemberFindService` 쪽 괜찮은지 봐주세요!