### PR TITLE
파일 포함 데이터 전달 시 requestBody로 전달하도록 변경

### DIFF
--- a/src/docs/asciidoc/library/book-manage.adoc
+++ b/src/docs/asciidoc/library/book-manage.adoc
@@ -51,7 +51,7 @@ include::{snippets}/assign-book/http-request.adoc[]
 
 include::{snippets}/assign-book/request-cookies.adoc[]
 
-==== Request Parameters
+==== Request Fields
 
 include::{snippets}/assign-book/request-part-bookMetaData-fields.adoc[]
 

--- a/src/docs/asciidoc/library/book-manage.adoc
+++ b/src/docs/asciidoc/library/book-manage.adoc
@@ -53,7 +53,7 @@ include::{snippets}/assign-book/request-cookies.adoc[]
 
 ==== Request Parameters
 
-include::{snippets}/assign-book/query-parameters.adoc[]
+include::{snippets}/assign-book/request-part-bookMetaData-fields.adoc[]
 
 ==== Request Parts
 

--- a/src/main/java/com/keeper/homepage/domain/library/api/BookManageController.kt
+++ b/src/main/java/com/keeper/homepage/domain/library/api/BookManageController.kt
@@ -11,6 +11,7 @@ import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.PositiveOrZero
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageRequest
+import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.annotation.Secured
 import org.springframework.validation.annotation.Validated
@@ -40,16 +41,17 @@ class BookManageController(
                 .map { book -> BookDetailResponse(book) })
     }
 
-    @PostMapping
+    @PostMapping(consumes = [MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE])
     fun addBook(
-        @ModelAttribute @Valid request: BookRequest
+        @RequestPart @Valid bookMetaData: BookRequest,
+        @RequestPart thumbnail: MultipartFile?,
     ): ResponseEntity<Void> {
         val addedBookId = bookManageService.addBook(
-            request.title!!,
-            request.author!!,
-            request.totalQuantity!!,
-            request.bookDepartment!!,
-            request.thumbnail,
+            bookMetaData.title!!,
+            bookMetaData.author!!,
+            bookMetaData.totalQuantity!!,
+            bookMetaData.bookDepartment!!,
+            thumbnail,
         )
         return ResponseEntity.created(URI.create("/books/${addedBookId}"))
             .build()

--- a/src/main/java/com/keeper/homepage/domain/library/dto/req/BookRequest.kt
+++ b/src/main/java/com/keeper/homepage/domain/library/dto/req/BookRequest.kt
@@ -26,6 +26,4 @@ data class BookRequest(
 
     @field:NotNull
     val bookDepartment: BookDepartment.BookDepartmentType?,
-
-    val thumbnail: MultipartFile?,
 )


### PR DESCRIPTION
## 🔥 Related Issue

[슬랙 호출 🥲](https://keepernewhome-5o41027.slack.com/archives/C04LNV3V604/p1690089269942479?thread_ts=1690041572.996339&cid=C04LNV3V604)

## 📝 Description

`content-type`이 `multipart/form-data`인 API의 경우 url query parameter로 request를 보냈었는데, 이렇게 되면 [url 길이 제한(2038자](https://support.microsoft.com/ko-kr/topic/internet-explorer%EC%9D%98-%EC%B5%9C%EB%8C%80-url-%EA%B8%B8%EC%9D%B4%EB%8A%94-2-083%EC%9E%90%EC%9E%85%EB%8B%88%EB%8B%A4-174e7c8a-6666-f4e0-6fd6-908b53c12246) 때문에 문제가 생길 수 있어서 request body로 데이터를 받게끔 변경함.

## ⭐️ Review Request

월요일 좋아~ 😭😭😭😭😭😭😭😭😭😭😭😭😭😭😭😭😭😭😭😭😭😭😭
