### PR TITLE
Feature/게시글 조회 api 스펙 변경

### DIFF
--- a/src/main/java/com/keeper/homepage/domain/post/application/PostService.java
+++ b/src/main/java/com/keeper/homepage/domain/post/application/PostService.java
@@ -28,6 +28,7 @@ import com.keeper.homepage.global.util.file.FileUtil;
 import com.keeper.homepage.global.util.thumbnail.ThumbnailUtil;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -103,7 +104,10 @@ public class PostService {
     post.addVisitCount();
 
     String writerName = getWriterName(post);
-    return PostDetailResponse.of(post, writerName);
+
+    Post previousPost = postRepository.findPreviousPost(postId, post.getCategory()).orElse(null);
+    Post nextPost = postRepository.findNextPost(postId, post.getCategory()).orElse(null);
+    return PostDetailResponse.of(post, writerName, previousPost, nextPost);
   }
 
   private void checkExamPost(Member member, Post post) {

--- a/src/main/java/com/keeper/homepage/domain/post/dao/PostRepository.java
+++ b/src/main/java/com/keeper/homepage/domain/post/dao/PostRepository.java
@@ -75,4 +75,20 @@ public interface PostRepository extends JpaRepository<Post, Long> {
       "AND p.registerTime BETWEEN :startDate AND :endDate")
   List<Post> findAllTrend(@Param("startDate") LocalDateTime startDate, @Param("endDate") LocalDateTime endDate);
 
+
+  @Query("SELECT p FROM Post p "
+      + "WHERE p.id > :postId "
+      + "AND p.category = :category "
+      + "AND p.isTemp = false "
+      + "ORDER BY p.id DESC "
+      + "LIMIT 1")
+  Optional<Post> findNextPost(@Param("postId") Long postId, @Param("category") Category category);
+
+  @Query("SELECT p FROM Post p "
+      + "WHERE p.id < :postId "
+      + "AND p.category = :category "
+      + "AND p.isTemp = false "
+      + "ORDER BY p.id DESC "
+      + "LIMIT 1")
+  Optional<Post> findPreviousPost(@Param("postId") Long postId, @Param("category") Category category);
 }

--- a/src/main/java/com/keeper/homepage/domain/post/dto/response/AdjacentPostResponse.java
+++ b/src/main/java/com/keeper/homepage/domain/post/dto/response/AdjacentPostResponse.java
@@ -1,0 +1,19 @@
+package com.keeper.homepage.domain.post.dto.response;
+
+import static lombok.AccessLevel.PRIVATE;
+
+import com.keeper.homepage.domain.post.entity.Post;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = PRIVATE)
+public class AdjacentPostResponse {
+
+  private Long postId;
+  private String title;
+
+  public static AdjacentPostResponse from(Post post) {
+    return new AdjacentPostResponse(post.getId(), post.getTitle());
+  }
+}

--- a/src/main/java/com/keeper/homepage/domain/post/dto/response/PostDetailResponse.java
+++ b/src/main/java/com/keeper/homepage/domain/post/dto/response/PostDetailResponse.java
@@ -1,6 +1,5 @@
 package com.keeper.homepage.domain.post.dto.response;
 
-import static java.util.stream.Collectors.toList;
 import static lombok.AccessLevel.PRIVATE;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
@@ -37,7 +36,10 @@ public class PostDetailResponse {
   @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
   private LocalDateTime updateTime;
 
-  public static PostDetailResponse of(Post post, String writerName) {
+  private AdjacentPostResponse previousPost;
+  private AdjacentPostResponse nextPost;
+
+  public static PostDetailResponse of(Post post, String writerName, Post previousPost, Post nextPost) {
     return PostDetailResponse.builder()
         .categoryName(post.getCategory().getName())
         .title(post.getTitle())
@@ -57,6 +59,8 @@ public class PostDetailResponse {
         .isNotice(post.isNotice())
         .isSecret(post.isSecret())
         .isTemp(post.isTemp())
+        .previousPost(previousPost != null ? AdjacentPostResponse.from(previousPost) : null)
+        .nextPost(nextPost != null ? AdjacentPostResponse.from(nextPost) : null)
         .build();
   }
 }

--- a/src/test/java/com/keeper/homepage/domain/post/api/PostControllerTest.java
+++ b/src/test/java/com/keeper/homepage/domain/post/api/PostControllerTest.java
@@ -67,6 +67,7 @@ public class PostControllerTest extends PostApiTestHelper {
     thumbnail = thumbnailTestHelper.getSmallThumbnailFile();
     file = new MockMultipartFile("files", "testImage_1x1.png", "image/png",
         new FileInputStream("src/test/resources/images/testImage_1x1.png"));
+    postTestHelper.builder().category(category).build();
     post = postTestHelper.builder().member(member).build();
     postId = post.getId();
   }
@@ -295,6 +296,7 @@ public class PostControllerTest extends PostApiTestHelper {
       String securedValue = getSecuredValue(PostController.class, "getPost");
 
       postId = postService.create(post, category.getId(), thumbnail, List.of(file));
+      postTestHelper.builder().category(category).build();
       em.flush();
       em.clear();
 
@@ -329,7 +331,11 @@ public class PostControllerTest extends PostApiTestHelper {
                   fieldWithPath("allowComment").description("댓글 허용 여부"),
                   fieldWithPath("isNotice").description("공지글 여부"),
                   fieldWithPath("isSecret").description("비밀글 여부"),
-                  fieldWithPath("isTemp").description("임시 저장글 여부")
+                  fieldWithPath("isTemp").description("임시 저장글 여부"),
+                  fieldWithPath("previousPost.postId").description("이전 게시글 ID"),
+                  fieldWithPath("previousPost.title").description("이전 게시글 제목"),
+                  fieldWithPath("nextPost.postId").description("다음 게시글 ID"),
+                  fieldWithPath("nextPost.title").description("다음 게시글 제목")
               )));
     }
 
@@ -338,8 +344,10 @@ public class PostControllerTest extends PostApiTestHelper {
     public void should_success_when_samePassword() throws Exception {
       String securedValue = getSecuredValue(PostController.class, "getPost");
 
+      postTestHelper.builder().category(category).build();
       post = postTestHelper.builder().member(other).password("비밀비밀").build();
       postId = postService.create(post, category.getId(), thumbnail, List.of(file));
+      postTestHelper.builder().category(category).build();
       em.flush();
       em.clear();
 
@@ -378,7 +386,11 @@ public class PostControllerTest extends PostApiTestHelper {
                   fieldWithPath("allowComment").description("댓글 허용 여부"),
                   fieldWithPath("isNotice").description("공지글 여부"),
                   fieldWithPath("isSecret").description("비밀글 여부"),
-                  fieldWithPath("isTemp").description("임시 저장글 여부")
+                  fieldWithPath("isTemp").description("임시 저장글 여부"),
+                  fieldWithPath("previousPost.postId").description("이전 게시글 ID"),
+                  fieldWithPath("previousPost.title").description("이전 게시글 제목"),
+                  fieldWithPath("nextPost.postId").description("다음 게시글 ID"),
+                  fieldWithPath("nextPost.title").description("다음 게시글 제목")
               )));
     }
 

--- a/src/test/java/com/keeper/homepage/domain/post/application/PostServiceTest.java
+++ b/src/test/java/com/keeper/homepage/domain/post/application/PostServiceTest.java
@@ -306,6 +306,50 @@ public class PostServiceTest extends IntegrationTest {
         postService.find(bestMember, post.getId(), null);
       });
     }
+
+    @Test
+    @DisplayName("id 기준으로 카테고리에 해당하는 이전과 다음 게시글 하나는 성공적으로 조회된다.")
+    public void id_기준으로_카테고리에_해당하는_이전과_다음_게시글_하나는_성공적으로_조회된다() throws Exception {
+      Post first = postTestHelper.builder().category(category).build();
+      Post middle = postTestHelper.builder().member(member).category(category).build();
+      Post last = postTestHelper.builder().category(category).build();
+
+      em.flush();
+      em.clear();
+      PostDetailResponse response = postService.find(member, middle.getId(), null);
+
+      assertThat(response.getPreviousPost().getPostId()).isEqualTo(first.getId());
+      assertThat(response.getNextPost().getPostId()).isEqualTo(last.getId());
+    }
+
+    @Test
+    @DisplayName("이전, 다음 게시글으로 임시 저장글은 조회되면 안돤다.")
+    public void 이전_다음_게시글으로_임시_저장글은_조회되면_안돤다() throws Exception {
+      Post first = postTestHelper.builder().category(category).isTemp(true).build();
+      Post middle = postTestHelper.builder().member(member).category(category).build();
+      Post last = postTestHelper.builder().category(category).build();
+
+      em.flush();
+      em.clear();
+      PostDetailResponse response = postService.find(member, middle.getId(), null);
+
+      assertThat(response.getPreviousPost().getPostId()).isNotEqualTo(first.getId());
+      assertThat(response.getNextPost().getPostId()).isEqualTo(last.getId());
+    }
+
+    @Test
+    @DisplayName("이전, 혹은 다음 게시글이 없을 경우 null로 조회된다.")
+    public void 이전_혹은_다음_게시글이_없을_경우_null로_조회된다() throws Exception {
+      Post first = postTestHelper.builder().category(category).build();
+      Post middle = postTestHelper.builder().member(member).category(category).build();
+
+      em.flush();
+      em.clear();
+      PostDetailResponse response = postService.find(member, middle.getId(), null);
+
+      assertThat(response.getPreviousPost().getPostId()).isEqualTo(first.getId());
+      assertThat(response.getNextPost()).isEqualTo(null);
+    }
   }
 
   @Nested


### PR DESCRIPTION
## 🔥 Related Issue

close: #없음

## 📝 Description

![image](https://github.com/KEEPER31337/Homepage-Back-R2/assets/92802207/0d51c0f6-39bc-46bf-ac52-4b6aae4dc2f2)

요구사항에 맞게 게시글 조회 api의 응답 필드에 이전, 다음 게시글 정보를 추가했습니다.

---

게시글 쪽 테스트 코드 엉망이네요... 일단 미루고 추후 리팩토링 하겠습니다 😂