### PR TITLE
야구게임 추가사항 구현

### DIFF
--- a/src/main/java/com/keeper/homepage/domain/game/api/GameController.kt
+++ b/src/main/java/com/keeper/homepage/domain/game/api/GameController.kt
@@ -8,6 +8,7 @@ import com.keeper.homepage.domain.game.dto.res.BaseballResponse
 import com.keeper.homepage.domain.game.dto.res.BaseballStatusResponse
 import com.keeper.homepage.domain.game.dto.res.GameInfoByMemberResponse
 import com.keeper.homepage.domain.game.dto.res.GameRankResponse
+import com.keeper.homepage.domain.game.entity.redis.SECOND_PER_GAME
 import com.keeper.homepage.domain.member.entity.Member
 import com.keeper.homepage.global.config.security.annotation.LoginMember
 import jakarta.validation.Valid
@@ -42,7 +43,7 @@ class GameController(
         @RequestBody @Valid request: BaseballStartRequest
     ): ResponseEntity<BaseballResponse> {
         val earnablePoint = baseballService.start(requestMember, request.bettingPoint)
-        return ResponseEntity.ok(BaseballResponse(emptyList(), earnablePoint))
+        return ResponseEntity.ok(BaseballResponse(emptyList(), earnablePoint, SECOND_PER_GAME))
     }
 
     @PostMapping("/baseball/guess")
@@ -50,19 +51,19 @@ class GameController(
         @LoginMember requestMember: Member,
         @RequestBody @Valid request: BaseballGuessRequest
     ): ResponseEntity<BaseballResponse> {
-        val (results, earnablePoint) = baseballService.guess(requestMember, request.guessNumber)
+        val (results, earnablePoint, remainedSeconds) = baseballService.guess(requestMember, request.guessNumber)
         return ResponseEntity.ok(BaseballResponse(results.map { i ->
             if (i == null) null else BaseballResponse.GuessResultResponse(i)
-        }, earnablePoint))
+        }, earnablePoint, remainedSeconds))
     }
 
     @GetMapping("/baseball/result")
     fun getBaseballResult(
         @LoginMember requestMember: Member
     ): ResponseEntity<BaseballResponse> {
-        val (results, earnablePoint) = baseballService.getResult(requestMember)
+        val (results, earnablePoint, remainedSeconds) = baseballService.getResult(requestMember)
         return ResponseEntity.ok(BaseballResponse(results.map { i ->
             if (i == null) null else BaseballResponse.GuessResultResponse(i)
-        }, earnablePoint))
+        }, earnablePoint, remainedSeconds))
     }
 }

--- a/src/main/java/com/keeper/homepage/domain/game/application/BaseballService.kt
+++ b/src/main/java/com/keeper/homepage/domain/game/application/BaseballService.kt
@@ -44,7 +44,11 @@ class BaseballService(
         if (gameEntity.baseball.isNeverStartedToday) {
             return Pair(BaseballStatus.NOT_START, gameEntity.baseball.baseballPerDay)
         }
+
         val baseballResult = getBaseballResultInRedis(requestMember, gameEntity)
+        baseballResult.updateTimeoutGames()
+        saveBaseballResultInRedis(requestMember.id, baseballResult, gameEntity.baseball.baseballPerDay)
+
         if (baseballResult.isEnd()) {
             return Pair(BaseballStatus.END, gameEntity.baseball.baseballPerDay)
         }

--- a/src/main/java/com/keeper/homepage/domain/game/application/BaseballService.kt
+++ b/src/main/java/com/keeper/homepage/domain/game/application/BaseballService.kt
@@ -140,6 +140,7 @@ class BaseballService(
         }
 
         val remainedSeconds = baseballResultEntity.updateTimeoutGames()
+        saveBaseballResultInRedis(requestMember.id, baseballResultEntity, gameEntity.baseball.baseballPerDay)
 
         return Triple(baseballResultEntity.results, gameEntity.baseball.baseballDayPoint, remainedSeconds)
     }

--- a/src/main/java/com/keeper/homepage/domain/game/application/BaseballService.kt
+++ b/src/main/java/com/keeper/homepage/domain/game/application/BaseballService.kt
@@ -1,7 +1,6 @@
 package com.keeper.homepage.domain.game.application
 
 import com.keeper.homepage.domain.game.dto.res.BaseballStatus
-import com.keeper.homepage.domain.game.dto.res.BaseballStatusResponse
 import com.keeper.homepage.domain.game.dto.res.GameInfoByMemberResponse
 import com.keeper.homepage.domain.game.entity.Game
 import com.keeper.homepage.domain.game.entity.embedded.Baseball.BASEBALL_MAX_PLAYTIME
@@ -53,7 +52,7 @@ class BaseballService(
     }
 
     @Transactional
-    fun start(requestMember: Member, bettingPoint: Int): Int  {
+    fun start(requestMember: Member, bettingPoint: Int): Int {
         if (isAlreadyPlayedAllOfThem(requestMember)) {
             throw BusinessException(requestMember.id, "memberId", ErrorCode.IS_ALREADY_PLAYED)
         }
@@ -108,12 +107,15 @@ class BaseballService(
     }
 
     @Transactional
-    fun guess(requestMember: Member, guessNumber: String): Pair<List<BaseballResultEntity.GuessResultEntity?>, Int> {
+    fun guess(
+        requestMember: Member,
+        guessNumber: String
+    ): Triple<List<BaseballResultEntity.GuessResultEntity?>, Int, Int> {
         val gameEntity = gameFindService.findByMemberOrInit(requestMember)
         val baseballResultEntity = getBaseballResultInRedis(requestMember, gameEntity)
 
         if (baseballResultEntity.isEnd()) {
-            return Pair(baseballResultEntity.results, gameEntity.baseball.baseballDayPoint)
+            return Triple(baseballResultEntity.results, gameEntity.baseball.baseballDayPoint, 0)
         }
 
         baseballResultEntity.update(guessNumber)
@@ -123,23 +125,23 @@ class BaseballService(
         requestMember.addPoint(earnablePoint, EARN_POINT_MESSAGE)
         gameEntity.baseball.baseballDayPoint = earnablePoint
 
-        return Pair(baseballResultEntity.results, earnablePoint)
+        return Triple(baseballResultEntity.results, earnablePoint, 0)
     }
 
-    fun getResult(requestMember: Member): Pair<List<BaseballResultEntity.GuessResultEntity?>, Int> {
+    fun getResult(requestMember: Member): Triple<List<BaseballResultEntity.GuessResultEntity?>, Int, Int> {
         if (isNotPlayedYet(requestMember)) {
-            return Pair(listOf(), 0)
+            return Triple(listOf(), 0, 0)
         }
         val gameEntity = gameFindService.findByMemberOrInit(requestMember)
         val baseballResultEntity = getBaseballResultInRedis(requestMember, gameEntity)
 
         if (baseballResultEntity.isEnd()) {
-            return Pair(baseballResultEntity.results, gameEntity.baseball.baseballDayPoint)
+            return Triple(baseballResultEntity.results, gameEntity.baseball.baseballDayPoint, 0)
         }
 
-        baseballResultEntity.updateTimeoutGames()
+        val remainedSeconds = baseballResultEntity.updateTimeoutGames()
 
-        return Pair(baseballResultEntity.results, gameEntity.baseball.baseballDayPoint)
+        return Triple(baseballResultEntity.results, gameEntity.baseball.baseballDayPoint, remainedSeconds)
     }
 
     private fun isNotPlayedYet(requestMember: Member): Boolean {

--- a/src/main/java/com/keeper/homepage/domain/game/dto/res/BaseballResponse.kt
+++ b/src/main/java/com/keeper/homepage/domain/game/dto/res/BaseballResponse.kt
@@ -5,6 +5,7 @@ import com.keeper.homepage.domain.game.entity.redis.BaseballResultEntity
 data class BaseballResponse(
     val results: List<GuessResultResponse?>,
     val earnablePoint: Int,
+    val remainedSecond: Int, // millis 단위는 버림.
 ) {
     data class GuessResultResponse(val guessNumber: String, val strike: Int, val ball: Int) {
         constructor(guessResultEntity: BaseballResultEntity.GuessResultEntity) : this(

--- a/src/main/java/com/keeper/homepage/domain/game/entity/redis/BaseballResultEntity.kt
+++ b/src/main/java/com/keeper/homepage/domain/game/entity/redis/BaseballResultEntity.kt
@@ -1,6 +1,5 @@
 package com.keeper.homepage.domain.game.entity.redis
 
-import com.fasterxml.jackson.annotation.JsonIgnore
 import com.keeper.homepage.domain.game.application.GUESS_NUMBER_LENGTH
 import com.keeper.homepage.domain.game.application.TRY_COUNT
 import com.keeper.homepage.domain.game.support.BaseballSupport
@@ -16,13 +15,14 @@ class BaseballResultEntity(
 ) {
     var lastGuessTime: LocalDateTime = LocalDateTime.now()
 
-    fun updateTimeoutGames() {
-        val passedGameCount = BaseballSupport.getPassedGameCount(results.size, lastGuessTime)
+    fun updateTimeoutGames(): Int {
+        val (passedGameCount, remainedSeconds) = BaseballSupport.getPassedGameCount(results.size, lastGuessTime)
         (1..passedGameCount).forEach { _ -> if (results.size < TRY_COUNT) results.add(null) }
-        updateearnablePointByTimeoutGames(passedGameCount)
+        updateEarnablePointByTimeoutGames(passedGameCount)
+        return remainedSeconds
     }
 
-    private fun updateearnablePointByTimeoutGames(passedGameCount: Int) {
+    private fun updateEarnablePointByTimeoutGames(passedGameCount: Int) {
         (1..passedGameCount).forEach { _ ->
             // TODO: 포인트 획득 전략 정해지면 다시 구현
             this.earnablePoint -= this.earnablePoint / 10

--- a/src/main/java/com/keeper/homepage/domain/game/support/BaseballSupport.kt
+++ b/src/main/java/com/keeper/homepage/domain/game/support/BaseballSupport.kt
@@ -12,15 +12,16 @@ class BaseballSupport {
         fun getPassedGameCount(
             playedRoundCount: Int,
             lastGuessTime: LocalDateTime,
-        ): Int {
+        ): Pair<Int, Int> {
             val now = LocalDateTime.now()
             val passedSecond = now.toEpochSecond(UTC) - lastGuessTime.toEpochSecond(UTC)
             // 마지막으로 플레이 한 시간이 너무 오래 지나 list에 너무 많은 값이 들어가는걸 방지
             val passedGameCount = passedSecond / SECOND_PER_GAME
+            val remainedRoundSeconds = SECOND_PER_GAME - passedSecond % SECOND_PER_GAME - 1 // 버림값 1초
             return if (passedGameCount < TRY_COUNT - playedRoundCount) {
-                passedGameCount.toInt()
+                Pair(passedGameCount.toInt(), remainedRoundSeconds.toInt())
             } else {
-                TRY_COUNT - playedRoundCount
+                Pair(TRY_COUNT - playedRoundCount, 0)
             }
         }
 

--- a/src/test/java/com/keeper/homepage/domain/game/api/GameControllerTest.kt
+++ b/src/test/java/com/keeper/homepage/domain/game/api/GameControllerTest.kt
@@ -4,6 +4,7 @@ import com.keeper.homepage.domain.game.application.*
 import com.keeper.homepage.domain.game.dto.res.BaseballStatus
 import com.keeper.homepage.domain.game.entity.redis.BaseballResultEntity
 import com.keeper.homepage.domain.game.entity.redis.BaseballResultEntity.GuessResultEntity
+import com.keeper.homepage.domain.game.entity.redis.SECOND_PER_GAME
 import com.keeper.homepage.global.config.security.data.JwtType
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
@@ -193,6 +194,7 @@ class GameControllerTest : GameApiTestHelper() {
                     responseFields(
                         fieldWithPath("results").description("start API에선 빈 배열로 내려갑니다."),
                         fieldWithPath("earnablePoint").description("처음 할당된 획득할 포인트"),
+                        fieldWithPath("remainedSecond").description("이번 라운드 남은 초. 이 API에선 항상 ${SECOND_PER_GAME}으로 반환됩니다."),
                     )
                 )
             )
@@ -261,6 +263,7 @@ class GameControllerTest : GameApiTestHelper() {
                         fieldWithPath("results[].strike").description("strike"),
                         fieldWithPath("results[].ball").description("ball"),
                         fieldWithPath("earnablePoint").description("획득한 포인트 (마지막 게임이 아니면 0)"),
+                        fieldWithPath("remainedSecond").description("이번 라운드 남은 초. 이 API에선 항상 0으로 반환됩니다."),
                     ),
                 )
             )
@@ -367,6 +370,7 @@ class GameControllerTest : GameApiTestHelper() {
                         responseFields(
                             subsectionWithPath("results").description("타임아웃난 round는 null"),
                             fieldWithPath("earnablePoint").description("획득한 포인트 (오늘 끝낸 게임이 아니면 0)"),
+                            fieldWithPath("remainedSecond").description("이번 라운드 남은 초. ms 단위는 버림해서 내려갑니다."),
                         ),
                     )
                 )

--- a/src/test/java/com/keeper/homepage/domain/game/support/BaseballSupportTest.kt
+++ b/src/test/java/com/keeper/homepage/domain/game/support/BaseballSupportTest.kt
@@ -18,42 +18,42 @@ class BaseballSupportTest {
         @Test
         fun `시간안에 플레이 했으면 pass한 게임은 없어야 한다`() {
             val lastGuessTime = LocalDateTime.now().minusSeconds(15)
-            val passedGameCount = BaseballSupport.getPassedGameCount(0, lastGuessTime)
+            val (passedGameCount, _) = BaseballSupport.getPassedGameCount(0, lastGuessTime)
             assertThat(passedGameCount).isEqualTo(0)
         }
 
         @Test
         fun `34초가 지난 후면 1게임은 pass한 게임이어야 한다`() {
             val lastGuessTime = LocalDateTime.now().minusSeconds(34)
-            val passedGameCount = BaseballSupport.getPassedGameCount(0, lastGuessTime)
+            val (passedGameCount, _) = BaseballSupport.getPassedGameCount(0, lastGuessTime)
             assertThat(passedGameCount).isEqualTo(1)
         }
 
         @Test
         fun `90초가 지난 후면 3게임은 pass한 게임이어야 한다`() {
             val lastGuessTime = LocalDateTime.now().minusSeconds(90)
-            val passedGameCount = BaseballSupport.getPassedGameCount(0, lastGuessTime)
+            val (passedGameCount, _) = BaseballSupport.getPassedGameCount(0, lastGuessTime)
             assertThat(passedGameCount).isEqualTo(3)
         }
 
         @Test
         fun `92초가 지난 후면 3게임은 pass한 게임이어야 한다`() {
             val lastGuessTime = LocalDateTime.now().minusSeconds(92)
-            val passedGameCount = BaseballSupport.getPassedGameCount(0, lastGuessTime)
+            val (passedGameCount, _) = BaseballSupport.getPassedGameCount(0, lastGuessTime)
             assertThat(passedGameCount).isEqualTo(3)
         }
 
         @Test
         fun `300초가 지난 후면 9게임은 pass한 게임이어야 한다`() {
             val lastGuessTime = LocalDateTime.now().minusSeconds(300)
-            val passedGameCount = BaseballSupport.getPassedGameCount(0, lastGuessTime)
+            val (passedGameCount, _) = BaseballSupport.getPassedGameCount(0, lastGuessTime)
             assertThat(passedGameCount).isEqualTo(9)
         }
 
         @Test
         fun `1000초가 지났더라도 9게임만 pass한 게임이어야 한다`() {
             val lastGuessTime = LocalDateTime.now().minusSeconds(1000)
-            val passedGameCount = BaseballSupport.getPassedGameCount(0, lastGuessTime)
+            val (passedGameCount, _) = BaseballSupport.getPassedGameCount(0, lastGuessTime)
             assertThat(passedGameCount).isEqualTo(9)
         }
 
@@ -61,7 +61,7 @@ class BaseballSupportTest {
         fun `2게임을 플레이했으면 1000초가 지났더라도 7 게임만 pass 되어야 한다`() {
             val results: MutableList<GuessResultEntity?> = mutableListOf(GuessResultEntity("1234", 1, 2), GuessResultEntity("5678", 3, 1))
             val lastGuessTime = LocalDateTime.now().minusSeconds(1000)
-            val passedGameCount = BaseballSupport.getPassedGameCount(results.size, lastGuessTime)
+            val (passedGameCount, _) = BaseballSupport.getPassedGameCount(results.size, lastGuessTime)
             assertThat(passedGameCount).isEqualTo(7)
         }
     }

--- a/src/test/java/com/keeper/homepage/domain/game/support/BaseballSupportTest.kt
+++ b/src/test/java/com/keeper/homepage/domain/game/support/BaseballSupportTest.kt
@@ -23,38 +23,46 @@ class BaseballSupportTest {
         }
 
         @Test
-        fun `34초가 지난 후면 1게임은 pass한 게임이어야 한다`() {
+        fun `34초가 지난 후면 1게임은 pass한 게임이고 남은 시간은 26초여야 한다`() {
             val lastGuessTime = LocalDateTime.now().minusSeconds(34)
-            val (passedGameCount, _) = BaseballSupport.getPassedGameCount(0, lastGuessTime)
+            val (passedGameCount, remainedSeconds) = BaseballSupport.getPassedGameCount(0, lastGuessTime)
             assertThat(passedGameCount).isEqualTo(1)
+            assertThat(remainedSeconds).isLessThan(26)
+            assertThat(remainedSeconds).isGreaterThan(24) // 테스트 실행시간 2초 여유 줌
         }
 
         @Test
-        fun `90초가 지난 후면 3게임은 pass한 게임이어야 한다`() {
+        fun `90초가 지난 후면 3게임은 pass한 게임이고 남은 시간은 30초여야 한다`() {
             val lastGuessTime = LocalDateTime.now().minusSeconds(90)
-            val (passedGameCount, _) = BaseballSupport.getPassedGameCount(0, lastGuessTime)
+            val (passedGameCount, remainedSeconds) = BaseballSupport.getPassedGameCount(0, lastGuessTime)
             assertThat(passedGameCount).isEqualTo(3)
+            assertThat(remainedSeconds).isLessThan(30)
+            assertThat(remainedSeconds).isGreaterThan(28) // 테스트 실행시간 2초 여유 줌
         }
 
         @Test
-        fun `92초가 지난 후면 3게임은 pass한 게임이어야 한다`() {
+        fun `92초가 지난 후면 3게임은 pass한 게임이고 남은 시간은 28초여야 한다`() {
             val lastGuessTime = LocalDateTime.now().minusSeconds(92)
-            val (passedGameCount, _) = BaseballSupport.getPassedGameCount(0, lastGuessTime)
+            val (passedGameCount, remainedSeconds) = BaseballSupport.getPassedGameCount(0, lastGuessTime)
             assertThat(passedGameCount).isEqualTo(3)
+            assertThat(remainedSeconds).isLessThan(28)
+            assertThat(remainedSeconds).isGreaterThan(26) // 테스트 실행시간 2초 여유 줌
         }
 
         @Test
         fun `300초가 지난 후면 9게임은 pass한 게임이어야 한다`() {
             val lastGuessTime = LocalDateTime.now().minusSeconds(300)
-            val (passedGameCount, _) = BaseballSupport.getPassedGameCount(0, lastGuessTime)
+            val (passedGameCount, remainedSeconds) = BaseballSupport.getPassedGameCount(0, lastGuessTime)
             assertThat(passedGameCount).isEqualTo(9)
+            assertThat(remainedSeconds).isEqualTo(0)
         }
 
         @Test
         fun `1000초가 지났더라도 9게임만 pass한 게임이어야 한다`() {
             val lastGuessTime = LocalDateTime.now().minusSeconds(1000)
-            val (passedGameCount, _) = BaseballSupport.getPassedGameCount(0, lastGuessTime)
+            val (passedGameCount, remainedSeconds) = BaseballSupport.getPassedGameCount(0, lastGuessTime)
             assertThat(passedGameCount).isEqualTo(9)
+            assertThat(remainedSeconds).isEqualTo(0)
         }
 
         @Test


### PR DESCRIPTION
## 🔥 Related Issue

> close: 없음.

## 📝 Description

1. BaseballResponse에 이제 이번 라운드의 남은 seconds가 함께 내려갑니다.
    - results를 호출할 때 이 seconds로 타이머를 갱신해주시면 백엔드와 남은 seconds 동기화를 할 수 있습니다.
2. timeout을 업데이트 하지 않아 계속 status에서 PLAYING이 나오던 버그를 해결했습니다.
3. 이제 /status 를 호출해도 timeout이 갱신됩니다.

## ⭐️ Review Request

벌써 일요일이 끝나가다니...
