### PR TITLE
Feature/#279 회원의 게시글, 임시 게시글 목록 조회 api 구현

### DIFF
--- a/src/docs/asciidoc/post/post.adoc
+++ b/src/docs/asciidoc/post/post.adoc
@@ -415,5 +415,30 @@ include::{snippets}/get-member-posts/http-response.adoc[]
 
 include::{snippets}/get-member-posts/response-fields.adoc[]
 
+== *임시글 목록 조회*
+
+=== 요청
+
+==== Request
+
+include::{snippets}/get-temp-posts/http-request.adoc[]
+
+==== Request Cookies
+
+include::{snippets}/get-temp-posts/request-cookies.adoc[]
+
+==== Query Parameters
+
+include::{snippets}/get-temp-posts/query-parameters.adoc[]
+
+=== 응답
+
+==== Response
+
+include::{snippets}/get-temp-posts/http-response.adoc[]
+
+==== Response Fields
+
+include::{snippets}/get-temp-posts/response-fields.adoc[]
 
 

--- a/src/docs/asciidoc/post/post.adoc
+++ b/src/docs/asciidoc/post/post.adoc
@@ -385,3 +385,35 @@ include::{snippets}/get-post-files/http-response.adoc[]
 
 include::{snippets}/get-post-files/response-fields.adoc[]
 
+== *회원의 게시글 목록 조회*
+
+=== 요청
+
+==== Request
+
+include::{snippets}/get-member-posts/http-request.adoc[]
+
+==== Request Cookies
+
+include::{snippets}/get-member-posts/request-cookies.adoc[]
+
+==== Path Parameters
+
+include::{snippets}/get-member-posts/path-parameters.adoc[]
+
+==== Query Parameters
+
+include::{snippets}/get-member-posts/query-parameters.adoc[]
+
+=== 응답
+
+==== Response
+
+include::{snippets}/get-member-posts/http-response.adoc[]
+
+==== Response Fields
+
+include::{snippets}/get-member-posts/response-fields.adoc[]
+
+
+

--- a/src/main/java/com/keeper/homepage/domain/post/api/PostController.java
+++ b/src/main/java/com/keeper/homepage/domain/post/api/PostController.java
@@ -10,6 +10,7 @@ import com.keeper.homepage.domain.post.dto.response.MemberPostResponse;
 import com.keeper.homepage.domain.post.dto.response.PostDetailResponse;
 import com.keeper.homepage.domain.post.dto.response.PostListResponse;
 import com.keeper.homepage.domain.post.dto.response.PostResponse;
+import com.keeper.homepage.domain.post.dto.response.TempPostResponse;
 import com.keeper.homepage.global.config.security.annotation.LoginMember;
 import com.keeper.homepage.global.util.web.WebUtil;
 import jakarta.validation.Valid;
@@ -196,6 +197,16 @@ public class PostController {
       @RequestParam(defaultValue = "10") @PositiveOrZero int size
   ) {
     Page<MemberPostResponse> responses = postService.getMemberPosts(memberId, PageRequest.of(page, size));
+    return ResponseEntity.ok(responses);
+  }
+
+  @GetMapping("/temp")
+  public ResponseEntity<Page<TempPostResponse>> getTempPosts(
+      @LoginMember Member member,
+      @RequestParam(defaultValue = "0") @PositiveOrZero int page,
+      @RequestParam(defaultValue = "10") @PositiveOrZero int size
+  ) {
+    Page<TempPostResponse> responses = postService.getTempPosts(member, PageRequest.of(page, size));
     return ResponseEntity.ok(responses);
   }
 }

--- a/src/main/java/com/keeper/homepage/domain/post/api/PostController.java
+++ b/src/main/java/com/keeper/homepage/domain/post/api/PostController.java
@@ -5,8 +5,9 @@ import com.keeper.homepage.domain.post.application.PostService;
 import com.keeper.homepage.domain.post.dto.request.PostCreateRequest;
 import com.keeper.homepage.domain.post.dto.request.PostUpdateRequest;
 import com.keeper.homepage.domain.post.dto.response.FileResponse;
-import com.keeper.homepage.domain.post.dto.response.PostListResponse;
+import com.keeper.homepage.domain.post.dto.response.MemberPostResponse;
 import com.keeper.homepage.domain.post.dto.response.PostDetailResponse;
+import com.keeper.homepage.domain.post.dto.response.PostListResponse;
 import com.keeper.homepage.domain.post.dto.response.PostResponse;
 import com.keeper.homepage.global.config.security.annotation.LoginMember;
 import com.keeper.homepage.global.util.web.WebUtil;
@@ -185,5 +186,15 @@ public class PostController {
   @GetMapping("/trend")
   public ResponseEntity<List<PostResponse>> getTrendPosts() {
     return ResponseEntity.ok(postService.getTrendPosts());
+  }
+
+  @GetMapping("/members/{memberId}")
+  public ResponseEntity<Page<MemberPostResponse>> getMemberPosts(
+      @PathVariable long memberId,
+      @RequestParam(defaultValue = "0") @PositiveOrZero int page,
+      @RequestParam(defaultValue = "10") @PositiveOrZero int size
+  ) {
+    Page<MemberPostResponse> responses = postService.getMemberPosts(memberId, PageRequest.of(page, size));
+    return ResponseEntity.ok(responses);
   }
 }

--- a/src/main/java/com/keeper/homepage/domain/post/api/PostController.java
+++ b/src/main/java/com/keeper/homepage/domain/post/api/PostController.java
@@ -5,6 +5,7 @@ import com.keeper.homepage.domain.post.application.PostService;
 import com.keeper.homepage.domain.post.dto.request.PostCreateRequest;
 import com.keeper.homepage.domain.post.dto.request.PostUpdateRequest;
 import com.keeper.homepage.domain.post.dto.response.FileResponse;
+import com.keeper.homepage.domain.post.dto.response.MainPostResponse;
 import com.keeper.homepage.domain.post.dto.response.MemberPostResponse;
 import com.keeper.homepage.domain.post.dto.response.PostDetailResponse;
 import com.keeper.homepage.domain.post.dto.response.PostListResponse;
@@ -178,13 +179,13 @@ public class PostController {
   }
 
   @GetMapping("/recent")
-  public ResponseEntity<List<PostResponse>> getRecentPosts() {
+  public ResponseEntity<List<MainPostResponse>> getRecentPosts() {
     return ResponseEntity.ok(postService.getRecentPosts());
   }
 
 
   @GetMapping("/trend")
-  public ResponseEntity<List<PostResponse>> getTrendPosts() {
+  public ResponseEntity<List<MainPostResponse>> getTrendPosts() {
     return ResponseEntity.ok(postService.getTrendPosts());
   }
 

--- a/src/main/java/com/keeper/homepage/domain/post/application/PostService.java
+++ b/src/main/java/com/keeper/homepage/domain/post/application/PostService.java
@@ -25,6 +25,7 @@ import com.keeper.homepage.domain.post.dto.response.MemberPostResponse;
 import com.keeper.homepage.domain.post.dto.response.PostDetailResponse;
 import com.keeper.homepage.domain.post.dto.response.PostListResponse;
 import com.keeper.homepage.domain.post.dto.response.PostResponse;
+import com.keeper.homepage.domain.post.dto.response.TempPostResponse;
 import com.keeper.homepage.domain.post.entity.Post;
 import com.keeper.homepage.domain.post.entity.PostHasFile;
 import com.keeper.homepage.domain.post.entity.category.Category;
@@ -360,5 +361,10 @@ public class PostService {
     Member member = memberFindService.findById(memberId);
     return postRepository.findAllByMember(member, pageable)
         .map(MemberPostResponse::from);
+  }
+
+  public Page<TempPostResponse> getTempPosts(Member member, Pageable pageable) {
+    return postRepository.findAllByMemberAndIsTempTrue(member, pageable)
+        .map(TempPostResponse::from);
   }
 }

--- a/src/main/java/com/keeper/homepage/domain/post/application/PostService.java
+++ b/src/main/java/com/keeper/homepage/domain/post/application/PostService.java
@@ -20,6 +20,7 @@ import com.keeper.homepage.domain.post.application.convenience.ValidPostFindServ
 import com.keeper.homepage.domain.post.dao.PostHasFileRepository;
 import com.keeper.homepage.domain.post.dao.PostRepository;
 import com.keeper.homepage.domain.post.dto.response.FileResponse;
+import com.keeper.homepage.domain.post.dto.response.MainPostResponse;
 import com.keeper.homepage.domain.post.dto.response.MemberPostResponse;
 import com.keeper.homepage.domain.post.dto.response.PostDetailResponse;
 import com.keeper.homepage.domain.post.dto.response.PostListResponse;
@@ -322,14 +323,21 @@ public class PostService {
     return PostResponse.from(post);
   }
 
-  public List<PostResponse> getRecentPosts() {
+  private MainPostResponse getMainPostResponse(Post post) {
+    if (post.isCategory(익명게시판)) {
+      return MainPostResponse.of(post, ANONYMOUS_NAME, null);
+    }
+    return MainPostResponse.from(post);
+  }
+
+  public List<MainPostResponse> getRecentPosts() {
     return postRepository.findAllRecent().stream()
-        .map(this::getPostResponse)
+        .map(this::getMainPostResponse)
         .limit(10)
         .toList();
   }
 
-  public List<PostResponse> getTrendPosts() {
+  public List<MainPostResponse> getTrendPosts() {
     LocalDateTime startDateTime = LocalDateTime.now().minusWeeks(2);
     LocalDateTime endDateTime = LocalDateTime.now().plusDays(1);
     List<Post> posts = postRepository.findAllTrend(startDateTime, endDateTime);
@@ -339,7 +347,7 @@ public class PostService {
       return Integer.compare(postScore2, postScore1);
     });
     return posts.stream()
-        .map(this::getPostResponse)
+        .map(this::getMainPostResponse)
         .limit(10)
         .toList();
   }

--- a/src/main/java/com/keeper/homepage/domain/post/application/PostService.java
+++ b/src/main/java/com/keeper/homepage/domain/post/application/PostService.java
@@ -12,6 +12,7 @@ import static com.keeper.homepage.global.error.ErrorCode.POST_SEARCH_TYPE_NOT_FO
 
 import com.keeper.homepage.domain.file.dao.FileRepository;
 import com.keeper.homepage.domain.file.entity.FileEntity;
+import com.keeper.homepage.domain.member.application.convenience.MemberFindService;
 import com.keeper.homepage.domain.member.entity.Member;
 import com.keeper.homepage.domain.post.application.convenience.CategoryFindService;
 import com.keeper.homepage.domain.post.application.convenience.PostDeleteService;
@@ -19,6 +20,7 @@ import com.keeper.homepage.domain.post.application.convenience.ValidPostFindServ
 import com.keeper.homepage.domain.post.dao.PostHasFileRepository;
 import com.keeper.homepage.domain.post.dao.PostRepository;
 import com.keeper.homepage.domain.post.dto.response.FileResponse;
+import com.keeper.homepage.domain.post.dto.response.MemberPostResponse;
 import com.keeper.homepage.domain.post.dto.response.PostDetailResponse;
 import com.keeper.homepage.domain.post.dto.response.PostListResponse;
 import com.keeper.homepage.domain.post.dto.response.PostResponse;
@@ -34,6 +36,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
@@ -53,6 +56,7 @@ public class PostService {
   private final ValidPostFindService validPostFindService;
   private final PostDeleteService postDeleteService;
   private final CategoryFindService categoryFindService;
+  private final MemberFindService memberFindService;
 
   private static final String ANONYMOUS_NAME = "익명";
   private static final int EXAM_ACCESSIBLE_POINT = 30000;
@@ -342,5 +346,11 @@ public class PostService {
 
   private int getPostScore(Post post) {
     return post.getVisitCount() + post.getPostLikes().size() * 2 - post.getPostDislikes().size();
+  }
+
+  public Page<MemberPostResponse> getMemberPosts(long memberId, Pageable pageable) {
+    Member member = memberFindService.findById(memberId);
+    return postRepository.findAllByMember(member, pageable)
+        .map(MemberPostResponse::from);
   }
 }

--- a/src/main/java/com/keeper/homepage/domain/post/dao/PostRepository.java
+++ b/src/main/java/com/keeper/homepage/domain/post/dao/PostRepository.java
@@ -1,5 +1,6 @@
 package com.keeper.homepage.domain.post.dao;
 
+import com.keeper.homepage.domain.member.entity.Member;
 import com.keeper.homepage.domain.post.entity.Post;
 import com.keeper.homepage.domain.post.entity.category.Category;
 import java.time.LocalDateTime;
@@ -141,4 +142,6 @@ public interface PostRepository extends JpaRepository<Post, Long> {
       + "ORDER BY p.id DESC "
       + "LIMIT 1")
   Optional<Post> findPreviousPost(@Param("postId") Long postId, @Param("category") Category category);
+
+  Page<Post> findAllByMember(Member member, Pageable pageable);
 }

--- a/src/main/java/com/keeper/homepage/domain/post/dao/PostRepository.java
+++ b/src/main/java/com/keeper/homepage/domain/post/dao/PostRepository.java
@@ -144,4 +144,6 @@ public interface PostRepository extends JpaRepository<Post, Long> {
   Optional<Post> findPreviousPost(@Param("postId") Long postId, @Param("category") Category category);
 
   Page<Post> findAllByMember(Member member, Pageable pageable);
+
+  Page<Post> findAllByMemberAndIsTempTrue(Member member, Pageable pageable);
 }

--- a/src/main/java/com/keeper/homepage/domain/post/dto/response/MainPostResponse.java
+++ b/src/main/java/com/keeper/homepage/domain/post/dto/response/MainPostResponse.java
@@ -1,0 +1,56 @@
+package com.keeper.homepage.domain.post.dto.response;
+
+import static lombok.AccessLevel.PRIVATE;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.keeper.homepage.domain.post.entity.Post;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = PRIVATE)
+public class MainPostResponse {
+
+  private Long id;
+  private String title;
+  private Long categoryId;
+  private String categoryName;
+  private String writerName;
+  private String writerThumbnailPath;
+  private Integer visitCount;
+  private Boolean isSecret;
+
+  @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+  private LocalDateTime registerTime;
+
+  public static MainPostResponse from(Post post) {
+    return MainPostResponse.builder()
+        .id(post.getId())
+        .title(post.getTitle())
+        .categoryId(post.getCategory().getId())
+        .categoryName(post.getCategory().getType().getName())
+        .writerName(post.getMember().getRealName())
+        .writerThumbnailPath(post.getMember().getThumbnailPath())
+        .visitCount(post.getVisitCount())
+        .isSecret(post.isSecret())
+        .registerTime(post.getRegisterTime())
+        .build();
+  }
+
+  public static MainPostResponse of(Post post, String writerName, String writerThumbnailPath) {
+    return MainPostResponse.builder()
+        .id(post.getId())
+        .title(post.getTitle())
+        .categoryId(post.getCategory().getId())
+        .categoryName(post.getCategory().getType().getName())
+        .writerName(writerName)
+        .writerThumbnailPath(writerThumbnailPath)
+        .visitCount(post.getVisitCount())
+        .isSecret(post.isSecret())
+        .registerTime(post.getRegisterTime())
+        .build();
+  }
+}

--- a/src/main/java/com/keeper/homepage/domain/post/dto/response/MainPostResponse.java
+++ b/src/main/java/com/keeper/homepage/domain/post/dto/response/MainPostResponse.java
@@ -16,6 +16,7 @@ public class MainPostResponse {
 
   private Long id;
   private String title;
+  private String thumbnailPath;
   private Long categoryId;
   private String categoryName;
   private String writerName;
@@ -30,6 +31,7 @@ public class MainPostResponse {
     return MainPostResponse.builder()
         .id(post.getId())
         .title(post.getTitle())
+        .thumbnailPath(post.getThumbnailPath())
         .categoryId(post.getCategory().getId())
         .categoryName(post.getCategory().getType().getName())
         .writerName(post.getMember().getRealName())
@@ -44,6 +46,7 @@ public class MainPostResponse {
     return MainPostResponse.builder()
         .id(post.getId())
         .title(post.getTitle())
+        .thumbnailPath(post.getThumbnailPath())
         .categoryId(post.getCategory().getId())
         .categoryName(post.getCategory().getType().getName())
         .writerName(writerName)

--- a/src/main/java/com/keeper/homepage/domain/post/dto/response/MemberPostResponse.java
+++ b/src/main/java/com/keeper/homepage/domain/post/dto/response/MemberPostResponse.java
@@ -1,0 +1,36 @@
+package com.keeper.homepage.domain.post.dto.response;
+
+import static lombok.AccessLevel.PRIVATE;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.keeper.homepage.domain.post.entity.Post;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = PRIVATE)
+public class MemberPostResponse {
+
+  private Long id;
+  private String title;
+  private Long categoryId;
+  private String categoryName;
+  private Integer visitCount;
+
+  @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+  private LocalDateTime registerTime;
+
+  public static MemberPostResponse from(Post post) {
+    return MemberPostResponse.builder()
+        .id(post.getId())
+        .title(post.getTitle())
+        .categoryId(post.getCategory().getId())
+        .categoryName(post.getCategory().getType().getName())
+        .visitCount(post.getVisitCount())
+        .registerTime(post.getRegisterTime())
+        .build();
+  }
+}

--- a/src/main/java/com/keeper/homepage/domain/post/dto/response/TempPostResponse.java
+++ b/src/main/java/com/keeper/homepage/domain/post/dto/response/TempPostResponse.java
@@ -1,0 +1,34 @@
+package com.keeper.homepage.domain.post.dto.response;
+
+import static lombok.AccessLevel.PRIVATE;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.keeper.homepage.domain.post.entity.Post;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = PRIVATE)
+public class TempPostResponse {
+
+  private Long id;
+  private String title;
+  private Long categoryId;
+  private String categoryName;
+
+  @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+  private LocalDateTime registerTime;
+
+  public static TempPostResponse from(Post post) {
+    return TempPostResponse.builder()
+        .id(post.getId())
+        .title(post.getTitle())
+        .categoryId(post.getCategory().getId())
+        .categoryName(post.getCategory().getType().getName())
+        .registerTime(post.getRegisterTime())
+        .build();
+  }
+}

--- a/src/test/java/com/keeper/homepage/domain/post/api/PostApiTestHelper.java
+++ b/src/test/java/com/keeper/homepage/domain/post/api/PostApiTestHelper.java
@@ -154,4 +154,15 @@ public class PostApiTestHelper extends IntegrationTest {
         fieldWithPath("registerTime").description("게시글 등록 시간")
     };
   }
+
+  FieldDescriptor[] getMemberPostsResponse() {
+    return new FieldDescriptor[]{
+        fieldWithPath("id").description("게시글 ID"),
+        fieldWithPath("title").description("게시글 제목"),
+        fieldWithPath("categoryId").description("게시글 카테고리 ID"),
+        fieldWithPath("categoryName").description("게시글 카테고리 이름"),
+        fieldWithPath("visitCount").description("게시글 조회수"),
+        fieldWithPath("registerTime").description("게시글 등록 시간")
+    };
+  }
 }

--- a/src/test/java/com/keeper/homepage/domain/post/api/PostApiTestHelper.java
+++ b/src/test/java/com/keeper/homepage/domain/post/api/PostApiTestHelper.java
@@ -180,4 +180,14 @@ public class PostApiTestHelper extends IntegrationTest {
         fieldWithPath("registerTime").description("게시글 등록 시간")
     };
   }
+
+  FieldDescriptor[] getTempPostsResponse() {
+    return new FieldDescriptor[]{
+        fieldWithPath("id").description("게시글 ID"),
+        fieldWithPath("title").description("게시글 제목"),
+        fieldWithPath("categoryId").description("게시글 카테고리 ID"),
+        fieldWithPath("categoryName").description("게시글 카테고리 이름"),
+        fieldWithPath("registerTime").description("게시글 등록 시간")
+    };
+  }
 }

--- a/src/test/java/com/keeper/homepage/domain/post/api/PostApiTestHelper.java
+++ b/src/test/java/com/keeper/homepage/domain/post/api/PostApiTestHelper.java
@@ -155,6 +155,21 @@ public class PostApiTestHelper extends IntegrationTest {
     };
   }
 
+  FieldDescriptor[] getMainPostsResponse() {
+    return new FieldDescriptor[]{
+        fieldWithPath("id").description("게시글 ID"),
+        fieldWithPath("title").description("게시글 제목"),
+        fieldWithPath("writerName").description("게시글 작성자 닉네임"),
+        fieldWithPath("writerThumbnailPath").description("게시글 작성자 썸네일 주소"),
+        fieldWithPath("categoryId").description("카테고리 ID"),
+        fieldWithPath("categoryName").description("카테고리 이름"),
+        fieldWithPath("visitCount").description("게시글 조회수"),
+        fieldWithPath("isSecret").description("비밀글 여부"),
+        fieldWithPath("thumbnailPath").description("게시글 썸네일 주소"),
+        fieldWithPath("registerTime").description("게시글 등록 시간")
+    };
+  }
+
   FieldDescriptor[] getMemberPostsResponse() {
     return new FieldDescriptor[]{
         fieldWithPath("id").description("게시글 ID"),

--- a/src/test/java/com/keeper/homepage/domain/post/api/PostControllerTest.java
+++ b/src/test/java/com/keeper/homepage/domain/post/api/PostControllerTest.java
@@ -829,6 +829,36 @@ public class PostControllerTest extends PostApiTestHelper {
                   pageHelper(getMemberPostsResponse())
               )));
     }
+
+    @Test
+    @DisplayName("유효한 요청이면 회원의 임시글 목록 조회는 성공한다.")
+    public void 유효한_요청이면_회원의_임시글_목록_조회는_성공한다() throws Exception {
+      String securedValue = getSecuredValue(PostController.class, "getTempPosts");
+
+      postTestHelper.builder().member(member).isTemp(true).build();
+      postTestHelper.builder().member(member).isTemp(true).build();
+      postTestHelper.builder().member(member).isTemp(true).build();
+
+      em.flush();
+      em.clear();
+      mockMvc.perform(get("/posts/temp")
+              .cookie(new Cookie(ACCESS_TOKEN.getTokenName(), memberToken)))
+          .andExpect(status().isOk())
+          .andDo(document("get-temp-posts",
+              requestCookies(
+                  cookieWithName(ACCESS_TOKEN.getTokenName())
+                      .description("ACCESS TOKEN %s".formatted(securedValue))
+              ),
+              queryParameters(
+                  parameterWithName("page").description("페이지 (default: 0)")
+                      .optional(),
+                  parameterWithName("size").description("한 페이지당 불러올 개수 (default: 10)")
+                      .optional()
+              ),
+              responseFields(
+                  pageHelper(getTempPostsResponse())
+              )));
+    }
   }
 
   @Nested

--- a/src/test/java/com/keeper/homepage/domain/post/api/PostControllerTest.java
+++ b/src/test/java/com/keeper/homepage/domain/post/api/PostControllerTest.java
@@ -800,6 +800,35 @@ public class PostControllerTest extends PostApiTestHelper {
                   listHelper("", getPostsResponse())
               )));
     }
+
+    @Test
+    @DisplayName("유효한 요청이면 회원의 게시글 목록 조회는 성공한다.")
+    public void 유효한_요청이면_회원의_게시글_목록_조회는_성공한다() throws Exception {
+      String securedValue = getSecuredValue(PostController.class, "getMemberPosts");
+
+      em.flush();
+      em.clear();
+      mockMvc.perform(get("/posts/members/{memberId}", member.getId())
+              .cookie(new Cookie(ACCESS_TOKEN.getTokenName(), memberToken)))
+          .andExpect(status().isOk())
+          .andDo(document("get-member-posts",
+              requestCookies(
+                  cookieWithName(ACCESS_TOKEN.getTokenName())
+                      .description("ACCESS TOKEN %s".formatted(securedValue))
+              ),
+              pathParameters(
+                  parameterWithName("memberId").description("회원의 ID")
+              ),
+              queryParameters(
+                  parameterWithName("page").description("페이지 (default: 0)")
+                      .optional(),
+                  parameterWithName("size").description("한 페이지당 불러올 개수 (default: 10)")
+                      .optional()
+              ),
+              responseFields(
+                  pageHelper(getMemberPostsResponse())
+              )));
+    }
   }
 
   @Nested

--- a/src/test/java/com/keeper/homepage/domain/post/api/PostControllerTest.java
+++ b/src/test/java/com/keeper/homepage/domain/post/api/PostControllerTest.java
@@ -784,7 +784,7 @@ public class PostControllerTest extends PostApiTestHelper {
           .andExpect(status().isOk())
           .andDo(document("get-recent-posts",
               responseFields(
-                  listHelper("", getPostsResponse())
+                  listHelper("", getMainPostsResponse())
               )));
     }
 
@@ -797,7 +797,7 @@ public class PostControllerTest extends PostApiTestHelper {
           .andExpect(status().isOk())
           .andDo(document("get-trend-posts",
               responseFields(
-                  listHelper("", getPostsResponse())
+                  listHelper("", getMainPostsResponse())
               )));
     }
 


### PR DESCRIPTION
## 🔥 Related Issue

> close: #279

## 📝 Description

- 회원의 게시글 목록 조회 기능 구현했습니다.
- 임시 게시글 목록 조회 기능 구현했습니다.
- 메인페이지에서 사용될 게시글(최근 게시글, 트랜드 게시글) 응답 DTO 따로 분리했습니다!

## ⭐️ Review Request

[기획서 링크](https://www.notion.so/C1-C2-a28c6567f6a24079a19f04a097dda1dc?pvs=4) 입니다!
