### PR TITLE
feat: 로그인 시 회원 상세 정보 전달하도록 변경

### DIFF
--- a/src/main/java/com/keeper/homepage/domain/auth/api/SignInController.java
+++ b/src/main/java/com/keeper/homepage/domain/auth/api/SignInController.java
@@ -6,12 +6,12 @@ import com.keeper.homepage.domain.auth.dto.request.FindLoginIdRequest;
 import com.keeper.homepage.domain.auth.dto.request.MemberIdAndEmailRequest;
 import com.keeper.homepage.domain.auth.dto.request.SignInRequest;
 import com.keeper.homepage.domain.auth.dto.response.CheckAuthCodeResponse;
+import com.keeper.homepage.domain.auth.dto.response.SignInResponse;
 import com.keeper.homepage.domain.member.entity.embedded.EmailAddress;
 import com.keeper.homepage.domain.member.entity.embedded.LoginId;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Email;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -29,9 +29,13 @@ public class SignInController {
   private final SignInService signInService;
 
   @PostMapping
-  public ResponseEntity<List<String>> signIn(@RequestBody @Valid SignInRequest request, HttpServletResponse response) {
-    List<String> roles = signInService.signIn(LoginId.from(request.getLoginId()), request.getRawPassword(), response);
-    return ResponseEntity.ok(roles);
+  public ResponseEntity<SignInResponse> signIn(@RequestBody @Valid SignInRequest request,
+      HttpServletResponse response) {
+    return ResponseEntity.ok(
+        signInService.signIn(
+            LoginId.from(request.getLoginId()),
+            request.getRawPassword(),
+            response));
   }
 
   @PostMapping("/find-login-id")

--- a/src/main/java/com/keeper/homepage/domain/auth/application/SignInService.java
+++ b/src/main/java/com/keeper/homepage/domain/auth/application/SignInService.java
@@ -1,5 +1,6 @@
 package com.keeper.homepage.domain.auth.application;
 
+import com.keeper.homepage.domain.auth.dto.response.SignInResponse;
 import com.keeper.homepage.domain.member.dao.MemberRepository;
 import com.keeper.homepage.domain.member.entity.Member;
 import com.keeper.homepage.domain.member.entity.embedded.EmailAddress;
@@ -35,7 +36,7 @@ public class SignInService {
   private final MailUtil mailUtil;
 
   @Transactional
-  public List<String> signIn(LoginId loginId, String rawPassword, HttpServletResponse response) {
+  public SignInResponse signIn(LoginId loginId, String rawPassword, HttpServletResponse response) {
     Member member = memberRepository.findByProfileLoginId(loginId)
         .orElseThrow(
             () -> new BusinessException(loginId.get(), "loginId", ErrorCode.MEMBER_NOT_FOUND));
@@ -44,7 +45,7 @@ public class SignInService {
     }
     authCookieService.setNewCookieInResponse(String.valueOf(member.getId()),
         getRoles(member), response);
-    return Arrays.stream(getRoles(member)).toList();
+    return SignInResponse.of(member, Arrays.stream(getRoles(member)).toList());
   }
 
   private static String[] getRoles(Member member) {

--- a/src/main/java/com/keeper/homepage/domain/auth/dto/response/SignInResponse.java
+++ b/src/main/java/com/keeper/homepage/domain/auth/dto/response/SignInResponse.java
@@ -1,0 +1,52 @@
+package com.keeper.homepage.domain.auth.dto.response;
+
+import static lombok.AccessLevel.PRIVATE;
+
+import com.keeper.homepage.domain.member.entity.Member;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = PRIVATE)
+public class SignInResponse {
+
+  private long id;
+  private String emailAddress;
+  private String realName;
+  private String nickname;
+  private LocalDate birthday;
+  private String studentId;
+  private String thumbnailPath;
+  private String generation;
+  private int point;
+  private int level;
+  private int merit;
+  private int demerit;
+  private int totalAttendance;
+  private String memberType;
+  private String memberRank;
+  private List<String> memberJobs;
+
+  public static SignInResponse of(Member member, List<String> roles) {
+    return new SignInResponse(
+        member.getId(),
+        member.getProfile().getEmailAddress().get(),
+        member.getRealName(),
+        member.getNickname(),
+        member.getProfile().getBirthday(),
+        member.getProfile().getStudentId().get(),
+        member.getThumbnailPath(),
+        Float.toString(member.getGeneration()),
+        member.getPoint(),
+        member.getLevel(),
+        member.getMeritDemerit().getMerit(),
+        member.getMeritDemerit().getDemerit(),
+        member.getTotalAttendance(),
+        member.getMemberType().getType().name(),
+        member.getMemberRank().getType().name(),
+        roles);
+  }
+
+}

--- a/src/test/java/com/keeper/homepage/domain/auth/api/SignInControllerTest.java
+++ b/src/test/java/com/keeper/homepage/domain/auth/api/SignInControllerTest.java
@@ -77,7 +77,22 @@ class SignInControllerTest extends IntegrationTest {
                   fieldWithPath("password").description("비밀번호")
               ),
               responseFields(
-                  fieldWithPath("[]").description("회원 역할")
+                  fieldWithPath("id").description("회원 아이디"),
+                  fieldWithPath("emailAddress").description("이메일"),
+                  fieldWithPath("realName").description("실명"),
+                  fieldWithPath("nickname").description("닉네임"),
+                  fieldWithPath("birthday").description("생일"),
+                  fieldWithPath("studentId").description("학번"),
+                  fieldWithPath("thumbnailPath").description("썸네일 경로"),
+                  fieldWithPath("generation").description("기수"),
+                  fieldWithPath("point").description("보유 포인트"),
+                  fieldWithPath("level").description("레벨"),
+                  fieldWithPath("merit").description("상점"),
+                  fieldWithPath("demerit").description("벌점"),
+                  fieldWithPath("totalAttendance").description("총 출석 횟수"),
+                  fieldWithPath("memberType").description("회원 타입"),
+                  fieldWithPath("memberRank").description("회원 랭크"),
+                  fieldWithPath("memberJobs[]").description("회원 역할")
               ),
               responseCookies(
                   cookieWithName(ACCESS_TOKEN.getTokenName()).description("ACCESS TOKEN"),


### PR DESCRIPTION
## 🔥 Related Issue

> close: 없음.

## 📝 Description

원래 로그인 시 역할만 전달했었는데, 회원 상세 정보를 모두 보내주도록 변경했습니다.

PR 머지시 프론트에 [로그인 API](https://api.dev.keeper.or.kr/docs/auth/auth.html#_%EB%A1%9C%EA%B7%B8%EC%9D%B8) 전달

## ⭐️ Review Request

벌써 월요일이라니...