### PR TITLE
Feature/스터디 변경 요구사항

### DIFF
--- a/src/docs/asciidoc/study/study.adoc
+++ b/src/docs/asciidoc/study/study.adoc
@@ -15,7 +15,7 @@ link:../keeper.html[API 목록으로 돌아가기]
 
 == *스터디 생성*
 
-NOTE: 호출 시 스터디원으로 추가됩니다.
+NOTE: 호출한 회원은 스터디원으로 등록됩니다.
 
 === 요청
 
@@ -145,6 +145,8 @@ include::{snippets}/update-study-thumbnail/http-response.adoc[]
 
 == *스터디 수정*
 
+NOTE: 호출한 회원은 스터디원으로 등록됩니다.
+
 === 요청
 
 ==== Request
@@ -174,76 +176,3 @@ include::{snippets}/update-study/http-response.adoc[]
 ==== Response Headers
 
 include::{snippets}/update-study/response-headers.adoc[]
-
-== *스터디원 추가*
-
-=== 요청
-
-==== Request
-
-include::{snippets}/join-study/http-request.adoc[]
-
-==== Request Cookies
-
-include::{snippets}/join-study/request-cookies.adoc[]
-
-==== Path Parameters
-
-include::{snippets}/join-study/path-parameters.adoc[]
-
-=== 응답
-
-==== Response
-
-include::{snippets}/join-study/http-response.adoc[]
-
-== *스터디원 다중 추가*
-
-=== 요청
-
-==== Request
-
-include::{snippets}/members-join-study/http-request.adoc[]
-
-==== Request Cookies
-
-include::{snippets}/members-join-study/request-cookies.adoc[]
-
-==== Path Parameters
-
-include::{snippets}/members-join-study/path-parameters.adoc[]
-
-==== Request Fields
-
-include::{snippets}/members-join-study/request-fields.adoc[]
-
-=== 응답
-
-==== Response
-
-include::{snippets}/members-join-study/http-response.adoc[]
-
-
-== *스터디원 삭제*
-
-NOTE: 스터디장은 삭제할 수 없습니다.
-
-=== 요청
-
-==== Request
-
-include::{snippets}/leave-study/http-request.adoc[]
-
-==== Request Cookies
-
-include::{snippets}/leave-study/request-cookies.adoc[]
-
-==== Path Parameters
-
-include::{snippets}/leave-study/path-parameters.adoc[]
-
-=== 응답
-
-==== Response
-
-include::{snippets}/leave-study/http-response.adoc[]

--- a/src/main/java/com/keeper/homepage/domain/member/entity/Member.java
+++ b/src/main/java/com/keeper/homepage/domain/member/entity/Member.java
@@ -140,7 +140,7 @@ public class Member {
   @OneToMany(mappedBy = "member", cascade = ALL, orphanRemoval = true)
   private final Set<MemberHasCommentDislike> commentDislikes = new HashSet<>();
 
-  @OneToMany(mappedBy = "member", cascade = PERSIST)
+  @OneToMany(mappedBy = "member", cascade = ALL)
   private final Set<StudyHasMember> studyMembers = new HashSet<>();
 
   @OneToMany(mappedBy = "member")

--- a/src/main/java/com/keeper/homepage/domain/member/entity/Member.java
+++ b/src/main/java/com/keeper/homepage/domain/member/entity/Member.java
@@ -10,7 +10,6 @@ import static com.keeper.homepage.domain.member.entity.type.MemberType.MemberTyp
 import static jakarta.persistence.CascadeType.ALL;
 import static jakarta.persistence.CascadeType.PERSIST;
 import static jakarta.persistence.CascadeType.REMOVE;
-import static java.util.stream.Collectors.*;
 
 import com.keeper.homepage.domain.attendance.entity.Attendance;
 import com.keeper.homepage.domain.comment.entity.Comment;
@@ -59,7 +58,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -142,7 +140,7 @@ public class Member {
   @OneToMany(mappedBy = "member", cascade = ALL, orphanRemoval = true)
   private final Set<MemberHasCommentDislike> commentDislikes = new HashSet<>();
 
-  @OneToMany(mappedBy = "member", cascade = ALL, orphanRemoval = true)
+  @OneToMany(mappedBy = "member", cascade = PERSIST)
   private final Set<StudyHasMember> studyMembers = new HashSet<>();
 
   @OneToMany(mappedBy = "member")
@@ -289,10 +287,6 @@ public class Member {
         .member(this)
         .build();
     studyMembers.add(studyMember);
-  }
-
-  public void leave(Study study) {
-    studyMembers.removeIf(studyMember -> studyMember.getStudy().equals(study));
   }
 
   public void join(CtfTeam ctfTeam) {

--- a/src/main/java/com/keeper/homepage/domain/study/api/StudyController.java
+++ b/src/main/java/com/keeper/homepage/domain/study/api/StudyController.java
@@ -41,7 +41,7 @@ public class StudyController {
       @RequestPart @Valid StudyCreateRequest request,
       @RequestPart(required = false) MultipartFile thumbnail
   ) {
-    studyService.create(request.toEntity(member), thumbnail);
+    studyService.create(member, request.toEntity(member), request.getMemberIds(), thumbnail);
     return ResponseEntity.status(HttpStatus.CREATED)
         .build();
   }

--- a/src/main/java/com/keeper/homepage/domain/study/api/StudyController.java
+++ b/src/main/java/com/keeper/homepage/domain/study/api/StudyController.java
@@ -3,7 +3,6 @@ package com.keeper.homepage.domain.study.api;
 import com.keeper.homepage.domain.member.entity.Member;
 import com.keeper.homepage.domain.study.application.StudyService;
 import com.keeper.homepage.domain.study.dto.request.StudyCreateRequest;
-import com.keeper.homepage.domain.study.dto.request.StudyJoinRequest;
 import com.keeper.homepage.domain.study.dto.request.StudyUpdateRequest;
 import com.keeper.homepage.domain.study.dto.response.StudyDetailResponse;
 import com.keeper.homepage.domain.study.dto.response.StudyListResponse;
@@ -80,7 +79,7 @@ public class StudyController {
       @PathVariable long studyId,
       @RequestBody @Valid StudyUpdateRequest request
   ) {
-    studyService.update(member, studyId, request.toEntity());
+    studyService.update(member, studyId, request.toEntity(), request.getMemberIds());
     return ResponseEntity.status(HttpStatus.CREATED)
         .location(URI.create("/studies/" + studyId))
         .build();
@@ -93,33 +92,6 @@ public class StudyController {
       @ModelAttribute MultipartFile thumbnail
   ) {
     studyService.updateStudyThumbnail(member, studyId, thumbnail);
-    return ResponseEntity.noContent().build();
-  }
-
-  @PostMapping("/{studyId}/members/{memberId}")
-  public ResponseEntity<Void> joinStudy(
-      @PathVariable long studyId,
-      @PathVariable long memberId
-  ) {
-    studyService.joinStudy(studyId, memberId);
-    return ResponseEntity.status(HttpStatus.CREATED).build();
-  }
-
-  @PostMapping("/{studyId}/members")
-  public ResponseEntity<Void> joinStudy(
-      @PathVariable long studyId,
-      @RequestBody @Valid StudyJoinRequest request
-  ) {
-    studyService.joinStudy(studyId, request.getMemberIds());
-    return ResponseEntity.status(HttpStatus.CREATED).build();
-  }
-
-  @DeleteMapping("/{studyId}/members/{memberId}")
-  public ResponseEntity<Void> leaveStudy(
-      @PathVariable long studyId,
-      @PathVariable long memberId
-  ) {
-    studyService.leaveStudy(studyId, memberId);
     return ResponseEntity.noContent().build();
   }
 }

--- a/src/main/java/com/keeper/homepage/domain/study/application/StudyService.java
+++ b/src/main/java/com/keeper/homepage/domain/study/application/StudyService.java
@@ -34,11 +34,16 @@ public class StudyService {
   private final MemberFindService memberFindService;
 
   @Transactional
-  public void create(Study study, MultipartFile thumbnail) {
+  public void create(Member headMember, Study study, List<Long> memberIds, MultipartFile thumbnail) {
     checkLink(study);
     saveStudyThumbnail(study, thumbnail);
-    long studyId = studyRepository.save(study).getId();
-    joinStudy(studyId, study.getHeadMember().getId());
+
+    Study savedStudy = studyRepository.save(study);
+
+    headMember.join(savedStudy);
+    memberIds.stream()
+        .map(memberFindService::findById)
+        .forEach(member -> member.join(savedStudy));
   }
 
   private void checkLink(Study study) {

--- a/src/main/java/com/keeper/homepage/domain/study/dao/StudyHasMemberRepository.java
+++ b/src/main/java/com/keeper/homepage/domain/study/dao/StudyHasMemberRepository.java
@@ -6,11 +6,16 @@ import com.keeper.homepage.domain.study.entity.StudyHasMember;
 import com.keeper.homepage.domain.study.entity.StudyHasMemberPK;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface StudyHasMemberRepository extends JpaRepository<StudyHasMember, StudyHasMemberPK> {
 
   Optional<StudyHasMember> findByStudyAndMember(Study study, Member member);
 
-  void deleteAllByStudy(Study study);
+  @Modifying
+  @Query("delete from StudyHasMember s where s.study=:study")
+  void deleteAllByStudy(@Param("study") Study study);
 
 }

--- a/src/main/java/com/keeper/homepage/domain/study/dto/request/StudyCreateRequest.java
+++ b/src/main/java/com/keeper/homepage/domain/study/dto/request/StudyCreateRequest.java
@@ -13,6 +13,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -55,6 +56,8 @@ public class StudyCreateRequest {
   @Nullable
   private String etcLink;
 
+  @NotNull(message = "회원의 ID 리스트를 입력해주세요.")
+  private List<@NotNull Long> memberIds;
 
   public Study toEntity(Member member) {
     return Study.builder()

--- a/src/main/java/com/keeper/homepage/domain/study/dto/request/StudyUpdateRequest.java
+++ b/src/main/java/com/keeper/homepage/domain/study/dto/request/StudyUpdateRequest.java
@@ -14,6 +14,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -52,6 +53,9 @@ public class StudyUpdateRequest {
 
   @Nullable
   private String etcLink;
+
+  @NotNull(message = "회원의 ID 리스트를 입력해주세요.")
+  private List<@NotNull Long> memberIds;
 
   public Study toEntity() {
     return Study.builder()

--- a/src/main/java/com/keeper/homepage/domain/study/entity/Study.java
+++ b/src/main/java/com/keeper/homepage/domain/study/entity/Study.java
@@ -7,7 +7,6 @@ import com.keeper.homepage.domain.thumbnail.entity.Thumbnail;
 import com.keeper.homepage.global.entity.BaseEntity;
 import jakarta.persistence.AttributeOverride;
 import jakarta.persistence.AttributeOverrides;
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -75,7 +74,7 @@ public class Study extends BaseEntity {
   @JoinColumn(name = "head_member_id", nullable = false)
   private Member headMember;
 
-  @OneToMany(mappedBy = "study", cascade = CascadeType.REMOVE)
+  @OneToMany(mappedBy = "study")
   private final Set<StudyHasMember> studyMembers = new HashSet<>();
 
   @Builder

--- a/src/test/java/com/keeper/homepage/domain/study/api/StudyControllerTest.java
+++ b/src/test/java/com/keeper/homepage/domain/study/api/StudyControllerTest.java
@@ -39,8 +39,6 @@ import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.mock.web.MockPart;
 import org.springframework.restdocs.snippet.Attributes.Attribute;
-import org.springframework.util.LinkedMultiValueMap;
-import org.springframework.util.MultiValueMap;
 
 public class StudyControllerTest extends StudyApiTestHelper {
 
@@ -48,7 +46,6 @@ public class StudyControllerTest extends StudyApiTestHelper {
   private Member member, other;
   private String memberToken, otherToken;
   private long studyId;
-  private final MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
 
   @BeforeEach
   void setUp() throws IOException {
@@ -77,6 +74,7 @@ public class StudyControllerTest extends StudyApiTestHelper {
           .gitLink("https://github.com/KEEPER31337/Homepage-Back-R2")
           .notionLink("https://www.notion.so/Java-Spring")
           .etcLink("etc.com")
+          .memberIds(List.of(other.getId()))
           .build();
 
       MockPart mockPart = new MockPart("request", asJsonString(request).getBytes(StandardCharsets.UTF_8));
@@ -105,7 +103,9 @@ public class StudyControllerTest extends StudyApiTestHelper {
                   fieldWithPath("etcTitle")
                       .description("스터디 기타 자료 제목을 입력해주세요.").optional(),
                   fieldWithPath("etcLink")
-                      .description("스터디 기타 링크를 입력해주세요.").optional()
+                      .description("스터디 기타 링크를 입력해주세요.").optional(),
+                  fieldWithPath("memberIds[]")
+                      .description("스터디원 Id 리스트를 입력해주세요.")
               ),
               requestParts(
                   partWithName("request").description("스터디 정보"),
@@ -123,8 +123,44 @@ public class StudyControllerTest extends StudyApiTestHelper {
           .year(2023)
           .season(1)
           .gitLink("https://www.youtube.com/")
-          .notionLink("https://www.notion.so/Java-Spring")
-          .etcLink("etc.com")
+          .memberIds(List.of(other.getId()))
+          .build();
+
+      MockPart mockPart = new MockPart("request", asJsonString(request).getBytes(StandardCharsets.UTF_8));
+      mockPart.getHeaders().setContentType(MediaType.APPLICATION_JSON);
+
+      callCreateStudyApiWithThumbnail(memberToken, thumbnail, mockPart)
+          .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("스터디원 리스트가 비어있어도 스터디 생성은 성공해야 한다.")
+    public void 스터디원_리스트가_비어있어도_스터디_생성은_성공해야_한다() throws Exception {
+      StudyCreateRequest request = StudyCreateRequest.builder()
+          .title("자바 스터디")
+          .information("자바 스터디 입니다")
+          .year(2023)
+          .season(1)
+          .gitLink("https://github.com/KEEPER31337/Homepage-Back-R2")
+          .memberIds(List.of())
+          .build();
+
+      MockPart mockPart = new MockPart("request", asJsonString(request).getBytes(StandardCharsets.UTF_8));
+      mockPart.getHeaders().setContentType(MediaType.APPLICATION_JSON);
+
+      callCreateStudyApiWithThumbnail(memberToken, thumbnail, mockPart)
+          .andExpect(status().isCreated());
+    }
+
+    @Test
+    @DisplayName("스터디원 리스트가 null일 경우 스터디 생성은 실패한다.")
+    public void 스터디원_리스트가_null일_경우_스터디_생성은_실패한다() throws Exception {
+      StudyCreateRequest request = StudyCreateRequest.builder()
+          .title("자바 스터디")
+          .information("자바 스터디 입니다")
+          .year(2023)
+          .season(1)
+          .gitLink("https://www.youtube.com/")
           .build();
 
       MockPart mockPart = new MockPart("request", asJsonString(request).getBytes(StandardCharsets.UTF_8));

--- a/src/test/java/com/keeper/homepage/domain/study/api/StudyControllerTest.java
+++ b/src/test/java/com/keeper/homepage/domain/study/api/StudyControllerTest.java
@@ -20,6 +20,7 @@ import static org.springframework.restdocs.request.RequestDocumentation.partWith
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 import static org.springframework.restdocs.request.RequestDocumentation.requestParts;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.keeper.homepage.domain.member.entity.Member;
@@ -157,7 +158,7 @@ public class StudyControllerTest extends StudyApiTestHelper {
           .information("자바 스터디 입니다")
           .year(2023)
           .season(1)
-          .gitLink("https://www.youtube.com/")
+          .gitLink("https://github.com/KEEPER31337/Homepage-Back-R2")
           .build();
 
       MockPart mockPart = new MockPart("request", asJsonString(request).getBytes(StandardCharsets.UTF_8));

--- a/src/test/java/com/keeper/homepage/domain/study/application/StudyServiceTest.java
+++ b/src/test/java/com/keeper/homepage/domain/study/application/StudyServiceTest.java
@@ -41,7 +41,7 @@ public class StudyServiceTest extends IntegrationTest {
           .link(Link.builder().build())
           .build();
       assertThrows(BusinessException.class, () -> {
-        studyService.create(study, null);
+        studyService.create(member, study, List.of(), null);
       });
     }
   }

--- a/src/test/java/com/keeper/homepage/domain/study/dao/StudyHasMemberRepositoryTest.java
+++ b/src/test/java/com/keeper/homepage/domain/study/dao/StudyHasMemberRepositoryTest.java
@@ -1,13 +1,11 @@
 package com.keeper.homepage.domain.study.dao;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.keeper.homepage.IntegrationTest;
 import com.keeper.homepage.domain.member.entity.Member;
 import com.keeper.homepage.domain.study.entity.Study;
 import com.keeper.homepage.domain.study.entity.StudyHasMemberPK;
-import java.util.NoSuchElementException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -27,6 +25,7 @@ public class StudyHasMemberRepositoryTest extends IntegrationTest {
   @Nested
   @DisplayName("DB studyHasMember(스터디-스터디원) 관리 테스트")
   class StudyHasMemberTest {
+
     @Test
     @DisplayName("DB에 스터디와 스터디원이 성공적으로 추가되어야 한다.")
     public void should_member_successfullyJoin_study() {
@@ -38,83 +37,5 @@ public class StudyHasMemberRepositoryTest extends IntegrationTest {
       StudyHasMemberPK key = new StudyHasMemberPK(study.getId(), member.getId());
       assertThat(studyHasMemberRepository.existsById(key)).isTrue();
     }
-
-
-    @Test
-    @DisplayName("DB에 스터디와 스터디원이 성공적으로 삭제되어야 한다.")
-    public void should_member_successfullyLeave_study() {
-      member.join(study);
-      assertThat(studyHasMemberRepository.findAll()).hasSize(1);
-
-      member.leave(study);
-
-      em.flush();
-      em.clear();
-
-      StudyHasMemberPK key = new StudyHasMemberPK(study.getId(), member.getId());
-      assertThat(studyHasMemberRepository.existsById(key)).isFalse();
-    }
-
-    @Test
-    @DisplayName("스터디를 삭제하면 스터디원에 대한 정보도 삭제되어야 한다.")
-    public void should_successfullyDelete_studyMember_when_studyIsDeleted() {
-      Member memberA = memberTestHelper.generate();
-      Member memberB = memberTestHelper.generate();
-
-      memberA.join(study);
-      memberB.join(study);
-
-      em.flush();
-      em.clear();
-
-      StudyHasMemberPK keyA = new StudyHasMemberPK(study.getId(), memberA.getId());
-      StudyHasMemberPK keyB = new StudyHasMemberPK(study.getId(), memberB.getId());
-      assertThat(studyHasMemberRepository.existsById(keyA)).isTrue();
-      assertThat(studyHasMemberRepository.findById(keyB)).isNotEmpty();
-
-      study = studyRepository.findById(study.getId()).orElseThrow();
-      studyRepository.delete(study);
-
-      em.flush();
-      em.clear();
-
-      assertThat(studyHasMemberRepository.existsById(keyA)).isFalse();
-      assertThat(studyHasMemberRepository.findById(keyB)).isEmpty();
-      assertThatThrownBy(() -> studyHasMemberRepository.findById(keyA).orElseThrow())
-          .isInstanceOf(NoSuchElementException.class);
-      assertThatThrownBy(() -> studyHasMemberRepository.findById(keyB).orElseThrow())
-          .isInstanceOf(NoSuchElementException.class);
-    }
-
-    @Test
-    @DisplayName("회원이 탈퇴하면 그 회원이 포함된 스터디들에 대한 정보도 삭제되어야 한다.")
-    public void should_successfullyDelete_studyMember_when_memberIsDeleted() {
-      Study studyA = studyTestHelper.generate();
-      Study studyB = studyTestHelper.generate();
-
-      member.join(studyA);
-      member.join(studyB);
-
-      em.flush();
-      em.clear();
-
-      StudyHasMemberPK keyA = new StudyHasMemberPK(studyA.getId(), member.getId());
-      StudyHasMemberPK keyB = new StudyHasMemberPK(studyB.getId(), member.getId());
-      assertThat(studyHasMemberRepository.existsById(keyA)).isTrue();
-      assertThat(studyHasMemberRepository.findById(keyB)).isNotEmpty();
-
-      memberRepository.delete(member);
-
-      em.flush();
-      em.clear();
-
-      assertThat(studyHasMemberRepository.existsById(keyA)).isFalse();
-      assertThat(studyHasMemberRepository.findById(keyB)).isEmpty();
-      assertThatThrownBy(() -> studyHasMemberRepository.findById(keyA).orElseThrow())
-          .isInstanceOf(NoSuchElementException.class);
-      assertThatThrownBy(() -> studyHasMemberRepository.findById(keyB).orElseThrow())
-          .isInstanceOf(NoSuchElementException.class);
-    }
   }
-
 }


### PR DESCRIPTION
## 🔥 Related Issue

> issue: #323

## 📝 Description

프론트 개발자님이 스터디원 추가, 삭제 api를 따로 따로 적용하기가 처리할 부분이 많다고 하여, 스터디 생성과 수정 api에서 스터디원까지 함께 업데이트 하도록 방식을 바꾸었습니다.
- 스터디 수정시 변경되지 않는 회원은 불필요하게 삭제, 추가 과정을 거쳐야 하는 데 크리티컬하지 않을 것 같아서 요청을 수락하였습니다. 괜찮을 지 검토 부탁드립니다!

바꾸는 김에, 이슈 #323 을 고려하여 cascadeType.REMOVE와 orphanRemoval을 부분적으로 제거해보았습니다. 오히려 명시적으로 제거해주는 코드가 있어서 가독성 측면에서도 나쁘지 않은 것 같은데 피드백 부탁드립니다!

## ⭐️ Review Request

로직이 변경되어서 기존의 api와 테스트를 삭제하였는데 뭔가 아깝네요...ㅠㅠ
