### PR TITLE
fix: 댓글 목록 조회 api 스펙에 commentId 추가

### DIFF
--- a/src/main/java/com/keeper/homepage/domain/comment/dto/response/CommentResponse.java
+++ b/src/main/java/com/keeper/homepage/domain/comment/dto/response/CommentResponse.java
@@ -12,6 +12,7 @@ import lombok.Getter;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class CommentResponse {
 
+  private Long commentId;
   private String writerName;
   private String writerThumbnailPath;
   private String content;
@@ -22,6 +23,7 @@ public class CommentResponse {
 
   public static CommentResponse from(Comment comment) {
     return CommentResponse.builder()
+        .commentId(comment.getId())
         .writerName(comment.getMember().getNickname())
         .writerThumbnailPath(comment.getWriterThumbnailPath())
         .content(comment.getContent())

--- a/src/test/java/com/keeper/homepage/domain/comment/api/CommentControllerTest.java
+++ b/src/test/java/com/keeper/homepage/domain/comment/api/CommentControllerTest.java
@@ -151,6 +151,7 @@ public class CommentControllerTest extends CommentApiTestHelper {
                   parameterWithName("postId").description("조회하고자 하는 댓글목록의 게시글 ID")
               ),
               responseFields(
+                  fieldWithPath("comments[].commentId").description("댓글 ID"),
                   fieldWithPath("comments[].writerName").description("댓글 작성자 이름"),
                   fieldWithPath("comments[].writerThumbnailPath").description("댓글 작성자의 썸네일 경로"),
                   fieldWithPath("comments[].content").description("댓글 내용"),


### PR DESCRIPTION
## 🔥 Related Issue

close: #없음

## 📝 Description

빠져 있던 `commentId`를 응답으로 추가했습니다.