### PR TITLE
feat: 관리자 도서 목록 조회 API 추가

### DIFF
--- a/src/docs/asciidoc/library/book-manage.adoc
+++ b/src/docs/asciidoc/library/book-manage.adoc
@@ -13,6 +13,32 @@ endif::[]
 
 link:../keeper.html[API 목록으로 돌아가기]
 
+== *책 목록 가져오기*
+
+=== 요청
+
+==== Request
+
+include::{snippets}/get-books/http-request.adoc[]
+
+==== Request Cookies
+
+include::{snippets}/get-books/request-cookies.adoc[]
+
+==== Request Params
+
+include::{snippets}/get-books/query-parameters.adoc[]
+
+=== 응답
+
+==== Response
+
+include::{snippets}/get-books/http-response.adoc[]
+
+==== Response Fields
+
+include::{snippets}/get-books/response-fields.adoc[]
+
 == *책 추가*
 
 === 요청

--- a/src/docs/asciidoc/library/book-manage.adoc
+++ b/src/docs/asciidoc/library/book-manage.adoc
@@ -19,25 +19,25 @@ link:../keeper.html[API 목록으로 돌아가기]
 
 ==== Request
 
-include::{snippets}/get-books/http-request.adoc[]
+include::{snippets}/manager-get-books/http-request.adoc[]
 
 ==== Request Cookies
 
-include::{snippets}/get-books/request-cookies.adoc[]
+include::{snippets}/manager-get-books/request-cookies.adoc[]
 
 ==== Request Params
 
-include::{snippets}/get-books/query-parameters.adoc[]
+include::{snippets}/manager-get-books/query-parameters.adoc[]
 
 === 응답
 
 ==== Response
 
-include::{snippets}/get-books/http-response.adoc[]
+include::{snippets}/manager-get-books/http-response.adoc[]
 
 ==== Response Fields
 
-include::{snippets}/get-books/response-fields.adoc[]
+include::{snippets}/manager-get-books/response-fields.adoc[]
 
 == *책 추가*
 

--- a/src/main/java/com/keeper/homepage/domain/library/application/BookManageService.kt
+++ b/src/main/java/com/keeper/homepage/domain/library/application/BookManageService.kt
@@ -7,6 +7,8 @@ import com.keeper.homepage.domain.library.entity.BookDepartment
 import com.keeper.homepage.global.error.BusinessException
 import com.keeper.homepage.global.error.ErrorCode
 import com.keeper.homepage.global.util.thumbnail.ThumbnailUtil
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageRequest
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.multipart.MultipartFile
@@ -20,6 +22,13 @@ class BookManageService(
     val bookRepository: BookRepository,
     val thumbnailUtil: ThumbnailUtil
 ) {
+    fun getBooks(bookKeyword: String?, pageable: PageRequest): Page<Book> {
+        if (bookKeyword.isNullOrBlank()) {
+            return bookRepository.findAll(pageable)
+        }
+        return bookRepository.findAllByTitleOrAuthor(bookKeyword, pageable)
+    }
+
     @Transactional
     fun addBook(
         title: String,

--- a/src/main/java/com/keeper/homepage/domain/library/dto/resp/BookDetailResponse.kt
+++ b/src/main/java/com/keeper/homepage/domain/library/dto/resp/BookDetailResponse.kt
@@ -19,7 +19,7 @@ data class BookDetailResponse(
         bookDepartment = book.bookDepartment.type.name,
         totalCount = book.totalQuantity,
         borrowingCount = book.bookBorrowInfos.count { it.isInBorrowing },
-        thumbnailPath = book.thumbnail.path,
+        thumbnailPath = book.thumbnailPath,
         borrowInfos = book.bookBorrowInfos.map(::BorrowDetailResponse),
     )
 }

--- a/src/test/java/com/keeper/homepage/domain/library/api/BookManageControllerTest.kt
+++ b/src/test/java/com/keeper/homepage/domain/library/api/BookManageControllerTest.kt
@@ -82,7 +82,7 @@ class BookManageControllerTest : BookManageApiTestHelper() {
                 .andExpect(jsonPath("$.totalPages").value("2"))
                 .andDo(
                     document(
-                        "get-books",
+                        "manager-get-books",
                         requestCookies(
                             cookieWithName(ACCESS_TOKEN.tokenName).description("ACCESS TOKEN ${securedValue}"),
                             cookieWithName(REFRESH_TOKEN.tokenName).description("REFRESH TOKEN ${securedValue}")

--- a/src/test/java/com/keeper/homepage/domain/library/api/BorrowManageControllerTest.kt
+++ b/src/test/java/com/keeper/homepage/domain/library/api/BorrowManageControllerTest.kt
@@ -24,13 +24,6 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
-fun BookBorrowInfoTestHelper.generate(
-    borrowStatus: BookBorrowStatus.BookBorrowStatusType,
-    expiredDate: LocalDateTime = LocalDateTime.now().plusWeeks(2)
-): BookBorrowInfo {
-    return this.builder().borrowStatus(getBookBorrowStatusBy(borrowStatus)).expireDate(expiredDate).build()
-}
-
 class BorrowManageControllerTest : BorrowManageApiTestHelper() {
 
     @TestInstance(TestInstance.Lifecycle.PER_CLASS)


### PR DESCRIPTION
## 🔥 Related Issue

close: 없음

## 📝 Description

관리자 도서 목록 조회 API 추가

<img width="536" alt="image" src="https://github.com/KEEPER31337/Homepage-Back-R2/assets/26597702/27612e69-6055-4e9e-91f6-6b796b93c0c4">

![image](https://github.com/KEEPER31337/Homepage-Back-R2/assets/26597702/0d1eb218-bd03-45c5-917e-6ec8548763ec) ![image](https://github.com/KEEPER31337/Homepage-Back-R2/assets/26597702/c0b3c928-4623-40f9-9b06-3340a3aff4c8)


## ⭐️ Review

남기고 싶은 내용을 설명해주세요.