### PR TITLE
Feature/출석 + 출석 랭킹 기능 구현

### DIFF
--- a/src/docs/asciidoc/attendance/attendance.adoc
+++ b/src/docs/asciidoc/attendance/attendance.adoc
@@ -1,0 +1,84 @@
+ifndef::snippets[]
+:snippets: ./build/generated-snippets
+endif::[]
+
+= ATTENDANCE API 문서
+:icons: font
+:source-highlighter: highlight.js
+:toc: left
+:toclevels: 1
+:sectlinks:
+
+== API 목록
+
+link:../keeper.html[API 목록으로 돌아가기]
+
+== *출석*
+
+=== 요청
+
+==== Request
+
+include::{snippets}/create-attendance/http-request.adoc[]
+
+==== Request Cookies
+
+include::{snippets}/create-attendance/request-cookies.adoc[]
+
+=== 응답
+
+==== Response
+
+include::{snippets}/create-attendance/http-response.adoc[]
+
+== *당일 출석 랭킹 조회*
+
+NOTE: 당일의 출석 시간이 빠른 순서대로 정렬되어 조회됩니다.
+
+=== 요청
+
+==== Request
+
+include::{snippets}/get-today-attendance-ranks/http-request.adoc[]
+
+==== Request Cookies
+
+include::{snippets}/get-today-attendance-ranks/request-cookies.adoc[]
+
+==== Query Parameters
+
+include::{snippets}/get-today-attendance-ranks/query-parameters.adoc[]
+
+=== 응답
+
+==== Response
+
+include::{snippets}/get-today-attendance-ranks/http-response.adoc[]
+
+==== Response Fields
+
+include::{snippets}/get-today-attendance-ranks/response-fields.adoc[]
+
+== *연속 출석 랭킹 조회*
+
+NOTE: 연속 출석일이 많은 순으로 정렬되어 조회됩니다.
+
+=== 요청
+
+==== Request
+
+include::{snippets}/get-continuous-attendance-ranks/http-request.adoc[]
+
+==== Request Cookies
+
+include::{snippets}/get-continuous-attendance-ranks/request-cookies.adoc[]
+
+=== 응답
+
+==== Response
+
+include::{snippets}/get-continuous-attendance-ranks/http-response.adoc[]
+
+==== Response Fields
+
+include::{snippets}/get-continuous-attendance-ranks/response-fields.adoc[]

--- a/src/docs/asciidoc/keeper.adoc
+++ b/src/docs/asciidoc/keeper.adoc
@@ -46,3 +46,7 @@ link:study/study.html[API 문서 보기]
 == *GAME API*
 
 link:game/game.html[API 문서 보기]
+
+== *ATTENDANCE API*
+
+link:attendance/attendance.html[API 문서 보기]

--- a/src/docs/asciidoc/post/post.adoc
+++ b/src/docs/asciidoc/post/post.adoc
@@ -279,9 +279,9 @@ include::{snippets}/get-notice-posts/http-request.adoc[]
 
 include::{snippets}/get-notice-posts/request-cookies.adoc[]
 
-==== Path Parameters
+==== Query Parameters
 
-include::{snippets}/get-notice-posts/path-parameters.adoc[]
+include::{snippets}/get-notice-posts/query-parameters.adoc[]
 
 === 응답
 

--- a/src/main/java/com/keeper/homepage/domain/attendance/api/AttendanceController.java
+++ b/src/main/java/com/keeper/homepage/domain/attendance/api/AttendanceController.java
@@ -33,7 +33,7 @@ public class AttendanceController {
         .build();
   }
 
-  @GetMapping("/today")
+  @GetMapping("/today-rank")
   public ResponseEntity<Page<AttendanceResponse>> getTodayRanks(
       @RequestParam(defaultValue = "0") @PositiveOrZero int page,
       @RequestParam(defaultValue = "10") @PositiveOrZero int size
@@ -41,7 +41,7 @@ public class AttendanceController {
     return ResponseEntity.ok(attendanceService.getTodayRanks(PageRequest.of(page, size)));
   }
 
-  @GetMapping("/continuous")
+  @GetMapping("/continuous-rank")
   public ResponseEntity<List<AttendanceResponse>> getContinuousRanks() {
     return ResponseEntity.ok(attendanceService.getContinuousRanks());
   }

--- a/src/main/java/com/keeper/homepage/domain/attendance/api/AttendanceController.java
+++ b/src/main/java/com/keeper/homepage/domain/attendance/api/AttendanceController.java
@@ -1,0 +1,48 @@
+package com.keeper.homepage.domain.attendance.api;
+
+import com.keeper.homepage.domain.attendance.application.AttendanceService;
+import com.keeper.homepage.domain.attendance.dto.response.AttendanceResponse;
+import com.keeper.homepage.domain.member.entity.Member;
+import com.keeper.homepage.global.config.security.annotation.LoginMember;
+import jakarta.validation.constraints.PositiveOrZero;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/attendances")
+@RequiredArgsConstructor
+public class AttendanceController {
+
+  private final AttendanceService attendanceService;
+
+  @PostMapping
+  public ResponseEntity<Void> create(
+      @LoginMember Member member
+  ) {
+    attendanceService.create(member);
+    return ResponseEntity.status(HttpStatus.CREATED)
+        .build();
+  }
+
+  @GetMapping("/today")
+  public ResponseEntity<Page<AttendanceResponse>> getTodayRanks(
+      @RequestParam(defaultValue = "0") @PositiveOrZero int page,
+      @RequestParam(defaultValue = "10") @PositiveOrZero int size
+  ) {
+    return ResponseEntity.ok(attendanceService.getTodayRanks(PageRequest.of(page, size)));
+  }
+
+  @GetMapping("/continuous")
+  public ResponseEntity<List<AttendanceResponse>> getContinuousRanks() {
+    return ResponseEntity.ok(attendanceService.getContinuousRanks());
+  }
+}

--- a/src/main/java/com/keeper/homepage/domain/attendance/application/AttendanceService.java
+++ b/src/main/java/com/keeper/homepage/domain/attendance/application/AttendanceService.java
@@ -1,0 +1,115 @@
+package com.keeper.homepage.domain.attendance.application;
+
+import static com.keeper.homepage.global.error.ErrorCode.ATTENDANCE_ALREADY;
+import static java.util.Comparator.comparing;
+
+import com.keeper.homepage.domain.attendance.dao.AttendanceRepository;
+import com.keeper.homepage.domain.attendance.dto.response.AttendanceResponse;
+import com.keeper.homepage.domain.attendance.entity.Attendance;
+import com.keeper.homepage.domain.member.entity.Member;
+import com.keeper.homepage.domain.point.application.PointLogService;
+import com.keeper.homepage.global.error.BusinessException;
+import com.keeper.homepage.global.util.redis.RedisUtil;
+import com.keeper.homepage.global.util.web.WebUtil;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AttendanceService {
+
+  private final AttendanceRepository attendanceRepository;
+  private final PointLogService pointLogService;
+  private final RedisUtil redisUtil;
+
+  private static final long RANK_DATA_EXPIRE_DURATION = 60 * 60 * 24; // 60s * 60m * 24h로 하루를 의미함.
+
+  private static final String ATTENDANCE_MESSAGE = "자동 출석입니다.";
+  private static final int RANDOM_MIN_POINT = 100;
+  private static final int RANDOM_MAX_POINT = 1000;
+  public static final int DAILY_POINT = 1000;
+
+  @Transactional
+  public void create(Member member) {
+    checkAlreadyAttendance(member);
+
+    LocalDateTime now = LocalDateTime.now();
+    int randomPoint = getRandomPoint();
+    int rank = getTodayRank(now.toLocalDate());
+    int rankPoint = getRankPoint(rank);
+    int continuousDay = getContinuousDay(member, now.toLocalDate());
+    int continuousPoint = getContinuousPoint(continuousDay);
+
+    Attendance attendance = Attendance.builder()
+        .time(now)
+        .date(now.toLocalDate())
+        .point(DAILY_POINT)
+        .randomPoint(randomPoint)
+        .rank(rank)
+        .rankPoint(rankPoint)
+        .continuousDay(continuousDay)
+        .continuousPoint(continuousPoint)
+        .ipAddress(WebUtil.getUserIP())
+        .greetings(ATTENDANCE_MESSAGE)
+        .member(member)
+        .build();
+    attendanceRepository.save(attendance);
+    pointLogService.create(attendance);
+  }
+
+  private void checkAlreadyAttendance(Member member) {
+    if (attendanceRepository.existsByMemberAndDate(member, LocalDate.now())) {
+      throw new BusinessException(member.getId(), "memberId", ATTENDANCE_ALREADY);
+    }
+  }
+
+  private int getRandomPoint() {
+    return (int) (Math.random() * (RANDOM_MAX_POINT - RANDOM_MIN_POINT) + RANDOM_MIN_POINT);
+  }
+
+  private int getTodayRank(LocalDate now) {
+    String key = "attendance:" + now.toString();
+    return redisUtil.increaseAndGetWithExpire(key, RANK_DATA_EXPIRE_DURATION).intValue();
+  }
+
+  private int getRankPoint(int rank) {
+    return RankPoint.getRankPoint(rank)
+        .orElse(0);
+  }
+
+  private int getContinuousDay(Member member, LocalDate now) {
+    Attendance yesterdayAttendance = attendanceRepository.findByMemberAndDate(member, now.minusDays(1))
+        .orElse(null);
+    if (yesterdayAttendance == null) {
+      return 1;
+    }
+    return yesterdayAttendance.getContinuousDay() + 1;
+  }
+
+  private int getContinuousPoint(int continuousDay) {
+    return BonusPoint.getBonusPoint(continuousDay)
+        .orElse(0);
+  }
+
+  public Page<AttendanceResponse> getTodayRanks(Pageable pageable) {
+    LocalDate now = LocalDate.now();
+    Page<Attendance> attendances = attendanceRepository.findAllByDateOrderByRankAsc(now, pageable);
+    return attendances.map(AttendanceResponse::from);
+  }
+
+  public List<AttendanceResponse> getContinuousRanks() {
+    LocalDate now = LocalDate.now();
+    List<Attendance> attendances = attendanceRepository.findAllByDateOrderByContinuousDayDesc(now);
+    return attendances.stream()
+        .map(AttendanceResponse::from)
+        .limit(4)
+        .toList();
+  }
+}

--- a/src/main/java/com/keeper/homepage/domain/attendance/application/AttendanceService.java
+++ b/src/main/java/com/keeper/homepage/domain/attendance/application/AttendanceService.java
@@ -108,8 +108,8 @@ public class AttendanceService {
     LocalDate now = LocalDate.now();
     List<Attendance> attendances = attendanceRepository.findAllByDateOrderByContinuousDayDesc(now);
     return attendances.stream()
-        .map(AttendanceResponse::from)
         .limit(4)
+        .map(AttendanceResponse::from)
         .toList();
   }
 }

--- a/src/main/java/com/keeper/homepage/domain/attendance/application/BonusPoint.java
+++ b/src/main/java/com/keeper/homepage/domain/attendance/application/BonusPoint.java
@@ -1,0 +1,30 @@
+package com.keeper.homepage.domain.attendance.application;
+
+import java.util.Arrays;
+import java.util.Optional;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum BonusPoint {
+
+  YEAR_BONUS_POINT(365, 100000),
+  MONTH_BONUS_POINT(30, 10000),
+  WEEK_BONUS_POINT(7, 3000),
+  ;
+
+  private final int date;
+  private final int point;
+
+  public static Optional<Integer> getBonusPoint(int date) {
+    return Arrays.stream(BonusPoint.values())
+        .filter(bonusPoint -> bonusPoint.isDateRange(date))
+        .map(BonusPoint::getPoint)
+        .findFirst();
+  }
+
+  private boolean isDateRange(int date) {
+    return this.date <= date;
+  }
+}

--- a/src/main/java/com/keeper/homepage/domain/attendance/application/BonusPoint.java
+++ b/src/main/java/com/keeper/homepage/domain/attendance/application/BonusPoint.java
@@ -19,12 +19,12 @@ public enum BonusPoint {
 
   public static Optional<Integer> getBonusPoint(int date) {
     return Arrays.stream(BonusPoint.values())
-        .filter(bonusPoint -> bonusPoint.isDateRange(date))
+        .filter(bonusPoint -> bonusPoint.isMatch(date))
         .map(BonusPoint::getPoint)
         .findFirst();
   }
 
-  private boolean isDateRange(int date) {
-    return this.date <= date;
+  private boolean isMatch(int date) {
+    return this.date == date;
   }
 }

--- a/src/main/java/com/keeper/homepage/domain/attendance/application/RankPoint.java
+++ b/src/main/java/com/keeper/homepage/domain/attendance/application/RankPoint.java
@@ -1,0 +1,29 @@
+package com.keeper.homepage.domain.attendance.application;
+
+import java.util.Arrays;
+import java.util.Optional;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum RankPoint {
+
+  FIRST_RANK_POINT(1),
+  SECOND_RANK_POINT(2),
+  THIRD_RANK_POINT(3),
+  ;
+
+  private final int point;
+
+  public static Optional<Integer> getRankPoint(int rank) {
+    return Arrays.stream(RankPoint.values())
+        .filter(rankPoint -> rankPoint.isMatch(rank))
+        .map(RankPoint::getPoint)
+        .findFirst();
+  }
+
+  private boolean isMatch(int rank) {
+    return this.point == rank;
+  }
+}

--- a/src/main/java/com/keeper/homepage/domain/attendance/application/RankPoint.java
+++ b/src/main/java/com/keeper/homepage/domain/attendance/application/RankPoint.java
@@ -9,11 +9,12 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum RankPoint {
 
-  FIRST_RANK_POINT(1),
-  SECOND_RANK_POINT(2),
-  THIRD_RANK_POINT(3),
+  FIRST_RANK_POINT(1, 500),
+  SECOND_RANK_POINT(2, 300),
+  THIRD_RANK_POINT(3, 100),
   ;
 
+  private final int rank;
   private final int point;
 
   public static Optional<Integer> getRankPoint(int rank) {
@@ -24,6 +25,6 @@ public enum RankPoint {
   }
 
   private boolean isMatch(int rank) {
-    return this.point == rank;
+    return this.rank == rank;
   }
 }

--- a/src/main/java/com/keeper/homepage/domain/attendance/dao/AttendanceRepository.java
+++ b/src/main/java/com/keeper/homepage/domain/attendance/dao/AttendanceRepository.java
@@ -1,8 +1,21 @@
 package com.keeper.homepage.domain.attendance.dao;
 
 import com.keeper.homepage.domain.attendance.entity.Attendance;
+import com.keeper.homepage.domain.member.entity.Member;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface AttendanceRepository extends JpaRepository<Attendance, Long> {
 
+  boolean existsByMemberAndDate(Member member, LocalDate date);
+
+  Optional<Attendance> findByMemberAndDate(Member member, LocalDate date);
+
+  Page<Attendance> findAllByDateOrderByRankAsc(LocalDate date, Pageable pageable);
+
+  List<Attendance> findAllByDateOrderByContinuousDayDesc(LocalDate date);
 }

--- a/src/main/java/com/keeper/homepage/domain/attendance/dto/response/AttendanceResponse.java
+++ b/src/main/java/com/keeper/homepage/domain/attendance/dto/response/AttendanceResponse.java
@@ -14,6 +14,7 @@ import lombok.Getter;
 @AllArgsConstructor(access = PRIVATE)
 public class AttendanceResponse {
 
+  private Integer rank;
   private String thumbnailPath;
   private String nickName;
   private Float generation;
@@ -24,6 +25,7 @@ public class AttendanceResponse {
 
   public static AttendanceResponse from(Attendance attendance) {
     return AttendanceResponse.builder()
+        .rank(attendance.getRank())
         .thumbnailPath(attendance.getMember().getThumbnailPath())
         .nickName(attendance.getMember().getNickname())
         .generation(attendance.getMember().getGeneration())

--- a/src/main/java/com/keeper/homepage/domain/attendance/dto/response/AttendanceResponse.java
+++ b/src/main/java/com/keeper/homepage/domain/attendance/dto/response/AttendanceResponse.java
@@ -1,0 +1,34 @@
+package com.keeper.homepage.domain.attendance.dto.response;
+
+import static lombok.AccessLevel.PRIVATE;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.keeper.homepage.domain.attendance.entity.Attendance;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = PRIVATE)
+public class AttendanceResponse {
+
+  private String thumbnailPath;
+  private String nickName;
+  private Float generation;
+  private Integer continuousDay;
+
+  @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+  private LocalDateTime time;
+
+  public static AttendanceResponse from(Attendance attendance) {
+    return AttendanceResponse.builder()
+        .thumbnailPath(attendance.getMember().getThumbnailPath())
+        .nickName(attendance.getMember().getNickname())
+        .generation(attendance.getMember().getGeneration())
+        .continuousDay(attendance.getContinuousDay())
+        .time(attendance.getTime())
+        .build();
+  }
+}

--- a/src/main/java/com/keeper/homepage/domain/attendance/entity/Attendance.java
+++ b/src/main/java/com/keeper/homepage/domain/attendance/entity/Attendance.java
@@ -25,8 +25,7 @@ import org.hibernate.annotations.DynamicUpdate;
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "attendance",
-    indexes = @Index(name = "is_duplicated", columnList = "member_id, date", unique = true))
+@Table(name = "attendance", indexes = @Index(name = "is_duplicated", columnList = "member_id, date", unique = true))
 public class Attendance {
 
   public static final int MAX_IP_ADDRESS_LENGTH = 128;
@@ -88,5 +87,9 @@ public class Attendance {
     this.continuousDay = continuousDay;
     this.member = member;
     this.rank = rank;
+  }
+
+  public Integer getTotalPoint() {
+    return point + randomPoint + continuousPoint;
   }
 }

--- a/src/main/java/com/keeper/homepage/domain/member/application/convenience/MemberFindService.java
+++ b/src/main/java/com/keeper/homepage/domain/member/application/convenience/MemberFindService.java
@@ -16,7 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class MemberFindService {
 
-  private static final long VIRTUAL_MEMBER_ID = 1;
+  public static final long VIRTUAL_MEMBER_ID = 1;
   private final MemberRepository memberRepository;
 
   public Member getVirtualMember() {

--- a/src/main/java/com/keeper/homepage/domain/member/dao/MemberRepository.java
+++ b/src/main/java/com/keeper/homepage/domain/member/dao/MemberRepository.java
@@ -33,4 +33,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
   Optional<Member> findByIdAndIdNot(Long memberId, Long virtualId);
 
   List<Member> findAllByProfileRealNameAndIdNot(RealName realName, long virtualId);
+
+  void deleteAllByIdNot(Long virtualId);
 }

--- a/src/main/java/com/keeper/homepage/domain/member/entity/Member.java
+++ b/src/main/java/com/keeper/homepage/domain/member/entity/Member.java
@@ -29,6 +29,7 @@ import com.keeper.homepage.domain.member.entity.post.MemberHasPostDislike;
 import com.keeper.homepage.domain.member.entity.post.MemberHasPostLike;
 import com.keeper.homepage.domain.member.entity.rank.MemberRank;
 import com.keeper.homepage.domain.member.entity.type.MemberType;
+import com.keeper.homepage.domain.point.entity.PointLog;
 import com.keeper.homepage.domain.post.entity.Post;
 import com.keeper.homepage.domain.study.entity.Study;
 import com.keeper.homepage.domain.study.entity.StudyHasMember;
@@ -138,6 +139,9 @@ public class Member {
 
   @OneToMany(mappedBy = "member")
   private final List<Comment> comments = new ArrayList<>();
+
+  @OneToMany(mappedBy = "member")
+  private final List<PointLog> pointLogs = new ArrayList<>();
 
   @Builder
   private Member(Profile profile, Integer point, Integer level, Integer merit, Integer demerit,

--- a/src/main/java/com/keeper/homepage/domain/point/application/PointLogService.java
+++ b/src/main/java/com/keeper/homepage/domain/point/application/PointLogService.java
@@ -1,0 +1,29 @@
+package com.keeper.homepage.domain.point.application;
+
+import com.keeper.homepage.domain.attendance.entity.Attendance;
+import com.keeper.homepage.domain.point.dao.PointLogRepository;
+import com.keeper.homepage.domain.point.entity.PointLog;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PointLogService {
+
+  private final PointLogRepository pointLogRepository;
+
+  private static final String ATTENDANCE_POINT_MESSAGE = "출석 포인트";
+
+  @Transactional
+  public void create(Attendance attendance) {
+    pointLogRepository.save(PointLog.builder()
+        .time(attendance.getTime())
+        .member(attendance.getMember())
+        .point(attendance.getTotalPoint())
+        .detail(ATTENDANCE_POINT_MESSAGE)
+        .isSpent(true)
+        .build());
+  }
+}

--- a/src/main/java/com/keeper/homepage/domain/point/dao/PointLogRepository.java
+++ b/src/main/java/com/keeper/homepage/domain/point/dao/PointLogRepository.java
@@ -1,0 +1,12 @@
+package com.keeper.homepage.domain.point.dao;
+
+import com.keeper.homepage.domain.member.entity.Member;
+import com.keeper.homepage.domain.point.entity.PointLog;
+import java.util.Map;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PointLogRepository extends JpaRepository<PointLog, Long> {
+
+  Optional<PointLog> findByMember(Member member);
+}

--- a/src/main/java/com/keeper/homepage/domain/point/entity/PointLog.java
+++ b/src/main/java/com/keeper/homepage/domain/point/entity/PointLog.java
@@ -1,0 +1,62 @@
+package com.keeper.homepage.domain.point.entity;
+
+import static jakarta.persistence.FetchType.LAZY;
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+import com.keeper.homepage.domain.member.entity.Member;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = PROTECTED)
+@Table(name = "point_log")
+public class PointLog {
+
+  private static final int MAX_DETAIL_LENGTH = 45;
+
+  @Id
+  @GeneratedValue(strategy = IDENTITY)
+  @Column(name = "id", nullable = false, updatable = false)
+  private Long id;
+
+  @Column(name = "time", nullable = false)
+  private LocalDateTime time;
+
+  @ManyToOne(fetch = LAZY)
+  @JoinColumn(name = "member_id", nullable = false, updatable = false)
+  private Member member;
+
+  @Column(name = "point", nullable = false)
+  private Integer point;
+
+  @Column(name = "detail", length = MAX_DETAIL_LENGTH)
+  private String detail;
+
+  @ManyToOne(fetch = LAZY)
+  @JoinColumn(name = "presented", updatable = false)
+  private Member presented;
+
+  @Column(name = "is_spent", nullable = false)
+  private Boolean isSpent;
+
+  @Builder
+  private PointLog(LocalDateTime time, Member member, Integer point, String detail, Member presented, Boolean isSpent) {
+    this.time = time;
+    this.member = member;
+    this.point = point;
+    this.detail = detail;
+    this.presented = presented;
+    this.isSpent = isSpent;
+  }
+}

--- a/src/main/java/com/keeper/homepage/global/error/ErrorCode.java
+++ b/src/main/java/com/keeper/homepage/global/error/ErrorCode.java
@@ -68,6 +68,8 @@ public enum ErrorCode {
   NOT_PLAYED_YET("아직 게임을 시작하지 않았습니다.", HttpStatus.BAD_REQUEST),
   // FILE
   FILE_NOT_FOUND("해당 파일은 존재하지 않습니다.", HttpStatus.BAD_REQUEST),
+  // ATTENDANCE
+  ATTENDANCE_ALREADY("이미 출석을 완료했습니다.", HttpStatus.BAD_REQUEST),
   ;
 
   private final String message;

--- a/src/main/java/com/keeper/homepage/global/util/redis/RedisUtil.java
+++ b/src/main/java/com/keeper/homepage/global/util/redis/RedisUtil.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Duration;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
@@ -38,6 +39,12 @@ public class RedisUtil {
     } catch (JsonProcessingException e) {
       throw new RuntimeException(e);
     }
+  }
+
+  public Long increaseAndGetWithExpire(String key, long durationMillis) {
+    ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
+    redisTemplate.expire(key, durationMillis, TimeUnit.SECONDS);
+    return valueOperations.increment(key);
   }
 
   public void deleteData(String key) {

--- a/src/test/java/com/keeper/homepage/IntegrationTest.java
+++ b/src/test/java/com/keeper/homepage/IntegrationTest.java
@@ -14,6 +14,7 @@ import com.keeper.homepage.domain.about.dao.StaticWriteContentRepository;
 import com.keeper.homepage.domain.about.dao.StaticWriteSubtitleImageRepository;
 import com.keeper.homepage.domain.about.dao.StaticWriteTitleRepository;
 import com.keeper.homepage.domain.attendance.AttendanceTestHelper;
+import com.keeper.homepage.domain.attendance.application.AttendanceService;
 import com.keeper.homepage.domain.attendance.dao.AttendanceRepository;
 import com.keeper.homepage.domain.auth.application.AuthCookieService;
 import com.keeper.homepage.domain.auth.application.CheckDuplicateService;
@@ -51,6 +52,8 @@ import com.keeper.homepage.domain.member.dao.rank.MemberRankRepository;
 import com.keeper.homepage.domain.member.dao.role.MemberHasMemberJobRepository;
 import com.keeper.homepage.domain.member.dao.role.MemberJobRepository;
 import com.keeper.homepage.domain.member.dao.type.MemberTypeRepository;
+import com.keeper.homepage.domain.point.application.PointLogService;
+import com.keeper.homepage.domain.point.dao.PointLogRepository;
 import com.keeper.homepage.domain.post.CategoryTestHelper;
 import com.keeper.homepage.domain.post.PostTestHelper;
 import com.keeper.homepage.domain.post.application.PostService;
@@ -221,6 +224,9 @@ public class IntegrationTest {
   @Autowired
   protected ThumbnailRepository thumbnailRepository;
 
+  @Autowired
+  protected PointLogRepository pointLogRepository;
+
   /******* Service *******/
   @SpyBean
   protected MemberService memberService;
@@ -275,6 +281,9 @@ public class IntegrationTest {
 
   @SpykBean
   protected GameFindService gameFindService;
+
+  @SpyBean
+  protected AttendanceService attendanceService;
 
   /******* Helper *******/
   @SpyBean

--- a/src/test/java/com/keeper/homepage/domain/attendance/api/AttendanceControllerTest.java
+++ b/src/test/java/com/keeper/homepage/domain/attendance/api/AttendanceControllerTest.java
@@ -1,0 +1,128 @@
+package com.keeper.homepage.domain.attendance.api;
+
+import static com.keeper.homepage.domain.member.entity.job.MemberJob.MemberJobType.ROLE_회원;
+import static com.keeper.homepage.global.config.security.data.JwtType.ACCESS_TOKEN;
+import static com.keeper.homepage.global.restdocs.RestDocsHelper.getSecuredValue;
+import static com.keeper.homepage.global.restdocs.RestDocsHelper.listHelper;
+import static com.keeper.homepage.global.restdocs.RestDocsHelper.pageHelper;
+import static org.springframework.restdocs.cookies.CookieDocumentation.cookieWithName;
+import static org.springframework.restdocs.cookies.CookieDocumentation.requestCookies;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.keeper.homepage.IntegrationTest;
+import com.keeper.homepage.domain.member.entity.Member;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+public class AttendanceControllerTest extends IntegrationTest {
+
+  private Member member;
+  private String memberToken;
+  private final MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+
+  @BeforeEach
+  void setUp() {
+    member = memberTestHelper.generate();
+    memberToken = jwtTokenProvider.createAccessToken(ACCESS_TOKEN, member.getId(), ROLE_회원);
+
+    params.add("page", "0");
+    params.add("size", "3");
+  }
+
+  @Nested
+  @DisplayName("출석 테스트")
+  class AttendanceTest {
+
+    @Test
+    @DisplayName("유효한 요청일 경우 출석은 성공한다.")
+    public void 유효한_요청일_경우_출석은_성공한다() throws Exception {
+      String securedValue = getSecuredValue(AttendanceController.class, "create");
+
+      mockMvc.perform(post("/attendances")
+              .cookie(new Cookie(ACCESS_TOKEN.getTokenName(), memberToken)))
+          .andExpect(status().isCreated())
+          .andDo(document("create-attendance",
+              requestCookies(
+                  cookieWithName(ACCESS_TOKEN.getTokenName())
+                      .description("ACCESS TOKEN %s".formatted(securedValue))
+              )));
+    }
+  }
+
+  @Nested
+  @DisplayName("출석 랭킹 조회 테스트")
+  class GetAttendanceRankTest {
+
+    @BeforeEach
+    void setUp() {
+      attendanceTestHelper.builder().continuousDay(1).build();
+      attendanceTestHelper.builder().continuousDay(2).build();
+      attendanceTestHelper.builder().continuousDay(3).build();
+    }
+
+    @Test
+    @DisplayName("유효한 요청일 경우 당일 출석 랭킹 조회는 성공한다.")
+    public void 유효한_요청일_경우_당일_출석_랭킹_조회는_성공한다() throws Exception {
+      String securedValue = getSecuredValue(AttendanceController.class, "getTodayRanks");
+
+      mockMvc.perform(get("/attendances/today")
+              .params(params)
+              .cookie(new Cookie(ACCESS_TOKEN.getTokenName(), memberToken)))
+          .andDo(document("get-today-attendance-ranks",
+              requestCookies(
+                  cookieWithName(ACCESS_TOKEN.getTokenName())
+                      .description("ACCESS TOKEN %s".formatted(securedValue))
+              ),
+              queryParameters(
+                  parameterWithName("page").description("페이지 (default: 0)")
+                      .optional(),
+                  parameterWithName("size").description("한 페이지당 불러올 개수 (default: 10)")
+                      .optional()
+              ),
+              responseFields(
+                  pageHelper(getAttendanceResponse())
+              )));
+    }
+
+    @Test
+    @DisplayName("유효한 요청일 경우 연속 출석 랭킹 조회는 성공한다.")
+    public void 유효한_요청일_경우_연속_출석_랭킹_조회는_성공한다() throws Exception {
+      String securedValue = getSecuredValue(AttendanceController.class, "getContinuousRanks");
+
+      mockMvc.perform(get("/attendances/continuous")
+              .cookie(new Cookie(ACCESS_TOKEN.getTokenName(), memberToken)))
+          .andExpect(status().isOk())
+          .andDo(document("get-continuous-attendance-ranks",
+              requestCookies(
+                  cookieWithName(ACCESS_TOKEN.getTokenName())
+                      .description("ACCESS TOKEN %s".formatted(securedValue))
+              ),
+              responseFields(
+                  listHelper("", getAttendanceResponse())
+              )));
+    }
+
+    FieldDescriptor[] getAttendanceResponse() {
+      return new FieldDescriptor[]{
+          fieldWithPath("thumbnailPath").description("회원 썸네일 경로"),
+          fieldWithPath("nickName").description("회원 닉네임"),
+          fieldWithPath("generation").description("회원 기수"),
+          fieldWithPath("continuousDay").description("회원 연속 출석 일수"),
+          fieldWithPath("time").description("회원 출석 시간")
+      };
+    }
+  }
+}

--- a/src/test/java/com/keeper/homepage/domain/attendance/api/AttendanceControllerTest.java
+++ b/src/test/java/com/keeper/homepage/domain/attendance/api/AttendanceControllerTest.java
@@ -78,9 +78,10 @@ public class AttendanceControllerTest extends IntegrationTest {
     public void 유효한_요청일_경우_당일_출석_랭킹_조회는_성공한다() throws Exception {
       String securedValue = getSecuredValue(AttendanceController.class, "getTodayRanks");
 
-      mockMvc.perform(get("/attendances/today")
+      mockMvc.perform(get("/attendances/today-rank")
               .params(params)
               .cookie(new Cookie(ACCESS_TOKEN.getTokenName(), memberToken)))
+          .andExpect(status().isOk())
           .andDo(document("get-today-attendance-ranks",
               requestCookies(
                   cookieWithName(ACCESS_TOKEN.getTokenName())
@@ -102,7 +103,7 @@ public class AttendanceControllerTest extends IntegrationTest {
     public void 유효한_요청일_경우_연속_출석_랭킹_조회는_성공한다() throws Exception {
       String securedValue = getSecuredValue(AttendanceController.class, "getContinuousRanks");
 
-      mockMvc.perform(get("/attendances/continuous")
+      mockMvc.perform(get("/attendances/continuous-rank")
               .cookie(new Cookie(ACCESS_TOKEN.getTokenName(), memberToken)))
           .andExpect(status().isOk())
           .andDo(document("get-continuous-attendance-ranks",
@@ -117,6 +118,7 @@ public class AttendanceControllerTest extends IntegrationTest {
 
     FieldDescriptor[] getAttendanceResponse() {
       return new FieldDescriptor[]{
+          fieldWithPath("rank").description("회원 당일 출석 순위"),
           fieldWithPath("thumbnailPath").description("회원 썸네일 경로"),
           fieldWithPath("nickName").description("회원 닉네임"),
           fieldWithPath("generation").description("회원 기수"),

--- a/src/test/java/com/keeper/homepage/domain/attendance/application/AttendanceServiceTest.java
+++ b/src/test/java/com/keeper/homepage/domain/attendance/application/AttendanceServiceTest.java
@@ -1,0 +1,57 @@
+package com.keeper.homepage.domain.attendance.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.keeper.homepage.IntegrationTest;
+import com.keeper.homepage.domain.member.entity.Member;
+import com.keeper.homepage.global.error.BusinessException;
+import java.time.LocalDate;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+public class AttendanceServiceTest extends IntegrationTest {
+
+  @Nested
+  @DisplayName("출석 테스트")
+  class AttendanceTest {
+
+    @Test
+    @DisplayName("출석할 경우 Redis에서 Rank가 계산된다.")
+    public void 출석할_경우_Redis에서_Rank가_계산된다() throws Exception {
+      Member member1 = memberTestHelper.generate();
+      Member member2 = memberTestHelper.generate();
+      redisUtil.flushAll();
+      attendanceService.create(member1);
+      attendanceService.create(member2);
+
+      LocalDate now = LocalDate.now();
+      Optional<String> data = redisUtil.getData("attendance:" + now, String.class);
+
+      assertThat(data).isNotEmpty();
+      assertThat(data.get()).isEqualTo(String.valueOf(2));
+    }
+
+    @Test
+    @DisplayName("출석할 경우 포인트 내역도 성공적으로 남아야 한다.")
+    public void 출석할_경우_포인트_내역도_성공적으로_남아야_한다() throws Exception {
+      Member member = memberTestHelper.generate();
+      attendanceService.create(member);
+
+      assertThat(pointLogRepository.findByMember(member)).isNotEmpty();
+    }
+
+    @Test
+    @DisplayName("오늘 이미 출석한 경우 출석은 실패한다.")
+    public void 오늘_이미_출석한_경우_출석은_실패한다() throws Exception {
+      Member member = memberTestHelper.generate();
+      attendanceService.create(member);
+
+      assertThrows(BusinessException.class, () -> {
+        attendanceService.create(member);
+      });
+    }
+  }
+}


### PR DESCRIPTION
## 🔥 Related Issue

close: #212
close: #173
close: #172
close: #16

## 📝 Description

- 출석 기능 구현
  - `PointLog` `Entity`, `Repository` 개발
  - `Rank`는 `Redis`에서 계산하도록 하였습니다! (이전 홈페이지 코드 참고했습니다!)
- 당일의 출석 랭킹 조회 구현
- 연속 출석 랭킹 조회 구현

## ⭐️ Review

`Redis`를 처음으로 직접 사용해봤습니다...! 이것 저것 다른 것도 `Redis`에 띄우면 좋겠다는 생각이 듭니다!