### PR TITLE
fix: refreshToken redis 저장 시 Id + userAgent 사용

### DIFF
--- a/src/main/java/com/keeper/homepage/domain/auth/api/SignInController.java
+++ b/src/main/java/com/keeper/homepage/domain/auth/api/SignInController.java
@@ -9,6 +9,7 @@ import com.keeper.homepage.domain.auth.dto.response.CheckAuthCodeResponse;
 import com.keeper.homepage.domain.auth.dto.response.SignInResponse;
 import com.keeper.homepage.domain.member.entity.embedded.EmailAddress;
 import com.keeper.homepage.domain.member.entity.embedded.LoginId;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Email;
@@ -30,12 +31,13 @@ public class SignInController {
 
   @PostMapping
   public ResponseEntity<SignInResponse> signIn(@RequestBody @Valid SignInRequest request,
-      HttpServletResponse response) {
+      HttpServletRequest httpRequest, HttpServletResponse httpResponse) {
     return ResponseEntity.ok(
         signInService.signIn(
             LoginId.from(request.getLoginId()),
             request.getRawPassword(),
-            response));
+            httpRequest,
+            httpResponse));
   }
 
   @PostMapping("/find-login-id")

--- a/src/main/java/com/keeper/homepage/domain/auth/application/AuthCookieService.java
+++ b/src/main/java/com/keeper/homepage/domain/auth/application/AuthCookieService.java
@@ -18,14 +18,14 @@ public class AuthCookieService {
   private final JwtTokenProvider jwtTokenProvider;
   private final RedisUtil redisUtil;
 
-  public void setNewCookieInResponse(String authId, String[] roles, HttpServletResponse response) {
+  public void setNewCookieInResponse(String authId, String[] roles, String userAgent, HttpServletResponse response) {
     String newRefreshToken = jwtTokenProvider.createAccessToken(REFRESH_TOKEN, authId, roles);
     setTokenInCookie(response, newRefreshToken, (int) REFRESH_TOKEN.getExpiredMillis() / 1000,
         REFRESH_TOKEN.getTokenName());
     String newAccessToken = jwtTokenProvider.createAccessToken(ACCESS_TOKEN, authId, roles);
     setTokenInCookie(response, newAccessToken, (int) REFRESH_TOKEN.getExpiredMillis() / 1000,
         ACCESS_TOKEN.getTokenName());
-    redisUtil.setDataExpire(authId, newRefreshToken, REFRESH_TOKEN.getExpiredMillis());
+    redisUtil.setDataExpire(JwtTokenProvider.getRefreshTokenKeyForRedis(authId, userAgent), newRefreshToken, REFRESH_TOKEN.getExpiredMillis());
   }
 
   private void setTokenInCookie(HttpServletResponse httpResponse, String token, int expiredSeconds, String cookieName) {

--- a/src/main/java/com/keeper/homepage/domain/auth/application/SignInService.java
+++ b/src/main/java/com/keeper/homepage/domain/auth/application/SignInService.java
@@ -12,12 +12,14 @@ import com.keeper.homepage.global.error.BusinessException;
 import com.keeper.homepage.global.error.ErrorCode;
 import com.keeper.homepage.global.util.mail.MailUtil;
 import com.keeper.homepage.global.util.redis.RedisUtil;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.Random;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -36,7 +38,8 @@ public class SignInService {
   private final MailUtil mailUtil;
 
   @Transactional
-  public SignInResponse signIn(LoginId loginId, String rawPassword, HttpServletResponse response) {
+  public SignInResponse signIn(LoginId loginId, String rawPassword, HttpServletRequest request,
+      HttpServletResponse response) {
     Member member = memberRepository.findByProfileLoginId(loginId)
         .orElseThrow(
             () -> new BusinessException(loginId.get(), "loginId", ErrorCode.MEMBER_NOT_FOUND));
@@ -44,7 +47,7 @@ public class SignInService {
       throw new BusinessException(loginId.get(), "loginId", ErrorCode.MEMBER_WRONG_ID_OR_PASSWORD);
     }
     authCookieService.setNewCookieInResponse(String.valueOf(member.getId()),
-        getRoles(member), response);
+        getRoles(member), request.getHeader(HttpHeaders.USER_AGENT), response);
     return SignInResponse.of(member, Arrays.stream(getRoles(member)).toList());
   }
 

--- a/src/main/java/com/keeper/homepage/global/config/security/JwtTokenProvider.java
+++ b/src/main/java/com/keeper/homepage/global/config/security/JwtTokenProvider.java
@@ -25,6 +25,7 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import java.security.Key;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
@@ -41,6 +42,11 @@ public class JwtTokenProvider {
   private static final String SEPARATOR = ",";
 
   final Key secretKey;
+
+  public static String getRefreshTokenKeyForRedis(String authId, String userAgent) {
+    String encodedUserAgent = Base64.getEncoder().encodeToString((userAgent == null ? "" : userAgent).getBytes());
+    return "refreshToken:" + authId + ":" + encodedUserAgent;
+  }
 
   public JwtTokenProvider(@Value("${spring.jwt.secret}") String secretKey) {
     this.secretKey = Keys.hmacShaKeyFor(secretKey.getBytes());

--- a/src/main/java/com/keeper/homepage/global/config/security/filter/RefreshTokenFilter.java
+++ b/src/main/java/com/keeper/homepage/global/config/security/filter/RefreshTokenFilter.java
@@ -3,6 +3,7 @@ package com.keeper.homepage.global.config.security.filter;
 import static com.keeper.homepage.global.config.security.data.JwtType.ACCESS_TOKEN;
 import static com.keeper.homepage.global.config.security.data.JwtType.REFRESH_TOKEN;
 import static com.keeper.homepage.global.config.security.data.JwtValidationType.EXPIRED;
+import static org.springframework.http.HttpHeaders.USER_AGENT;
 
 import com.keeper.homepage.domain.auth.application.AuthCookieService;
 import com.keeper.homepage.global.config.security.JwtTokenProvider;
@@ -41,7 +42,7 @@ public class RefreshTokenFilter extends GenericFilterBean {
     final var refreshTokenDto = jwtTokenProvider.tryCheckTokenValid(httpRequest, REFRESH_TOKEN);
     boolean isAccessExpiredAndRefreshValid = isAccessTokenExpired(accessTokenDto.getResultType()) &&
         isRefreshTokenValid(refreshTokenDto) &&
-        isTokenInRedis(refreshTokenDto);
+        isTokenInRedis(refreshTokenDto, httpRequest.getHeader(USER_AGENT));
 
     if (isAccessExpiredAndRefreshValid) {
       Authentication auth = jwtTokenProvider.getAuthentication(refreshTokenDto.getToken());
@@ -51,15 +52,16 @@ public class RefreshTokenFilter extends GenericFilterBean {
       String[] roles = jwtTokenProvider.getRoles(refreshTokenDto.getToken());
       HttpServletResponse httpResponse = (HttpServletResponse) response;
 
-      authCookieService.setNewCookieInResponse(authId, roles, httpResponse);
+      authCookieService.setNewCookieInResponse(authId, roles, httpRequest.getHeader(USER_AGENT), httpResponse);
     }
 
     filterChain.doFilter(request, response);
   }
 
-  private boolean isTokenInRedis(TokenValidationResultDto refreshTokenDto) {
+  private boolean isTokenInRedis(TokenValidationResultDto refreshTokenDto, String userAgent) {
     long authId = jwtTokenProvider.getAuthId(refreshTokenDto.getToken());
-    Optional<String> tokenInRedis = redisUtil.getData(String.valueOf(authId), String.class);
+    String refreshTokenKey = JwtTokenProvider.getRefreshTokenKeyForRedis(String.valueOf(authId), userAgent);
+    Optional<String> tokenInRedis = redisUtil.getData(refreshTokenKey, String.class);
     return tokenInRedis.isPresent() && tokenInRedis.get().equals(refreshTokenDto.getToken());
   }
 

--- a/src/test/java/com/keeper/homepage/domain/auth/api/SignInControllerTest.java
+++ b/src/test/java/com/keeper/homepage/domain/auth/api/SignInControllerTest.java
@@ -36,6 +36,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.util.LinkedMultiValueMap;
 
@@ -65,7 +66,9 @@ class SignInControllerTest extends IntegrationTest {
     @Test
     @DisplayName("유효한 요청이면 로그인에 성공해야 한다.")
     void should_successSignIn_when_validRequest() throws Exception {
+      String userAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/115.0.0.0 Safari/537.36";
       mockMvc.perform(post("/sign-in")
+              .header(HttpHeaders.USER_AGENT, userAgent)
               .contentType(MediaType.APPLICATION_JSON)
               .content(asJsonString(validRequest)))
           .andExpect(status().isOk())

--- a/src/test/java/com/keeper/homepage/domain/auth/api/test/AuthTestControllerTest.java
+++ b/src/test/java/com/keeper/homepage/domain/auth/api/test/AuthTestControllerTest.java
@@ -12,6 +12,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.keeper.homepage.IntegrationTest;
+import com.keeper.homepage.global.config.security.JwtTokenProvider;
 import io.jsonwebtoken.ExpiredJwtException;
 import jakarta.servlet.http.Cookie;
 import java.util.Objects;
@@ -174,7 +175,7 @@ class AuthTestControllerTest extends IntegrationTest {
 
       @BeforeEach
       void setupRefreshToken() {
-        redisUtil.setDataExpire(String.valueOf(0), refreshToken, REFRESH_TOKEN.getExpiredMillis());
+        redisUtil.setDataExpire(JwtTokenProvider.getRefreshTokenKeyForRedis("0", null), refreshToken, REFRESH_TOKEN.getExpiredMillis());
       }
 
       @Test
@@ -199,7 +200,7 @@ class AuthTestControllerTest extends IntegrationTest {
 
         jwtTokenProvider.getAuthId(newAccessToken);
         assertThat(newRefreshToken).isNotEqualTo(refreshCookie.getValue());
-        assertThat(redisUtil.getData("0", String.class)).isNotEmpty();
+        assertThat(redisUtil.getData(JwtTokenProvider.getRefreshTokenKeyForRedis("0", null), String.class)).isNotEmpty();
       }
 
       @Test


### PR DESCRIPTION
## 🔥 Related Issue

 close: 없음

## 📝 Description

<img width="997" alt="image" src="https://github.com/KEEPER31337/Homepage-Back-R2/assets/26597702/e0a8939d-9d4b-4c34-a4ff-11277d55f63b">

사용자가 다른 디바이스에서 로그인하면 기존 refreshToken이 무효화되는 문제를 해결하고자 userAgent를 사용하도록 하였습니다.

이제 refreshToken을 redis에 저장할 때 Id + userAgent를 key로 사용합니다.

[User Agent란?](https://developer.mozilla.org/ko/docs/Glossary/User_agent)

## ⭐️ Review Request

직장인도 방학... ㅠㅠ
