### PR TITLE
fix: ACCESS TOKEN 쿠키 만료시간은 REFRESH TOKEN과 동일하게 변경

### DIFF
--- a/src/main/java/com/keeper/homepage/domain/auth/application/AuthCookieService.java
+++ b/src/main/java/com/keeper/homepage/domain/auth/application/AuthCookieService.java
@@ -23,7 +23,7 @@ public class AuthCookieService {
     setTokenInCookie(response, newRefreshToken, (int) REFRESH_TOKEN.getExpiredMillis() / 1000,
         REFRESH_TOKEN.getTokenName());
     String newAccessToken = jwtTokenProvider.createAccessToken(ACCESS_TOKEN, authId, roles);
-    setTokenInCookie(response, newAccessToken, (int) ACCESS_TOKEN.getExpiredMillis() / 1000,
+    setTokenInCookie(response, newAccessToken, (int) REFRESH_TOKEN.getExpiredMillis() / 1000,
         ACCESS_TOKEN.getTokenName());
     redisUtil.setDataExpire(authId, newRefreshToken, REFRESH_TOKEN.getExpiredMillis());
   }


### PR DESCRIPTION
## 🔥 Related Issue

없음.

## 📝 Description

로그인이 자꾸 ACCESS TOKEN 만료시간만큼 지나면 풀린다는 이슈가 있어서 확인해봄.

`refresh token`이 있는데 동작을 하고 있지 않길래 봤더니 `access token 쿠키` 만료 시간이 `access token` 만료시간(1시간)과 같았음.
그래서 1시간이 지나면 **쿠키가 아예 사라져버려서** 백엔드에서 이상하게 동작하는게 원인이었음.
`access token`의 토큰 만료 시간은 1시간으로 하되, 쿠키 만료시간은 `refresh token`과 같은 2주로 변경.

## ⭐️ Review Request

화요일은 쉬는날~
