### PR TITLE
Feature/ctf 팀 api 개발

### DIFF
--- a/src/docs/asciidoc/ctf/ctf-team.adoc
+++ b/src/docs/asciidoc/ctf/ctf-team.adoc
@@ -60,3 +60,29 @@ include::{snippets}/update-ctf-team/request-fields.adoc[]
 ==== Response
 
 include::{snippets}/update-ctf-team/http-response.adoc[]
+
+== *CTF 팀 조회*
+
+=== 요청
+
+==== Request
+
+include::{snippets}/get-ctf-team/http-request.adoc[]
+
+==== Request Cookies
+
+include::{snippets}/get-ctf-team/request-cookies.adoc[]
+
+==== Path Parameters
+
+include::{snippets}/get-ctf-team/path-parameters.adoc[]
+
+=== 응답
+
+==== Response
+
+include::{snippets}/get-ctf-team/http-response.adoc[]
+
+==== Response Fields
+
+include::{snippets}/get-ctf-team/response-fields.adoc[]

--- a/src/docs/asciidoc/ctf/ctf-team.adoc
+++ b/src/docs/asciidoc/ctf/ctf-team.adoc
@@ -36,3 +36,27 @@ include::{snippets}/create-ctf-team/request-fields.adoc[]
 ==== Response
 
 include::{snippets}/create-ctf-team/http-response.adoc[]
+
+== *CTF 팀 정보 수정*
+
+NOTE: 팀원만 호출 가능합니다.
+
+=== 요청
+
+==== Request
+
+include::{snippets}/update-ctf-team/http-request.adoc[]
+
+==== Request Cookies
+
+include::{snippets}/update-ctf-team/request-cookies.adoc[]
+
+==== Request Fields
+
+include::{snippets}/update-ctf-team/request-fields.adoc[]
+
+=== 응답
+
+==== Response
+
+include::{snippets}/update-ctf-team/http-response.adoc[]

--- a/src/docs/asciidoc/ctf/ctf-team.adoc
+++ b/src/docs/asciidoc/ctf/ctf-team.adoc
@@ -112,3 +112,51 @@ include::{snippets}/get-ctf-teams/http-response.adoc[]
 ==== Response Fields
 
 include::{snippets}/get-ctf-teams/response-fields.adoc[]
+
+== *CTF 팀 가입*
+
+=== 요청
+
+==== Request
+
+include::{snippets}/join-ctf-team/http-request.adoc[]
+
+==== Request Cookies
+
+include::{snippets}/join-ctf-team/request-cookies.adoc[]
+
+==== Path Parameters
+
+include::{snippets}/join-ctf-team/path-parameters.adoc[]
+
+==== Request Fields
+
+include::{snippets}/join-ctf-team/request-fields.adoc[]
+
+=== 응답
+
+==== Response
+
+include::{snippets}/join-ctf-team/http-response.adoc[]
+
+== *CTF 팀 탈퇴*
+
+=== 요청
+
+==== Request
+
+include::{snippets}/leave-ctf-team/http-request.adoc[]
+
+==== Request Cookies
+
+include::{snippets}/leave-ctf-team/request-cookies.adoc[]
+
+==== Path Parameters
+
+include::{snippets}/leave-ctf-team/path-parameters.adoc[]
+
+=== 응답
+
+==== Response
+
+include::{snippets}/leave-ctf-team/http-response.adoc[]

--- a/src/docs/asciidoc/ctf/ctf-team.adoc
+++ b/src/docs/asciidoc/ctf/ctf-team.adoc
@@ -86,3 +86,29 @@ include::{snippets}/get-ctf-team/http-response.adoc[]
 ==== Response Fields
 
 include::{snippets}/get-ctf-team/response-fields.adoc[]
+
+== *CTF 팀 목록 조회 (검색)*
+
+=== 요청
+
+==== Request
+
+include::{snippets}/get-ctf-teams/http-request.adoc[]
+
+==== Request Cookies
+
+include::{snippets}/get-ctf-teams/request-cookies.adoc[]
+
+==== Query Parameters
+
+include::{snippets}/get-ctf-teams/query-parameters.adoc[]
+
+=== 응답
+
+==== Response
+
+include::{snippets}/get-ctf-teams/http-response.adoc[]
+
+==== Response Fields
+
+include::{snippets}/get-ctf-teams/response-fields.adoc[]

--- a/src/docs/asciidoc/ctf/ctf-team.adoc
+++ b/src/docs/asciidoc/ctf/ctf-team.adoc
@@ -1,0 +1,38 @@
+ifndef::snippets[]
+:snippets: ./build/generated-snippets
+endif::[]
+
+= CTF TEAM API 문서
+:icons: font
+:source-highlighter: highlight.js
+:toc: left
+:toclevels: 1
+:sectlinks:
+
+== API 목록
+
+link:../keeper.html[API 목록으로 돌아가기]
+
+== *CTF 팀 생성*
+
+NOTE: 호출 시 생성된 팀의 팀원으로 추가됩니다.
+
+=== 요청
+
+==== Request
+
+include::{snippets}/create-ctf-team/http-request.adoc[]
+
+==== Request Cookies
+
+include::{snippets}/create-ctf-team/request-cookies.adoc[]
+
+==== Request Fields
+
+include::{snippets}/create-ctf-team/request-fields.adoc[]
+
+=== 응답
+
+==== Response
+
+include::{snippets}/create-ctf-team/http-response.adoc[]

--- a/src/docs/asciidoc/keeper.adoc
+++ b/src/docs/asciidoc/keeper.adoc
@@ -52,3 +52,7 @@ link:game/game.html[API 문서 보기]
 == *ATTENDANCE API*
 
 link:attendance/attendance.html[API 문서 보기]
+
+== *CTF API*
+
+link:ctf/ctf-team[CTF TEAM API 문서 보기]

--- a/src/main/java/com/keeper/homepage/domain/ctf/api/CtfTeamController.java
+++ b/src/main/java/com/keeper/homepage/domain/ctf/api/CtfTeamController.java
@@ -3,12 +3,14 @@ package com.keeper.homepage.domain.ctf.api;
 import com.keeper.homepage.domain.ctf.application.CtfTeamService;
 import com.keeper.homepage.domain.ctf.dto.request.CreateTeamRequest;
 import com.keeper.homepage.domain.ctf.dto.request.UpdateTeamRequest;
+import com.keeper.homepage.domain.ctf.dto.response.CtfTeamDetailResponse;
 import com.keeper.homepage.domain.member.entity.Member;
 import com.keeper.homepage.global.config.security.annotation.LoginMember;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -42,5 +44,12 @@ public class CtfTeamController {
     ctfTeamService.updateTeam(member, teamId, request);
     return ResponseEntity.status(HttpStatus.CREATED)
         .build();
+  }
+
+  @GetMapping("/{teamId}")
+  public ResponseEntity<CtfTeamDetailResponse> getTeam(
+      @PathVariable long teamId
+  ) {
+    return ResponseEntity.ok(ctfTeamService.getTeam(teamId));
   }
 }

--- a/src/main/java/com/keeper/homepage/domain/ctf/api/CtfTeamController.java
+++ b/src/main/java/com/keeper/homepage/domain/ctf/api/CtfTeamController.java
@@ -1,0 +1,32 @@
+package com.keeper.homepage.domain.ctf.api;
+
+import com.keeper.homepage.domain.ctf.application.CtfTeamService;
+import com.keeper.homepage.domain.ctf.dto.request.CreateTeamRequest;
+import com.keeper.homepage.domain.member.entity.Member;
+import com.keeper.homepage.global.config.security.annotation.LoginMember;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/ctf/teams")
+public class CtfTeamController {
+
+  private final CtfTeamService ctfTeamService;
+
+  @PostMapping
+  public ResponseEntity<Void> createTeam(
+      @LoginMember Member member,
+      @RequestBody @Valid CreateTeamRequest request
+  ) {
+    ctfTeamService.createTeam(member, request);
+    return ResponseEntity.status(HttpStatus.CREATED)
+        .build();
+  }
+}

--- a/src/main/java/com/keeper/homepage/domain/ctf/api/CtfTeamController.java
+++ b/src/main/java/com/keeper/homepage/domain/ctf/api/CtfTeamController.java
@@ -2,6 +2,7 @@ package com.keeper.homepage.domain.ctf.api;
 
 import com.keeper.homepage.domain.ctf.application.CtfTeamService;
 import com.keeper.homepage.domain.ctf.dto.request.CreateTeamRequest;
+import com.keeper.homepage.domain.ctf.dto.request.JoinTeamRequest;
 import com.keeper.homepage.domain.ctf.dto.request.UpdateTeamRequest;
 import com.keeper.homepage.domain.ctf.dto.response.CtfTeamDetailResponse;
 import com.keeper.homepage.domain.ctf.dto.response.CtfTeamResponse;
@@ -14,6 +15,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -66,5 +68,25 @@ public class CtfTeamController {
       @RequestParam(defaultValue = "10") @PositiveOrZero int size
   ) {
     return ResponseEntity.ok(ctfTeamService.getTeams(contestId, search, PageRequest.of(page, size)));
+  }
+
+  @PostMapping("/{teamId}/members/{memberId}")
+  public ResponseEntity<Void> joinTeam(
+      @RequestBody @Valid JoinTeamRequest request,
+      @PathVariable long teamId,
+      @PathVariable long memberId
+  ) {
+    ctfTeamService.joinTeam(request.getContestId(), teamId, memberId);
+    return ResponseEntity.status(HttpStatus.CREATED)
+        .build();
+  }
+
+  @DeleteMapping("/{teamId}/members/{memberId}")
+  public ResponseEntity<Void> leaveTeam(
+      @PathVariable long teamId,
+      @PathVariable long memberId
+  ) {
+    ctfTeamService.leaveTeam(teamId, memberId);
+    return ResponseEntity.noContent().build();
   }
 }

--- a/src/main/java/com/keeper/homepage/domain/ctf/api/CtfTeamController.java
+++ b/src/main/java/com/keeper/homepage/domain/ctf/api/CtfTeamController.java
@@ -2,13 +2,16 @@ package com.keeper.homepage.domain.ctf.api;
 
 import com.keeper.homepage.domain.ctf.application.CtfTeamService;
 import com.keeper.homepage.domain.ctf.dto.request.CreateTeamRequest;
+import com.keeper.homepage.domain.ctf.dto.request.UpdateTeamRequest;
 import com.keeper.homepage.domain.member.entity.Member;
 import com.keeper.homepage.global.config.security.annotation.LoginMember;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -26,6 +29,17 @@ public class CtfTeamController {
       @RequestBody @Valid CreateTeamRequest request
   ) {
     ctfTeamService.createTeam(member, request);
+    return ResponseEntity.status(HttpStatus.CREATED)
+        .build();
+  }
+
+  @PutMapping("/{teamId}")
+  public ResponseEntity<Void> updateTeam(
+      @LoginMember Member member,
+      @PathVariable long teamId,
+      @RequestBody @Valid UpdateTeamRequest request
+  ) {
+    ctfTeamService.updateTeam(member, teamId, request);
     return ResponseEntity.status(HttpStatus.CREATED)
         .build();
   }

--- a/src/main/java/com/keeper/homepage/domain/ctf/api/CtfTeamController.java
+++ b/src/main/java/com/keeper/homepage/domain/ctf/api/CtfTeamController.java
@@ -4,10 +4,14 @@ import com.keeper.homepage.domain.ctf.application.CtfTeamService;
 import com.keeper.homepage.domain.ctf.dto.request.CreateTeamRequest;
 import com.keeper.homepage.domain.ctf.dto.request.UpdateTeamRequest;
 import com.keeper.homepage.domain.ctf.dto.response.CtfTeamDetailResponse;
+import com.keeper.homepage.domain.ctf.dto.response.CtfTeamResponse;
 import com.keeper.homepage.domain.member.entity.Member;
 import com.keeper.homepage.global.config.security.annotation.LoginMember;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.PositiveOrZero;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -16,6 +20,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -51,5 +56,15 @@ public class CtfTeamController {
       @PathVariable long teamId
   ) {
     return ResponseEntity.ok(ctfTeamService.getTeam(teamId));
+  }
+
+  @GetMapping
+  public ResponseEntity<Page<CtfTeamResponse>> getTeams(
+      @RequestParam long contestId,
+      @RequestParam(defaultValue = "") String search,
+      @RequestParam(defaultValue = "0") @PositiveOrZero int page,
+      @RequestParam(defaultValue = "10") @PositiveOrZero int size
+  ) {
+    return ResponseEntity.ok(ctfTeamService.getTeams(contestId, search, PageRequest.of(page, size)));
   }
 }

--- a/src/main/java/com/keeper/homepage/domain/ctf/application/CtfTeamService.java
+++ b/src/main/java/com/keeper/homepage/domain/ctf/application/CtfTeamService.java
@@ -12,6 +12,7 @@ import com.keeper.homepage.domain.ctf.dto.response.CtfTeamDetailResponse;
 import com.keeper.homepage.domain.ctf.dto.response.CtfTeamResponse;
 import com.keeper.homepage.domain.ctf.entity.CtfContest;
 import com.keeper.homepage.domain.ctf.entity.team.CtfTeam;
+import com.keeper.homepage.domain.member.application.convenience.MemberFindService;
 import com.keeper.homepage.domain.member.entity.Member;
 import com.keeper.homepage.global.error.BusinessException;
 import lombok.RequiredArgsConstructor;
@@ -28,6 +29,7 @@ public class CtfTeamService {
   private final CtfTeamRepository ctfTeamRepository;
   private final CtfContestFindService ctfContestFindService;
   private final CtfTeamFindService ctfTeamFindService;
+  private final MemberFindService memberFindService;
 
   @Transactional
   public void createTeam(Member member, CreateTeamRequest request) {
@@ -73,5 +75,22 @@ public class CtfTeamService {
     CtfContest contest = ctfContestFindService.findJoinableById(contestId);
     return ctfTeamRepository.findAllByCtfContestAndNameIgnoreCaseContaining(contest, search, pageable)
         .map(CtfTeamResponse::from);
+  }
+
+  @Transactional
+  public void joinTeam(long contestId, long teamId, long memberId) {
+    CtfContest contest = ctfContestFindService.findJoinableById(contestId);
+    Member member = memberFindService.findById(memberId);
+    checkMemberHasTeam(contest, member);
+
+    CtfTeam ctfTeam = ctfTeamFindService.findById(teamId);
+    member.join(ctfTeam);
+  }
+
+  @Transactional
+  public void leaveTeam(long teamId, long memberId) {
+    CtfTeam ctfTeam = ctfTeamFindService.findById(teamId);
+    Member member = memberFindService.findById(memberId);
+    member.leave(ctfTeam);
   }
 }

--- a/src/main/java/com/keeper/homepage/domain/ctf/application/CtfTeamService.java
+++ b/src/main/java/com/keeper/homepage/domain/ctf/application/CtfTeamService.java
@@ -1,0 +1,48 @@
+package com.keeper.homepage.domain.ctf.application;
+
+import static com.keeper.homepage.global.error.ErrorCode.CTF_TEAM_ALREADY_JOIN;
+
+import com.keeper.homepage.domain.ctf.application.convenience.CtfContestFindService;
+import com.keeper.homepage.domain.ctf.dao.team.CtfTeamRepository;
+import com.keeper.homepage.domain.ctf.dto.request.CreateTeamRequest;
+import com.keeper.homepage.domain.ctf.entity.CtfContest;
+import com.keeper.homepage.domain.ctf.entity.team.CtfTeam;
+import com.keeper.homepage.domain.member.entity.Member;
+import com.keeper.homepage.global.error.BusinessException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CtfTeamService {
+
+  private final CtfTeamRepository ctfTeamRepository;
+  private final CtfContestFindService ctfContestFindService;
+
+  @Transactional
+  public void createTeam(Member member, CreateTeamRequest request) {
+    CtfContest contest = ctfContestFindService.findJoinableById(request.getContestId());
+    checkMemberHasTeam(contest, member);
+
+    CtfTeam ctfTeam = CtfTeam.builder()
+        .name(request.getName())
+        .description(request.getDescription())
+        .creator(member)
+        .score(0)
+        .ctfContest(contest)
+        .build();
+
+    ctfTeamRepository.save(ctfTeam);
+    member.join(ctfTeam);
+    // TODO: 팀이 생성될 때 마다 Dynamic score 변경해 줘야 함.
+    // TODO: 팀이 생성될 때 마다 모든 문제에 해당하는 flag를 매핑해 줘야 함.
+  }
+
+  private void checkMemberHasTeam(CtfContest contest, Member member) {
+    if (member.hasTeam(contest)) {
+      throw new BusinessException(contest.getName(), "contest", CTF_TEAM_ALREADY_JOIN);
+    }
+  }
+}

--- a/src/main/java/com/keeper/homepage/domain/ctf/application/CtfTeamService.java
+++ b/src/main/java/com/keeper/homepage/domain/ctf/application/CtfTeamService.java
@@ -1,10 +1,13 @@
 package com.keeper.homepage.domain.ctf.application;
 
 import static com.keeper.homepage.global.error.ErrorCode.CTF_TEAM_ALREADY_JOIN;
+import static com.keeper.homepage.global.error.ErrorCode.CTF_TEAM_INACCESSIBLE;
 
 import com.keeper.homepage.domain.ctf.application.convenience.CtfContestFindService;
+import com.keeper.homepage.domain.ctf.application.convenience.CtfTeamFindService;
 import com.keeper.homepage.domain.ctf.dao.team.CtfTeamRepository;
 import com.keeper.homepage.domain.ctf.dto.request.CreateTeamRequest;
+import com.keeper.homepage.domain.ctf.dto.request.UpdateTeamRequest;
 import com.keeper.homepage.domain.ctf.entity.CtfContest;
 import com.keeper.homepage.domain.ctf.entity.team.CtfTeam;
 import com.keeper.homepage.domain.member.entity.Member;
@@ -20,6 +23,7 @@ public class CtfTeamService {
 
   private final CtfTeamRepository ctfTeamRepository;
   private final CtfContestFindService ctfContestFindService;
+  private final CtfTeamFindService ctfTeamFindService;
 
   @Transactional
   public void createTeam(Member member, CreateTeamRequest request) {
@@ -44,5 +48,15 @@ public class CtfTeamService {
     if (member.hasTeam(contest)) {
       throw new BusinessException(contest.getName(), "contest", CTF_TEAM_ALREADY_JOIN);
     }
+  }
+
+  @Transactional
+  public void updateTeam(Member member, long teamId, UpdateTeamRequest request) {
+    CtfTeam ctfTeam = ctfTeamFindService.findById(teamId);
+
+    if (!member.isJoin(ctfTeam)) {
+      throw new BusinessException(ctfTeam.getName(), "ctfTeam", CTF_TEAM_INACCESSIBLE);
+    }
+    ctfTeam.update(request.getName(), request.getDescription());
   }
 }

--- a/src/main/java/com/keeper/homepage/domain/ctf/application/CtfTeamService.java
+++ b/src/main/java/com/keeper/homepage/domain/ctf/application/CtfTeamService.java
@@ -8,6 +8,7 @@ import com.keeper.homepage.domain.ctf.application.convenience.CtfTeamFindService
 import com.keeper.homepage.domain.ctf.dao.team.CtfTeamRepository;
 import com.keeper.homepage.domain.ctf.dto.request.CreateTeamRequest;
 import com.keeper.homepage.domain.ctf.dto.request.UpdateTeamRequest;
+import com.keeper.homepage.domain.ctf.dto.response.CtfTeamDetailResponse;
 import com.keeper.homepage.domain.ctf.entity.CtfContest;
 import com.keeper.homepage.domain.ctf.entity.team.CtfTeam;
 import com.keeper.homepage.domain.member.entity.Member;
@@ -58,5 +59,10 @@ public class CtfTeamService {
       throw new BusinessException(ctfTeam.getName(), "ctfTeam", CTF_TEAM_INACCESSIBLE);
     }
     ctfTeam.update(request.getName(), request.getDescription());
+  }
+
+  public CtfTeamDetailResponse getTeam(long teamId) {
+    CtfTeam ctfTeam = ctfTeamFindService.findById(teamId);
+    return CtfTeamDetailResponse.from(ctfTeam);
   }
 }

--- a/src/main/java/com/keeper/homepage/domain/ctf/application/CtfTeamService.java
+++ b/src/main/java/com/keeper/homepage/domain/ctf/application/CtfTeamService.java
@@ -9,11 +9,14 @@ import com.keeper.homepage.domain.ctf.dao.team.CtfTeamRepository;
 import com.keeper.homepage.domain.ctf.dto.request.CreateTeamRequest;
 import com.keeper.homepage.domain.ctf.dto.request.UpdateTeamRequest;
 import com.keeper.homepage.domain.ctf.dto.response.CtfTeamDetailResponse;
+import com.keeper.homepage.domain.ctf.dto.response.CtfTeamResponse;
 import com.keeper.homepage.domain.ctf.entity.CtfContest;
 import com.keeper.homepage.domain.ctf.entity.team.CtfTeam;
 import com.keeper.homepage.domain.member.entity.Member;
 import com.keeper.homepage.global.error.BusinessException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -64,5 +67,11 @@ public class CtfTeamService {
   public CtfTeamDetailResponse getTeam(long teamId) {
     CtfTeam ctfTeam = ctfTeamFindService.findById(teamId);
     return CtfTeamDetailResponse.from(ctfTeam);
+  }
+
+  public Page<CtfTeamResponse> getTeams(long contestId, String search, Pageable pageable) {
+    CtfContest contest = ctfContestFindService.findJoinableById(contestId);
+    return ctfTeamRepository.findAllByCtfContestAndNameIgnoreCaseContaining(contest, search, pageable)
+        .map(CtfTeamResponse::from);
   }
 }

--- a/src/main/java/com/keeper/homepage/domain/ctf/application/convenience/CtfContestFindService.java
+++ b/src/main/java/com/keeper/homepage/domain/ctf/application/convenience/CtfContestFindService.java
@@ -1,0 +1,25 @@
+package com.keeper.homepage.domain.ctf.application.convenience;
+
+import static com.keeper.homepage.global.error.ErrorCode.CTF_CONTEST_NOT_FOUND;
+
+import com.keeper.homepage.domain.ctf.dao.CtfContestRepository;
+import com.keeper.homepage.domain.ctf.entity.CtfContest;
+import com.keeper.homepage.global.error.BusinessException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CtfContestFindService {
+
+  private static final long VIRTUAL_CONTEST_ID = 1;
+
+  private final CtfContestRepository ctfContestRepository;
+
+  public CtfContest findJoinableById(long contestId) {
+    return ctfContestRepository.findByIdAndIdNotAndIsJoinableTrue(contestId, VIRTUAL_CONTEST_ID)
+        .orElseThrow(() -> new BusinessException(contestId, "contestId", CTF_CONTEST_NOT_FOUND));
+  }
+}

--- a/src/main/java/com/keeper/homepage/domain/ctf/application/convenience/CtfTeamFindService.java
+++ b/src/main/java/com/keeper/homepage/domain/ctf/application/convenience/CtfTeamFindService.java
@@ -1,0 +1,24 @@
+package com.keeper.homepage.domain.ctf.application.convenience;
+
+import static com.keeper.homepage.global.error.ErrorCode.CTF_TEAM_NOT_FOUND;
+
+import com.keeper.homepage.domain.ctf.dao.team.CtfTeamRepository;
+import com.keeper.homepage.domain.ctf.entity.team.CtfTeam;
+import com.keeper.homepage.global.error.BusinessException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CtfTeamFindService {
+
+  private static final long VIRTUAL_TEAM_ID = 1;
+  private final CtfTeamRepository ctfTeamRepository;
+
+  public CtfTeam findById(long teamId) {
+    return ctfTeamRepository.findByIdAndIdNot(teamId, VIRTUAL_TEAM_ID)
+        .orElseThrow(() -> new BusinessException(teamId, "teamId", CTF_TEAM_NOT_FOUND));
+  }
+}

--- a/src/main/java/com/keeper/homepage/domain/ctf/dao/CtfContestRepository.java
+++ b/src/main/java/com/keeper/homepage/domain/ctf/dao/CtfContestRepository.java
@@ -1,8 +1,10 @@
 package com.keeper.homepage.domain.ctf.dao;
 
 import com.keeper.homepage.domain.ctf.entity.CtfContest;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CtfContestRepository extends JpaRepository<CtfContest, Long> {
 
+  Optional<CtfContest> findByIdAndIdNotAndIsJoinableTrue(long contestId, long virtualId);
 }

--- a/src/main/java/com/keeper/homepage/domain/ctf/dao/team/CtfTeamRepository.java
+++ b/src/main/java/com/keeper/homepage/domain/ctf/dao/team/CtfTeamRepository.java
@@ -1,8 +1,10 @@
 package com.keeper.homepage.domain.ctf.dao.team;
 
 import com.keeper.homepage.domain.ctf.entity.team.CtfTeam;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CtfTeamRepository extends JpaRepository<CtfTeam, Long> {
 
+  Optional<CtfTeam> findByIdAndIdNot(long teamId, long virtualId);
 }

--- a/src/main/java/com/keeper/homepage/domain/ctf/dao/team/CtfTeamRepository.java
+++ b/src/main/java/com/keeper/homepage/domain/ctf/dao/team/CtfTeamRepository.java
@@ -1,10 +1,15 @@
 package com.keeper.homepage.domain.ctf.dao.team;
 
+import com.keeper.homepage.domain.ctf.entity.CtfContest;
 import com.keeper.homepage.domain.ctf.entity.team.CtfTeam;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CtfTeamRepository extends JpaRepository<CtfTeam, Long> {
 
   Optional<CtfTeam> findByIdAndIdNot(long teamId, long virtualId);
+
+  Page<CtfTeam> findAllByCtfContestAndNameIgnoreCaseContaining(CtfContest ctfContest, String search, Pageable pageable);
 }

--- a/src/main/java/com/keeper/homepage/domain/ctf/dto/request/CreateTeamRequest.java
+++ b/src/main/java/com/keeper/homepage/domain/ctf/dto/request/CreateTeamRequest.java
@@ -1,0 +1,32 @@
+package com.keeper.homepage.domain.ctf.dto.request;
+
+import static lombok.AccessLevel.PRIVATE;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = PRIVATE)
+@AllArgsConstructor(access = PRIVATE)
+public class CreateTeamRequest {
+
+  public static final int TEAM_NAME_LENGTH = 20;
+  public static final int TEAM_DESCRIPTION_LENGTH = 40;
+
+  @NotBlank(message = "CTF 팀명을 입력해주세요.")
+  @Size(max = TEAM_NAME_LENGTH, message = "CTF 팀명은 {max}자 이하로 입력해주세요.")
+  private String name;
+
+  @NotBlank(message = "CTF 팀 설명을 입력해주세요.")
+  @Size(max = TEAM_DESCRIPTION_LENGTH, message = "게시글 제목은 {max}자 이하로 입력해주세요.")
+  private String description;
+
+  @NotNull(message = "CTF Contest ID를 입력해주세요.")
+  private long contestId;
+}

--- a/src/main/java/com/keeper/homepage/domain/ctf/dto/request/JoinTeamRequest.java
+++ b/src/main/java/com/keeper/homepage/domain/ctf/dto/request/JoinTeamRequest.java
@@ -1,0 +1,20 @@
+package com.keeper.homepage.domain.ctf.dto.request;
+
+import static lombok.AccessLevel.PRIVATE;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = PRIVATE)
+@AllArgsConstructor(access = PRIVATE)
+public class JoinTeamRequest {
+
+  @NotNull(message = "CTF Contest ID를 입력해주세요.")
+  private long contestId;
+
+}

--- a/src/main/java/com/keeper/homepage/domain/ctf/dto/request/UpdateTeamRequest.java
+++ b/src/main/java/com/keeper/homepage/domain/ctf/dto/request/UpdateTeamRequest.java
@@ -1,0 +1,28 @@
+package com.keeper.homepage.domain.ctf.dto.request;
+
+import static lombok.AccessLevel.PRIVATE;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = PRIVATE)
+@AllArgsConstructor(access = PRIVATE)
+public class UpdateTeamRequest {
+
+  public static final int TEAM_NAME_LENGTH = 20;
+  public static final int TEAM_DESCRIPTION_LENGTH = 40;
+
+  @NotBlank(message = "CTF 팀명을 입력해주세요.")
+  @Size(max = TEAM_NAME_LENGTH, message = "CTF 팀명은 {max}자 이하로 입력해주세요.")
+  private String name;
+
+  @NotBlank(message = "CTF 팀 설명을 입력해주세요.")
+  @Size(max = TEAM_DESCRIPTION_LENGTH, message = "게시글 제목은 {max}자 이하로 입력해주세요.")
+  private String description;
+}

--- a/src/main/java/com/keeper/homepage/domain/ctf/dto/response/CtfChallengeResponse.java
+++ b/src/main/java/com/keeper/homepage/domain/ctf/dto/response/CtfChallengeResponse.java
@@ -1,0 +1,5 @@
+package com.keeper.homepage.domain.ctf.dto.response;
+
+public class CtfChallengeResponse {
+
+}

--- a/src/main/java/com/keeper/homepage/domain/ctf/dto/response/CtfTeamDetailResponse.java
+++ b/src/main/java/com/keeper/homepage/domain/ctf/dto/response/CtfTeamDetailResponse.java
@@ -1,0 +1,38 @@
+package com.keeper.homepage.domain.ctf.dto.response;
+
+import static lombok.AccessLevel.PRIVATE;
+
+import com.keeper.homepage.domain.ctf.entity.team.CtfTeam;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = PRIVATE)
+public class CtfTeamDetailResponse {
+
+  private Long id;
+  private String name;
+  private String description;
+  private int rank;
+  private int score;
+  private List<String> memberNames;
+  private List<CtfChallengeResponse> solves;
+
+  public static CtfTeamDetailResponse from(CtfTeam ctfTeam) {
+    return CtfTeamDetailResponse.builder()
+        .id(ctfTeam.getId())
+        .name(ctfTeam.getName())
+        .description(ctfTeam.getDescription())
+        .rank(0) // TODO: 현재 순위 반환
+        .score(ctfTeam.getScore())
+        .memberNames(ctfTeam.getCtfTeamHasMembers()
+            .stream()
+            .map(ctfTeamHasMember -> ctfTeamHasMember.getMember().getRealName())
+            .toList())
+        .solves(List.of()) // TODO: 푼 문제 응답 반환
+        .build();
+  }
+}

--- a/src/main/java/com/keeper/homepage/domain/ctf/dto/response/CtfTeamResponse.java
+++ b/src/main/java/com/keeper/homepage/domain/ctf/dto/response/CtfTeamResponse.java
@@ -1,0 +1,24 @@
+package com.keeper.homepage.domain.ctf.dto.response;
+
+import static lombok.AccessLevel.PRIVATE;
+
+import com.keeper.homepage.domain.ctf.entity.team.CtfTeam;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = PRIVATE)
+public class CtfTeamResponse {
+
+  private Long id;
+  private String name;
+
+  public static CtfTeamResponse from(CtfTeam ctfTeam) {
+    return CtfTeamResponse.builder()
+        .id(ctfTeam.getId())
+        .name(ctfTeam.getName())
+        .build();
+  }
+}

--- a/src/main/java/com/keeper/homepage/domain/ctf/entity/team/CtfTeam.java
+++ b/src/main/java/com/keeper/homepage/domain/ctf/entity/team/CtfTeam.java
@@ -76,4 +76,9 @@ public class CtfTeam extends BaseEntity {
     this.ctfContest = ctfContest;
     this.lastSolveTime = lastSolveTime;
   }
+
+  public void update(String name, String description) {
+    this.name = name;
+    this.description = description;
+  }
 }

--- a/src/main/java/com/keeper/homepage/domain/member/entity/Member.java
+++ b/src/main/java/com/keeper/homepage/domain/member/entity/Member.java
@@ -15,6 +15,7 @@ import static jakarta.persistence.CascadeType.REMOVE;
 
 import com.keeper.homepage.domain.attendance.entity.Attendance;
 import com.keeper.homepage.domain.comment.entity.Comment;
+import com.keeper.homepage.domain.ctf.entity.CtfContest;
 import com.keeper.homepage.domain.ctf.entity.team.CtfTeam;
 import com.keeper.homepage.domain.ctf.entity.team.CtfTeamHasMember;
 import com.keeper.homepage.domain.library.entity.Book;
@@ -336,5 +337,10 @@ public class Member {
     return this.bookBorrowInfos.stream()
         .filter(BookBorrowInfo::isInBorrowing)
         .count();
+  }
+
+  public boolean hasTeam(CtfContest contest) {
+    return ctfTeamHasMembers.stream()
+        .anyMatch(ctfTeamHasMember -> ctfTeamHasMember.getCtfTeam().getCtfContest().equals(contest));
   }
 }

--- a/src/main/java/com/keeper/homepage/domain/member/entity/Member.java
+++ b/src/main/java/com/keeper/homepage/domain/member/entity/Member.java
@@ -343,4 +343,9 @@ public class Member {
     return ctfTeamHasMembers.stream()
         .anyMatch(ctfTeamHasMember -> ctfTeamHasMember.getCtfTeam().getCtfContest().equals(contest));
   }
+
+  public boolean isJoin(CtfTeam ctfTeam) {
+    return ctfTeamHasMembers.stream()
+        .anyMatch(ctfTeamHasMember -> ctfTeamHasMember.getCtfTeam().equals(ctfTeam));
+  }
 }

--- a/src/main/java/com/keeper/homepage/global/error/ErrorCode.java
+++ b/src/main/java/com/keeper/homepage/global/error/ErrorCode.java
@@ -79,6 +79,8 @@ public enum ErrorCode {
   // CTF
   CTF_CONTEST_NOT_FOUND("해당 대회는 끝났거나 없는 대회입니다.", HttpStatus.BAD_REQUEST),
   CTF_TEAM_ALREADY_JOIN("이미 가입한 팀이 있어 팀 가입이 불가합니다.", HttpStatus.BAD_REQUEST),
+  CTF_TEAM_NOT_FOUND("해당 팀을 찾을 수 없습니다.", HttpStatus.BAD_REQUEST),
+  CTF_TEAM_INACCESSIBLE("해당 팀에 접근이 불가합니다.", HttpStatus.BAD_REQUEST),
   ;
 
   private final String message;

--- a/src/main/java/com/keeper/homepage/global/error/ErrorCode.java
+++ b/src/main/java/com/keeper/homepage/global/error/ErrorCode.java
@@ -76,6 +76,9 @@ public enum ErrorCode {
   FILE_NOT_FOUND("해당 파일은 존재하지 않습니다.", HttpStatus.BAD_REQUEST),
   // ATTENDANCE
   ATTENDANCE_ALREADY("이미 출석을 완료했습니다.", HttpStatus.BAD_REQUEST),
+  // CTF
+  CTF_CONTEST_NOT_FOUND("해당 대회는 끝났거나 없는 대회입니다.", HttpStatus.BAD_REQUEST),
+  CTF_TEAM_ALREADY_JOIN("이미 가입한 팀이 있어 팀 가입이 불가합니다.", HttpStatus.BAD_REQUEST),
   ;
 
   private final String message;

--- a/src/test/java/com/keeper/homepage/IntegrationTest.java
+++ b/src/test/java/com/keeper/homepage/IntegrationTest.java
@@ -27,6 +27,7 @@ import com.keeper.homepage.domain.comment.application.CommentService;
 import com.keeper.homepage.domain.comment.dao.CommentRepository;
 import com.keeper.homepage.domain.ctf.CtfContestTestHelper;
 import com.keeper.homepage.domain.ctf.CtfTeamTestHelper;
+import com.keeper.homepage.domain.ctf.application.CtfTeamService;
 import com.keeper.homepage.domain.file.dao.FileRepository;
 import com.keeper.homepage.domain.game.GameTestHelper;
 import com.keeper.homepage.domain.game.application.BaseballService;
@@ -297,6 +298,9 @@ public class IntegrationTest {
 
   @SpyBean
   protected SeminarAttendanceService seminarAttendanceService;
+
+  @SpyBean
+  protected CtfTeamService ctfTeamService;
 
   /******* Helper *******/
   @SpyBean

--- a/src/test/java/com/keeper/homepage/domain/ctf/CtfTeamTestHelper.java
+++ b/src/test/java/com/keeper/homepage/domain/ctf/CtfTeamTestHelper.java
@@ -6,6 +6,7 @@ import com.keeper.homepage.domain.ctf.entity.team.CtfTeam;
 import com.keeper.homepage.domain.member.MemberTestHelper;
 import com.keeper.homepage.domain.member.entity.Member;
 import java.time.LocalDateTime;
+import java.util.Random;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -74,7 +75,7 @@ public class CtfTeamTestHelper {
 
     public CtfTeam build() {
       return ctfTeamRepository.save(CtfTeam.builder()
-          .name(name != null ? name : "KEEPER TEAM")
+          .name(name != null ? name : generateRandomAlphabeticString(10))
           .description(description != null ? description : "2023 CTF TEAM")
           .creator(creator != null ? creator : memberTestHelper.generate())
           .score(score != null ? score : 0)
@@ -84,4 +85,15 @@ public class CtfTeamTestHelper {
     }
   }
 
+  private static String generateRandomAlphabeticString(int length) {
+    final Random random = new Random();
+    char leftLimit = '0';
+    char rightLimit = 'z';
+
+    return random.ints(leftLimit, rightLimit + 1)
+        .filter(Character::isAlphabetic)
+        .limit(length)
+        .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
+        .toString();
+  }
 }

--- a/src/test/java/com/keeper/homepage/domain/ctf/api/CtfTeamControllerTest.java
+++ b/src/test/java/com/keeper/homepage/domain/ctf/api/CtfTeamControllerTest.java
@@ -1,0 +1,69 @@
+package com.keeper.homepage.domain.ctf.api;
+
+import static com.keeper.homepage.domain.ctf.dto.request.CreateTeamRequest.builder;
+import static com.keeper.homepage.domain.member.entity.job.MemberJob.MemberJobType.ROLE_회원;
+import static com.keeper.homepage.global.config.security.data.JwtType.ACCESS_TOKEN;
+import static com.keeper.homepage.global.restdocs.RestDocsHelper.getSecuredValue;
+import static org.springframework.restdocs.cookies.CookieDocumentation.cookieWithName;
+import static org.springframework.restdocs.cookies.CookieDocumentation.requestCookies;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.keeper.homepage.IntegrationTest;
+import com.keeper.homepage.domain.ctf.dto.request.CreateTeamRequest;
+import com.keeper.homepage.domain.ctf.entity.CtfContest;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+
+public class CtfTeamControllerTest extends IntegrationTest {
+
+  private String memberToken;
+  private CtfContest ctfContest;
+
+  @BeforeEach
+  void setUp() {
+    long memberId = memberTestHelper.generate().getId();
+    memberToken = jwtTokenProvider.createAccessToken(ACCESS_TOKEN, memberId, ROLE_회원);
+    ctfContest = ctfContestTestHelper.generate();
+  }
+
+  @Nested
+  @DisplayName("CTF 팀 생성 테스트")
+  class CtfTeamCreateTest {
+
+    @Test
+    @DisplayName("유효한 요청이면 CTF 팀 생성은 가능해야 한다.")
+    public void 유효한_요청이면_CTF_팀_생성은_가능해야_한다() throws Exception {
+      String securedValue = getSecuredValue(CtfTeamController.class, "createTeam");
+
+      CreateTeamRequest request = builder()
+          .name("KEEPER TEAM")
+          .description("2024 CTF TEAM")
+          .contestId(ctfContest.getId())
+          .build();
+
+      mockMvc.perform(post("/ctf/teams")
+              .content(asJsonString(request))
+              .cookie(new Cookie(ACCESS_TOKEN.getTokenName(), memberToken))
+              .contentType(MediaType.APPLICATION_JSON))
+          .andExpect(status().isCreated())
+          .andDo(document("create-ctf-team",
+              requestCookies(
+                  cookieWithName(ACCESS_TOKEN.getTokenName())
+                      .description("ACCESS TOKEN %s".formatted(securedValue))
+              ),
+              requestFields(
+                  fieldWithPath("name").description("CTF 팀명"),
+                  fieldWithPath("description").description("CTF 팀 설명"),
+                  fieldWithPath("contestId").description("CTF 대회 ID")
+              )));
+    }
+  }
+}

--- a/src/test/java/com/keeper/homepage/domain/ctf/api/CtfTeamControllerTest.java
+++ b/src/test/java/com/keeper/homepage/domain/ctf/api/CtfTeamControllerTest.java
@@ -7,10 +7,14 @@ import static com.keeper.homepage.global.restdocs.RestDocsHelper.getSecuredValue
 import static org.springframework.restdocs.cookies.CookieDocumentation.cookieWithName;
 import static org.springframework.restdocs.cookies.CookieDocumentation.requestCookies;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.keeper.homepage.IntegrationTest;
@@ -102,6 +106,42 @@ public class CtfTeamControllerTest extends IntegrationTest {
               requestFields(
                   fieldWithPath("name").description("CTF 팀명"),
                   fieldWithPath("description").description("CTF 팀 설명")
+              )));
+    }
+  }
+
+  @Nested
+  @DisplayName("CTF 팀 조회 테스트")
+  class CtfTeamGetTest {
+
+    @Test
+    @DisplayName("유효한 요청일 경우 팀 조회는 성공해야 한다.")
+    public void 유효한_요청일_경우_팀_조회는_성공해야_한다() throws Exception {
+      String securedValue = getSecuredValue(CtfTeamController.class, "getTeam");
+      CtfTeam ctfTeam = ctfTeamTestHelper.generate();
+      member.join(ctfTeam);
+      em.flush();
+      em.clear();
+
+      mockMvc.perform(get("/ctf/teams/{teamId}", ctfTeam.getId())
+              .cookie(new Cookie(ACCESS_TOKEN.getTokenName(), memberToken)))
+          .andExpect(status().isOk())
+          .andDo(document("get-ctf-team",
+              requestCookies(
+                  cookieWithName(ACCESS_TOKEN.getTokenName())
+                      .description("ACCESS TOKEN %s".formatted(securedValue))
+              ),
+              pathParameters(
+                  parameterWithName("teamId").description("조회하고자 하는 팀 ID")
+              ),
+              responseFields(
+                  fieldWithPath("id").description("팀 ID"),
+                  fieldWithPath("name").description("팀 이름"),
+                  fieldWithPath("description").description("팀 설명"),
+                  fieldWithPath("rank").description("팀 현재 순위"),
+                  fieldWithPath("score").description("팀 점순"),
+                  fieldWithPath("memberNames[]").description("팀원 실명 리스트"),
+                  fieldWithPath("solves[]").description("푼 문제 리스트") // TODO: 푼 문제 세부 응답 작성
               )));
     }
   }

--- a/src/test/java/com/keeper/homepage/domain/ctf/api/CtfTeamControllerTest.java
+++ b/src/test/java/com/keeper/homepage/domain/ctf/api/CtfTeamControllerTest.java
@@ -8,13 +8,17 @@ import static org.springframework.restdocs.cookies.CookieDocumentation.cookieWit
 import static org.springframework.restdocs.cookies.CookieDocumentation.requestCookies;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.keeper.homepage.IntegrationTest;
 import com.keeper.homepage.domain.ctf.dto.request.CreateTeamRequest;
+import com.keeper.homepage.domain.ctf.dto.request.UpdateTeamRequest;
 import com.keeper.homepage.domain.ctf.entity.CtfContest;
+import com.keeper.homepage.domain.ctf.entity.team.CtfTeam;
+import com.keeper.homepage.domain.member.entity.Member;
 import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -24,13 +28,14 @@ import org.springframework.http.MediaType;
 
 public class CtfTeamControllerTest extends IntegrationTest {
 
+  private Member member;
   private String memberToken;
   private CtfContest ctfContest;
 
   @BeforeEach
   void setUp() {
-    long memberId = memberTestHelper.generate().getId();
-    memberToken = jwtTokenProvider.createAccessToken(ACCESS_TOKEN, memberId, ROLE_회원);
+    member = memberTestHelper.generate();
+    memberToken = jwtTokenProvider.createAccessToken(ACCESS_TOKEN, member.getId(), ROLE_회원);
     ctfContest = ctfContestTestHelper.generate();
   }
 
@@ -63,6 +68,40 @@ public class CtfTeamControllerTest extends IntegrationTest {
                   fieldWithPath("name").description("CTF 팀명"),
                   fieldWithPath("description").description("CTF 팀 설명"),
                   fieldWithPath("contestId").description("CTF 대회 ID")
+              )));
+    }
+  }
+
+  @Nested
+  @DisplayName("CTF 팀 수정 테스트")
+  class CtfTeamUpdateTest {
+
+    @Test
+    @DisplayName("유효한 요청일 경우 CTF 팀 수정은 성공한다.")
+    public void 유효한_요청일_경우_CTF_팀_수정은_성공한다() throws Exception {
+      CtfTeam ctfTeam = ctfTeamTestHelper.generate();
+      member.join(ctfTeam);
+
+      String securedValue = getSecuredValue(CtfTeamController.class, "updateTeam");
+
+      UpdateTeamRequest request = UpdateTeamRequest.builder()
+          .name("KEEPER TEAM")
+          .description("2024 CTF TEAM")
+          .build();
+
+      mockMvc.perform(put("/ctf/teams/{teamId}", ctfTeam.getId())
+              .content(asJsonString(request))
+              .cookie(new Cookie(ACCESS_TOKEN.getTokenName(), memberToken))
+              .contentType(MediaType.APPLICATION_JSON))
+          .andExpect(status().isCreated())
+          .andDo(document("update-ctf-team",
+              requestCookies(
+                  cookieWithName(ACCESS_TOKEN.getTokenName())
+                      .description("ACCESS TOKEN %s".formatted(securedValue))
+              ),
+              requestFields(
+                  fieldWithPath("name").description("CTF 팀명"),
+                  fieldWithPath("description").description("CTF 팀 설명")
               )));
     }
   }

--- a/src/test/java/com/keeper/homepage/domain/ctf/application/CtfTeamServiceTest.java
+++ b/src/test/java/com/keeper/homepage/domain/ctf/application/CtfTeamServiceTest.java
@@ -6,7 +6,9 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.keeper.homepage.IntegrationTest;
 import com.keeper.homepage.domain.ctf.dto.request.CreateTeamRequest;
+import com.keeper.homepage.domain.ctf.dto.request.UpdateTeamRequest;
 import com.keeper.homepage.domain.ctf.entity.CtfContest;
+import com.keeper.homepage.domain.ctf.entity.team.CtfTeam;
 import com.keeper.homepage.domain.member.entity.Member;
 import com.keeper.homepage.global.error.BusinessException;
 import org.junit.jupiter.api.BeforeEach;
@@ -16,18 +18,18 @@ import org.junit.jupiter.api.Test;
 
 public class CtfTeamServiceTest extends IntegrationTest {
 
+  private Member member;
+  private CtfContest ctfContest;
+
+  @BeforeEach
+  void setUp() {
+    member = memberTestHelper.generate();
+    ctfContest = ctfContestTestHelper.generate();
+  }
+
   @Nested
   @DisplayName("CTF 팀 생성 테스트")
   class CtfTeamCreateTest {
-
-    private Member member;
-    private CtfContest ctfContest;
-
-    @BeforeEach
-    void setUp() {
-      member = memberTestHelper.generate();
-      ctfContest = ctfContestTestHelper.generate();
-    }
 
     @Test
     @DisplayName("팀을 생성한 사람은 팀에 가입되어야 한다.")
@@ -59,6 +61,29 @@ public class CtfTeamServiceTest extends IntegrationTest {
 
       assertThrows(BusinessException.class, () -> {
         ctfTeamService.createTeam(member, request);
+      });
+    }
+  }
+
+  @Nested
+  @DisplayName("CTF 팀 수정 테스트")
+  class CtfTeamUpdateTest {
+
+    @Test
+    @DisplayName("팀원이 아니라면 팀 정보 수정은 실패한다.")
+    public void 팀원이_아니라면_팀_정보_수정은_실패한다() throws Exception {
+      CtfTeam ctfTeam1 = ctfTeamTestHelper.generate();
+      CtfTeam ctfTeam2 = ctfTeamTestHelper.generate();
+
+      member.join(ctfTeam1);
+
+      UpdateTeamRequest request = UpdateTeamRequest.builder()
+          .name("팀 이름")
+          .description("팀 설명")
+          .build();
+
+      assertThrows(BusinessException.class, () -> {
+        ctfTeamService.updateTeam(member, ctfTeam2.getId(), request);
       });
     }
   }

--- a/src/test/java/com/keeper/homepage/domain/ctf/application/CtfTeamServiceTest.java
+++ b/src/test/java/com/keeper/homepage/domain/ctf/application/CtfTeamServiceTest.java
@@ -87,4 +87,22 @@ public class CtfTeamServiceTest extends IntegrationTest {
       });
     }
   }
+
+  @Nested
+  @DisplayName("CTF 팀 가입 & 탈퇴 테스트")
+  class CtfTeamJoinAndLeaveTest {
+
+    @Test
+    @DisplayName("해당 대회에서 이미 가입한 팀이 있다면 팀 가입은 실패한다.")
+    public void 해당_대회에서_이미_가입한_팀이_있다면_팀_가입은_실패한다() throws Exception {
+      CtfTeam ctfTeam = ctfTeamTestHelper.builder().ctfContest(ctfContest).build();
+      member.join(ctfTeam);
+
+      CtfTeam anotherTeam = ctfTeamTestHelper.builder().ctfContest(ctfContest).build();
+
+      assertThrows(BusinessException.class, () -> {
+        ctfTeamService.joinTeam(ctfContest.getId(), anotherTeam.getId(), member.getId());
+      });
+    }
+  }
 }

--- a/src/test/java/com/keeper/homepage/domain/ctf/application/CtfTeamServiceTest.java
+++ b/src/test/java/com/keeper/homepage/domain/ctf/application/CtfTeamServiceTest.java
@@ -1,0 +1,65 @@
+package com.keeper.homepage.domain.ctf.application;
+
+import static com.keeper.homepage.domain.ctf.dto.request.CreateTeamRequest.builder;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.keeper.homepage.IntegrationTest;
+import com.keeper.homepage.domain.ctf.dto.request.CreateTeamRequest;
+import com.keeper.homepage.domain.ctf.entity.CtfContest;
+import com.keeper.homepage.domain.member.entity.Member;
+import com.keeper.homepage.global.error.BusinessException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+public class CtfTeamServiceTest extends IntegrationTest {
+
+  @Nested
+  @DisplayName("CTF 팀 생성 테스트")
+  class CtfTeamCreateTest {
+
+    private Member member;
+    private CtfContest ctfContest;
+
+    @BeforeEach
+    void setUp() {
+      member = memberTestHelper.generate();
+      ctfContest = ctfContestTestHelper.generate();
+    }
+
+    @Test
+    @DisplayName("팀을 생성한 사람은 팀에 가입되어야 한다.")
+    public void 팀을_생성한_사람은_팀에_가입되어야_한다() throws Exception {
+      //given
+      CreateTeamRequest request = builder()
+          .name("KEEPER TEAM")
+          .description("2024 CTF TEAM")
+          .contestId(ctfContest.getId())
+          .build();
+
+      //when
+      ctfTeamService.createTeam(member, request);
+
+      //then
+      assertThat(member.getCtfTeamHasMembers()).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("해당 대회에서 이미 가입한 팀이 있다면 팀 생성은 실패한다.")
+    public void 해당_대회에서_이미_가입한_팀이_있다면_팀_생성은_실패한다() throws Exception {
+      member.join(ctfTeamTestHelper.builder().ctfContest(ctfContest).build());
+
+      CreateTeamRequest request = builder()
+          .name("KEEPER TEAM")
+          .description("2024 CTF TEAM")
+          .contestId(ctfContest.getId())
+          .build();
+
+      assertThrows(BusinessException.class, () -> {
+        ctfTeamService.createTeam(member, request);
+      });
+    }
+  }
+}


### PR DESCRIPTION
## 🔥 Related Issue

> issue: #243
> close: #244
> issue: #245
> close: #246
> close: #247

## 📝 Description

- CTF 팀 생성
#243에 TODO로 남겨두었는데, 
`팀이 생성될 때 마다 Dynamic score 변경` & `팀이 생성될 때 마다 모든 문제에 해당하는 flag를 매핑` 은 추후 Challenge와 Flag 엔티티를 개발 후 처리할려고 남겨두었습니다!
- CTF 팀 수정
- CTF 팀 조회
팀 상세 조회도, 푼 문제에 대한 응답을 반환하기 위해선 Challenge 엔티티가 개발되어야 하기에 TODO로 남겨두었습니다!
- CTF 팀 목록 조회 (검색)
- CTF 팀 가입 & 탈퇴

## ⭐️ Review Request

어제 열대야 대박 💦 날이 진짜 덥네요... 다들 고생 많으십니다~!