### PR TITLE
feat: 족보 열람시 차감된 포인트 로그 생성 코드 추가

### DIFF
--- a/src/main/java/com/keeper/homepage/domain/attendance/application/AttendanceService.java
+++ b/src/main/java/com/keeper/homepage/domain/attendance/application/AttendanceService.java
@@ -1,7 +1,6 @@
 package com.keeper.homepage.domain.attendance.application;
 
 import static com.keeper.homepage.global.error.ErrorCode.ATTENDANCE_ALREADY;
-import static java.util.Comparator.comparing;
 
 import com.keeper.homepage.domain.attendance.dao.AttendanceRepository;
 import com.keeper.homepage.domain.attendance.dto.response.AttendanceResponse;
@@ -61,7 +60,7 @@ public class AttendanceService {
         .member(member)
         .build();
     attendanceRepository.save(attendance);
-    pointLogService.create(attendance);
+    pointLogService.createAttendanceLog(attendance);
   }
 
   private void checkAlreadyAttendance(Member member) {

--- a/src/main/java/com/keeper/homepage/domain/attendance/application/AttendanceService.java
+++ b/src/main/java/com/keeper/homepage/domain/attendance/application/AttendanceService.java
@@ -6,7 +6,6 @@ import com.keeper.homepage.domain.attendance.dao.AttendanceRepository;
 import com.keeper.homepage.domain.attendance.dto.response.AttendanceResponse;
 import com.keeper.homepage.domain.attendance.entity.Attendance;
 import com.keeper.homepage.domain.member.entity.Member;
-import com.keeper.homepage.domain.point.application.PointLogService;
 import com.keeper.homepage.global.error.BusinessException;
 import com.keeper.homepage.global.util.redis.RedisUtil;
 import com.keeper.homepage.global.util.web.WebUtil;
@@ -25,7 +24,6 @@ import org.springframework.transaction.annotation.Transactional;
 public class AttendanceService {
 
   private final AttendanceRepository attendanceRepository;
-  private final PointLogService pointLogService;
   private final RedisUtil redisUtil;
 
   private static final long RANK_DATA_EXPIRE_DURATION = 60 * 60 * 24; // 60s * 60m * 24h로 하루를 의미함.
@@ -60,7 +58,7 @@ public class AttendanceService {
         .member(member)
         .build();
     attendanceRepository.save(attendance);
-    pointLogService.createAttendanceLog(attendance);
+    member.addPoint(attendance.getTotalPoint());
   }
 
   private void checkAlreadyAttendance(Member member) {

--- a/src/main/java/com/keeper/homepage/domain/attendance/application/AttendanceService.java
+++ b/src/main/java/com/keeper/homepage/domain/attendance/application/AttendanceService.java
@@ -29,6 +29,7 @@ public class AttendanceService {
   private static final long RANK_DATA_EXPIRE_DURATION = 60 * 60 * 24; // 60s * 60m * 24h로 하루를 의미함.
 
   private static final String ATTENDANCE_MESSAGE = "자동 출석입니다.";
+  private static final String ATTENDANCE_POINT_MESSAGE = "출석 포인트";
   private static final int RANDOM_MIN_POINT = 100;
   private static final int RANDOM_MAX_POINT = 1000;
   public static final int DAILY_POINT = 1000;
@@ -58,7 +59,7 @@ public class AttendanceService {
         .member(member)
         .build();
     attendanceRepository.save(attendance);
-    member.addPoint(attendance.getTotalPoint());
+    member.addPoint(attendance.getTotalPoint(), ATTENDANCE_POINT_MESSAGE);
   }
 
   private void checkAlreadyAttendance(Member member) {

--- a/src/main/java/com/keeper/homepage/domain/game/application/BaseballService.kt
+++ b/src/main/java/com/keeper/homepage/domain/game/application/BaseballService.kt
@@ -17,6 +17,8 @@ const val GUESS_NUMBER_LENGTH = 4
 const val TRY_COUNT = 9
 const val MAX_BETTING_POINT = 1000L
 const val MIN_BETTING_POINT = 10L
+const val BETTING_POINT_MESSAGE = "야구 게임 베팅"
+const val EARN_POINT_MESSAGE = "야구 게임 획득"
 
 @Service
 @Transactional(readOnly = true)
@@ -52,7 +54,7 @@ class BaseballService(
         }
 
         val game = gameFindService.findByMemberOrInit(requestMember)
-        requestMember.minusPoint(bettingPoint)
+        requestMember.minusPoint(bettingPoint, BETTING_POINT_MESSAGE)
         game.baseball.increaseBaseballTimes()
 
         val baseballResultEntity = BaseballResultEntity(
@@ -103,7 +105,7 @@ class BaseballService(
         saveBaseballResultInRedis(requestMember.id, baseballResultEntity, gameEntity.baseball.baseballPerDay)
 
         val earnablePoints = baseballResultEntity.earnablePoints
-        requestMember.addPoint(earnablePoints)
+        requestMember.addPoint(earnablePoints, EARN_POINT_MESSAGE)
         gameEntity.baseball.baseballDayPoint = earnablePoints
 
         return Pair(baseballResultEntity.results, earnablePoints)

--- a/src/main/java/com/keeper/homepage/domain/member/entity/Member.java
+++ b/src/main/java/com/keeper/homepage/domain/member/entity/Member.java
@@ -330,15 +330,19 @@ public class Member {
 
   public void addPoint(int point) {
     this.point += point;
+  }
+
+  public void addPoint(int point, String message) {
+    this.point += point;
     this.pointLogs.add(PointLog.builder()
         .time(LocalDateTime.now())
         .member(this)
         .point(point)
-        .isSpent(false)
+        .detail(message)
         .build());
   }
 
-  public void minusPoint(int point) {
+  public void minusPoint(int point, String message) {
     if (this.point < point && point < 0) {
       throw new IllegalArgumentException();
     }
@@ -347,7 +351,7 @@ public class Member {
         .time(LocalDateTime.now())
         .member(this)
         .point(-point)
-        .isSpent(false)
+        .detail(message)
         .build());
   }
 

--- a/src/main/java/com/keeper/homepage/domain/member/entity/Member.java
+++ b/src/main/java/com/keeper/homepage/domain/member/entity/Member.java
@@ -53,6 +53,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -147,7 +148,7 @@ public class Member {
   @OneToMany(mappedBy = "member")
   private final List<Comment> comments = new ArrayList<>();
 
-  @OneToMany(mappedBy = "member")
+  @OneToMany(mappedBy = "member", cascade = PERSIST)
   private final List<PointLog> pointLogs = new ArrayList<>();
 
   @OneToMany(mappedBy = "member", cascade = ALL, orphanRemoval = true)
@@ -329,6 +330,12 @@ public class Member {
 
   public void addPoint(int point) {
     this.point += point;
+    this.pointLogs.add(PointLog.builder()
+        .time(LocalDateTime.now())
+        .member(this)
+        .point(point)
+        .isSpent(false)
+        .build());
   }
 
   public void minusPoint(int point) {
@@ -336,6 +343,12 @@ public class Member {
       throw new IllegalArgumentException();
     }
     this.point -= point;
+    this.pointLogs.add(PointLog.builder()
+        .time(LocalDateTime.now())
+        .member(this)
+        .point(-point)
+        .isSpent(false)
+        .build());
   }
 
   public String getThumbnailPath() {

--- a/src/main/java/com/keeper/homepage/domain/point/application/PointLogService.java
+++ b/src/main/java/com/keeper/homepage/domain/point/application/PointLogService.java
@@ -1,8 +1,10 @@
 package com.keeper.homepage.domain.point.application;
 
 import com.keeper.homepage.domain.attendance.entity.Attendance;
+import com.keeper.homepage.domain.member.entity.Member;
 import com.keeper.homepage.domain.point.dao.PointLogRepository;
 import com.keeper.homepage.domain.point.entity.PointLog;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,15 +17,27 @@ public class PointLogService {
   private final PointLogRepository pointLogRepository;
 
   private static final String ATTENDANCE_POINT_MESSAGE = "출석 포인트";
+  private static final String EXAM_READ_POINT_MESSAGE = "족보 열람";
 
   @Transactional
-  public void create(Attendance attendance) {
+  public void createAttendanceLog(Attendance attendance) {
     pointLogRepository.save(PointLog.builder()
         .time(attendance.getTime())
         .member(attendance.getMember())
         .point(attendance.getTotalPoint())
         .detail(ATTENDANCE_POINT_MESSAGE)
-        .isSpent(true)
+        .isSpent(false)
+        .build());
+  }
+
+  @Transactional
+  public void createExamLog(Member member, int point) {
+    pointLogRepository.save(PointLog.builder()
+        .time(LocalDateTime.now())
+        .member(member)
+        .point(point)
+        .detail(EXAM_READ_POINT_MESSAGE)
+        .isSpent(false)
         .build());
   }
 }

--- a/src/main/java/com/keeper/homepage/domain/point/application/PointLogService.java
+++ b/src/main/java/com/keeper/homepage/domain/point/application/PointLogService.java
@@ -35,7 +35,7 @@ public class PointLogService {
     pointLogRepository.save(PointLog.builder()
         .time(LocalDateTime.now())
         .member(member)
-        .point(point)
+        .point(-point)
         .detail(EXAM_READ_POINT_MESSAGE)
         .isSpent(false)
         .build());

--- a/src/main/java/com/keeper/homepage/domain/point/application/PointLogService.java
+++ b/src/main/java/com/keeper/homepage/domain/point/application/PointLogService.java
@@ -1,10 +1,5 @@
 package com.keeper.homepage.domain.point.application;
 
-import com.keeper.homepage.domain.attendance.entity.Attendance;
-import com.keeper.homepage.domain.member.entity.Member;
-import com.keeper.homepage.domain.point.dao.PointLogRepository;
-import com.keeper.homepage.domain.point.entity.PointLog;
-import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -14,30 +9,4 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class PointLogService {
 
-  private final PointLogRepository pointLogRepository;
-
-  private static final String ATTENDANCE_POINT_MESSAGE = "출석 포인트";
-  private static final String EXAM_READ_POINT_MESSAGE = "족보 열람";
-
-  @Transactional
-  public void createAttendanceLog(Attendance attendance) {
-    pointLogRepository.save(PointLog.builder()
-        .time(attendance.getTime())
-        .member(attendance.getMember())
-        .point(attendance.getTotalPoint())
-        .detail(ATTENDANCE_POINT_MESSAGE)
-        .isSpent(false)
-        .build());
-  }
-
-  @Transactional
-  public void createExamLog(Member member, int point) {
-    pointLogRepository.save(PointLog.builder()
-        .time(LocalDateTime.now())
-        .member(member)
-        .point(-point)
-        .detail(EXAM_READ_POINT_MESSAGE)
-        .isSpent(false)
-        .build());
-  }
 }

--- a/src/main/java/com/keeper/homepage/domain/point/entity/PointLog.java
+++ b/src/main/java/com/keeper/homepage/domain/point/entity/PointLog.java
@@ -57,6 +57,6 @@ public class PointLog {
     this.point = point;
     this.detail = detail;
     this.presented = presented;
-    this.isSpent = isSpent;
+    this.isSpent = isSpent != null ? isSpent : false;
   }
 }

--- a/src/main/java/com/keeper/homepage/domain/post/application/PostService.java
+++ b/src/main/java/com/keeper/homepage/domain/post/application/PostService.java
@@ -14,7 +14,6 @@ import com.keeper.homepage.domain.file.dao.FileRepository;
 import com.keeper.homepage.domain.file.entity.FileEntity;
 import com.keeper.homepage.domain.member.application.convenience.MemberFindService;
 import com.keeper.homepage.domain.member.entity.Member;
-import com.keeper.homepage.domain.point.application.PointLogService;
 import com.keeper.homepage.domain.post.application.convenience.CategoryFindService;
 import com.keeper.homepage.domain.post.application.convenience.PostDeleteService;
 import com.keeper.homepage.domain.post.application.convenience.ValidPostFindService;
@@ -60,11 +59,11 @@ public class PostService {
   private final PostDeleteService postDeleteService;
   private final CategoryFindService categoryFindService;
   private final MemberFindService memberFindService;
-  private final PointLogService pointLogService;
 
   private static final String ANONYMOUS_NAME = "익명";
   private static final int EXAM_ACCESSIBLE_POINT = 30000;
   private static final int EXAM_READ_DEDUCTION_POINT = 10000;
+  private static final String EXAM_READ_POINT_MESSAGE = "족보 열람";
 
   @Transactional
   public Long create(Post post, Long categoryId, MultipartFile thumbnail, List<MultipartFile> multipartFiles) {
@@ -184,7 +183,7 @@ public class PostService {
 
     if (post.isCategory(시험게시판) && !member.isRead(post)) {
       member.read(post);
-      member.minusPoint(EXAM_READ_DEDUCTION_POINT);
+      member.minusPoint(EXAM_READ_DEDUCTION_POINT, EXAM_READ_POINT_MESSAGE);
     }
     return post.getPostHasFiles()
         .stream()

--- a/src/main/java/com/keeper/homepage/domain/post/application/PostService.java
+++ b/src/main/java/com/keeper/homepage/domain/post/application/PostService.java
@@ -14,6 +14,7 @@ import com.keeper.homepage.domain.file.dao.FileRepository;
 import com.keeper.homepage.domain.file.entity.FileEntity;
 import com.keeper.homepage.domain.member.application.convenience.MemberFindService;
 import com.keeper.homepage.domain.member.entity.Member;
+import com.keeper.homepage.domain.point.application.PointLogService;
 import com.keeper.homepage.domain.post.application.convenience.CategoryFindService;
 import com.keeper.homepage.domain.post.application.convenience.PostDeleteService;
 import com.keeper.homepage.domain.post.application.convenience.ValidPostFindService;
@@ -59,6 +60,7 @@ public class PostService {
   private final PostDeleteService postDeleteService;
   private final CategoryFindService categoryFindService;
   private final MemberFindService memberFindService;
+  private final PointLogService pointLogService;
 
   private static final String ANONYMOUS_NAME = "익명";
   private static final int EXAM_ACCESSIBLE_POINT = 30000;
@@ -183,6 +185,7 @@ public class PostService {
     if (post.isCategory(시험게시판) && !member.isRead(post)) {
       member.read(post);
       member.minusPoint(EXAM_READ_DEDUCTION_POINT);
+      pointLogService.createExamLog(member, EXAM_READ_DEDUCTION_POINT);
     }
     return post.getPostHasFiles()
         .stream()

--- a/src/main/java/com/keeper/homepage/domain/post/application/PostService.java
+++ b/src/main/java/com/keeper/homepage/domain/post/application/PostService.java
@@ -185,7 +185,6 @@ public class PostService {
     if (post.isCategory(시험게시판) && !member.isRead(post)) {
       member.read(post);
       member.minusPoint(EXAM_READ_DEDUCTION_POINT);
-      pointLogService.createExamLog(member, EXAM_READ_DEDUCTION_POINT);
     }
     return post.getPostHasFiles()
         .stream()

--- a/src/test/java/com/keeper/homepage/domain/game/api/GameControllerTest.kt
+++ b/src/test/java/com/keeper/homepage/domain/game/api/GameControllerTest.kt
@@ -107,7 +107,8 @@ class GameControllerTest : GameApiTestHelper() {
         @Test
         fun `베팅 포인트가 10포인트 이상, 1000포인트 이하면 게임이 시작된다`() {
             player.addPoint(1000)
-            memberRepository.save(player)
+            em.flush()
+            em.clear()
 
             val result = callBaseballStart(1000)
                 .andExpect(status().isNoContent)


### PR DESCRIPTION
## 🔥 Related Issue

> close: #없음

## 📝 Description

<img width="739" alt="image" src="https://github.com/KEEPER31337/Homepage-Back-R2/assets/92802207/cee43230-6861-46a7-8cad-f0b21bd9127f">

기획서 보니까 족보 열람할때 차감한 포인트에 대한 로그도 남겨줘야겠더라구요! 해당 작업 수행했습니다.

## ⭐️ Review Request

> 리뷰어에게 전달하고 싶은 내용을 적어주세요.
