### PR TITLE
Feature/study + member_job db 변경 적용

### DIFF
--- a/src/main/java/com/keeper/homepage/domain/member/entity/job/MemberJob.java
+++ b/src/main/java/com/keeper/homepage/domain/member/entity/job/MemberJob.java
@@ -64,12 +64,13 @@ public class MemberJob {
     ROLE_부회장(2),
     ROLE_대외부장(3),
     ROLE_학술부장(4),
-    ROLE_전산관리자(5),
-    ROLE_서기(6),
-    ROLE_총무(7),
-    ROLE_사서(8),
-    ROLE_회원(9),
-    ROLE_출제자(10),
+    ROLE_FRONT_전산관리자(5),
+    ROLE_BACK_전산관리자(6),
+    ROLE_서기(7),
+    ROLE_총무(8),
+    ROLE_사서(9),
+    ROLE_회원(10),
+    ROLE_출제자(11),
     ;
 
     private final long id;

--- a/src/main/java/com/keeper/homepage/domain/study/dto/request/StudyCreateRequest.java
+++ b/src/main/java/com/keeper/homepage/domain/study/dto/request/StudyCreateRequest.java
@@ -2,14 +2,14 @@ package com.keeper.homepage.domain.study.dto.request;
 
 import static com.keeper.homepage.domain.study.entity.embedded.GitLink.GIT_LINK_INVALID;
 import static com.keeper.homepage.domain.study.entity.embedded.GitLink.GIT_LINK_REGEX;
-import static com.keeper.homepage.domain.study.entity.embedded.NoteLink.NOTION_LINK_INVALID;
-import static com.keeper.homepage.domain.study.entity.embedded.NoteLink.NOTION_LINK_REGEX;
+import static com.keeper.homepage.domain.study.entity.embedded.NotionLink.NOTION_LINK_INVALID;
+import static com.keeper.homepage.domain.study.entity.embedded.NotionLink.NOTION_LINK_REGEX;
 import static lombok.AccessLevel.PRIVATE;
 
 import com.keeper.homepage.domain.member.entity.Member;
 import com.keeper.homepage.domain.study.entity.embedded.GitLink;
 import com.keeper.homepage.domain.study.entity.embedded.Link;
-import com.keeper.homepage.domain.study.entity.embedded.NoteLink;
+import com.keeper.homepage.domain.study.entity.embedded.NotionLink;
 import com.keeper.homepage.domain.study.entity.Study;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -49,7 +49,7 @@ public class StudyCreateRequest {
 
   @Nullable
   @Pattern(regexp = NOTION_LINK_REGEX, message = NOTION_LINK_INVALID)
-  private String noteLink;
+  private String notionLink;
 
   @Nullable
   private String etcLink;
@@ -66,7 +66,7 @@ public class StudyCreateRequest {
         .season(season)
         .link(Link.builder()
             .gitLink(gitLink == null ? null : GitLink.from(gitLink))
-            .noteLink(noteLink == null ? null : NoteLink.from(noteLink))
+            .notionLink(notionLink == null ? null : NotionLink.from(notionLink))
             .etcLink(etcLink)
             .build())
         .build();

--- a/src/main/java/com/keeper/homepage/domain/study/dto/request/StudyUpdateRequest.java
+++ b/src/main/java/com/keeper/homepage/domain/study/dto/request/StudyUpdateRequest.java
@@ -4,15 +4,14 @@ import static com.keeper.homepage.domain.study.dto.request.StudyCreateRequest.ST
 import static com.keeper.homepage.domain.study.dto.request.StudyCreateRequest.STUDY_TITLE_LENGTH;
 import static com.keeper.homepage.domain.study.entity.embedded.GitLink.GIT_LINK_INVALID;
 import static com.keeper.homepage.domain.study.entity.embedded.GitLink.GIT_LINK_REGEX;
-import static com.keeper.homepage.domain.study.entity.embedded.NoteLink.NOTION_LINK_INVALID;
-import static com.keeper.homepage.domain.study.entity.embedded.NoteLink.NOTION_LINK_REGEX;
+import static com.keeper.homepage.domain.study.entity.embedded.NotionLink.NOTION_LINK_INVALID;
+import static com.keeper.homepage.domain.study.entity.embedded.NotionLink.NOTION_LINK_REGEX;
 import static lombok.AccessLevel.PRIVATE;
 
-import com.keeper.homepage.domain.member.entity.Member;
 import com.keeper.homepage.domain.study.entity.Study;
 import com.keeper.homepage.domain.study.entity.embedded.GitLink;
 import com.keeper.homepage.domain.study.entity.embedded.Link;
-import com.keeper.homepage.domain.study.entity.embedded.NoteLink;
+import com.keeper.homepage.domain.study.entity.embedded.NotionLink;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
@@ -49,7 +48,7 @@ public class StudyUpdateRequest {
 
   @Nullable
   @Pattern(regexp = NOTION_LINK_REGEX, message = NOTION_LINK_INVALID)
-  private String noteLink;
+  private String notionLink;
 
   @Nullable
   private String etcLink;
@@ -62,7 +61,7 @@ public class StudyUpdateRequest {
         .season(season)
         .link(Link.builder()
             .gitLink(gitLink == null ? null : GitLink.from(gitLink))
-            .noteLink(noteLink == null ? null : NoteLink.from(noteLink))
+            .notionLink(notionLink == null ? null : NotionLink.from(notionLink))
             .etcLink(etcLink)
             .build())
         .build();

--- a/src/main/java/com/keeper/homepage/domain/study/dto/response/StudyDetailResponse.java
+++ b/src/main/java/com/keeper/homepage/domain/study/dto/response/StudyDetailResponse.java
@@ -18,7 +18,7 @@ public class StudyDetailResponse {
   private String information;
   private List<String> members;
   private String gitLink;
-  private String noteLink;
+  private String notionLink;
   private String etcLink;
 
   public static StudyDetailResponse from(Study study) {
@@ -30,7 +30,7 @@ public class StudyDetailResponse {
             .map(Member::getRealName)
             .toList())
         .gitLink(study.getGitLink())
-        .noteLink(study.getNoteLink())
+        .notionLink(study.getNotionLink())
         .etcLink(study.getEtcLink())
         .build();
   }

--- a/src/main/java/com/keeper/homepage/domain/study/entity/Study.java
+++ b/src/main/java/com/keeper/homepage/domain/study/entity/Study.java
@@ -63,7 +63,7 @@ public class Study extends BaseEntity {
   @Embedded
   @AttributeOverrides({
       @AttributeOverride(name = "gitLink", column = @Column(name = "git_link", length = MAX_LINK_LENGTH)),
-      @AttributeOverride(name = "noteLink", column = @Column(name = "note_link", length = MAX_LINK_LENGTH)),
+      @AttributeOverride(name = "notionLink", column = @Column(name = "notion_link", length = MAX_LINK_LENGTH)),
       @AttributeOverride(name = "etcLink", column = @Column(name = "etc_link", length = MAX_LINK_LENGTH))
   })
   private Link link;
@@ -105,8 +105,8 @@ public class Study extends BaseEntity {
     return this.link.getGitLink().get();
   }
 
-  public String getNoteLink() {
-    return this.link.getNoteLink().get();
+  public String getNotionLink() {
+    return this.link.getNotionLink().get();
   }
 
   public String getEtcLink() {

--- a/src/main/java/com/keeper/homepage/domain/study/entity/embedded/Link.java
+++ b/src/main/java/com/keeper/homepage/domain/study/entity/embedded/Link.java
@@ -17,18 +17,18 @@ public class Link {
   private GitLink gitLink;
 
   @Embedded
-  private NoteLink noteLink;
+  private NotionLink notionLink;
 
   private String etcLink;
 
   @Builder
-  private Link(GitLink gitLink, NoteLink noteLink, String etcLink) {
+  private Link(GitLink gitLink, NotionLink notionLink, String etcLink) {
     this.gitLink = gitLink;
-    this.noteLink = noteLink;
+    this.notionLink = notionLink;
     this.etcLink = etcLink;
   }
 
   public boolean isEmpty() {
-    return gitLink == null && noteLink == null && etcLink == null;
+    return gitLink == null && notionLink == null && etcLink == null;
   }
 }

--- a/src/main/java/com/keeper/homepage/domain/study/entity/embedded/NotionLink.java
+++ b/src/main/java/com/keeper/homepage/domain/study/entity/embedded/NotionLink.java
@@ -11,20 +11,20 @@ import lombok.NoArgsConstructor;
 @Embeddable
 @NoArgsConstructor(access = PROTECTED)
 @AllArgsConstructor(access = PRIVATE)
-public class NoteLink {
+public class NotionLink {
 
   public static final String NOTION_LINK_INVALID = "https://www.notion.so/ 로 시작하는 노션 주소를 입력해주세요.";
   public static final String NOTION_LINK_REGEX = "^https://www.notion.so/\\S+$";
 
   private static final Pattern NOTION_LINK_FORMAT = Pattern.compile(NOTION_LINK_REGEX);
 
-  private String noteLink;
+  private String notionLink;
 
-  public static NoteLink from(String noteLink) {
-    if (isInvalidFormat(noteLink)) {
+  public static NotionLink from(String notionLink) {
+    if (isInvalidFormat(notionLink)) {
       throw new IllegalArgumentException(NOTION_LINK_INVALID);
     }
-    return new NoteLink(noteLink);
+    return new NotionLink(notionLink);
   }
 
   private static boolean isInvalidFormat(String noteLink) {
@@ -32,6 +32,6 @@ public class NoteLink {
   }
 
   public String get() {
-    return this.noteLink;
+    return this.notionLink;
   }
 }

--- a/src/test/java/com/keeper/homepage/domain/study/StudyTestHelper.java
+++ b/src/test/java/com/keeper/homepage/domain/study/StudyTestHelper.java
@@ -5,7 +5,7 @@ import com.keeper.homepage.domain.member.entity.Member;
 import com.keeper.homepage.domain.study.dao.StudyRepository;
 import com.keeper.homepage.domain.study.entity.embedded.GitLink;
 import com.keeper.homepage.domain.study.entity.embedded.Link;
-import com.keeper.homepage.domain.study.entity.embedded.NoteLink;
+import com.keeper.homepage.domain.study.entity.embedded.NotionLink;
 import com.keeper.homepage.domain.study.entity.Study;
 import com.keeper.homepage.domain.thumbnail.entity.Thumbnail;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -34,7 +34,7 @@ public class StudyTestHelper {
     private Integer year;
     private Integer season;
     private GitLink gitLink;
-    private NoteLink noteLink;
+    private NotionLink notionLink;
     private String etcLink;
     private Thumbnail thumbnail;
     private Member headMember;
@@ -64,8 +64,8 @@ public class StudyTestHelper {
       return this;
     }
 
-    public StudyBuilder NoteLink(NoteLink noteLink) {
-      this.noteLink = noteLink;
+    public StudyBuilder NotionLink(NotionLink notionLink) {
+      this.notionLink = notionLink;
       return this;
     }
 
@@ -92,7 +92,7 @@ public class StudyTestHelper {
           .season(season)
           .link(Link.builder()
               .gitLink(gitLink != null ? gitLink : GitLink.from("https://github.com/KEEPER31337/Homepage-Back-R2"))
-              .noteLink(noteLink != null ? noteLink : NoteLink.from("https://www.notion.so/Java-Spring"))
+              .notionLink(notionLink != null ? notionLink : NotionLink.from("https://www.notion.so/Java-Spring"))
               .etcLink(etcLink != null ? etcLink : "etc.com")
               .build())
           .thumbnail(thumbnail)

--- a/src/test/java/com/keeper/homepage/domain/study/api/StudyControllerTest.java
+++ b/src/test/java/com/keeper/homepage/domain/study/api/StudyControllerTest.java
@@ -130,7 +130,7 @@ public class StudyControllerTest extends StudyApiTestHelper {
       params.add("year", "2023");
       params.add("season", "1");
       params.add("gitLink", "https://github.com/KEEPER31337/Homepage-Back-R2");
-      params.add("noteLink", "https://www.youtube.com/");
+      params.add("notionLink", "https://www.youtube.com/");
       params.add("etcLink", "etc.com");
 
       callCreateStudyApiWithThumbnail(memberToken, thumbnail, params)
@@ -196,7 +196,7 @@ public class StudyControllerTest extends StudyApiTestHelper {
                   fieldWithPath("information").description("스터디 정보"),
                   fieldWithPath("members[]").description("스터디원 실명 리스트"),
                   fieldWithPath("gitLink").description("스터디 깃허브 링크 주소"),
-                  fieldWithPath("noteLink").description("스터디 노트(노션) 링크 주소"),
+                  fieldWithPath("notionLink").description("스터디 노트(노션) 링크 주소"),
                   fieldWithPath("etcLink").description("스터디 기타 링크 주소")
               )));
     }
@@ -263,7 +263,7 @@ public class StudyControllerTest extends StudyApiTestHelper {
                   field("gitLink", "깃허브 링크")
                       .attributes(new Attribute("format", "\"https://github.com\"으로 시작"))
                       .optional(),
-                  field("noteLink", "노션 링크")
+                  field("notionLink", "노션 링크")
                       .attributes(new Attribute("format", "\"https://www.notion.so\"으로 시작"))
                       .optional(),
                   field("etcLink", "기타 링크")


### PR DESCRIPTION
## 🔥 Related Issue

close: #202
close: #226

## 📝 Description

20230716일자 DB 업데이트 사항을 백엔드에 적용했습니다.
- `study`
   - `note_link` 컬럼명을 `notion_link`로 변경했습니다. (기획 상 노션 링크만 받게되어 그렇습니다.)
- `member_job`
   - `ROLE_전산관리자` 직책을 `ROLE_FRONT_전산관리자` , `ROLE_BACK_전산관리자` 직책으로 나눴습니다. 이제 두 직책을 구별할 수 있습니다.