### PR TITLE
refactor: String.format에서 formatted로 변경하기 #118

### DIFF
--- a/src/main/java/com/keeper/homepage/global/config/p6spy/PrettySqlFormat.java
+++ b/src/main/java/com/keeper/homepage/global/config/p6spy/PrettySqlFormat.java
@@ -19,7 +19,7 @@ public class PrettySqlFormat implements MessageFormattingStrategy {
     @Override
     public String formatMessage(int connectionId, String now, long elapsed, String category, String prepared, String sql, String url) {
         sql = formatSql(category, sql);
-        return String.format("[%s] | %d ms | %s", category, elapsed, formatSql(category, sql));
+        return "[%s] | %d ms | %s".formatted(category, elapsed, formatSql(category, sql));
     }
 
     private String formatSql(String category, String sql) {

--- a/src/main/java/com/keeper/homepage/global/config/password/PasswordFactory.java
+++ b/src/main/java/com/keeper/homepage/global/config/password/PasswordFactory.java
@@ -52,7 +52,7 @@ public class PasswordFactory {
   private static String encodeWithPBKDF2SHA256(String password, String salt, int iterations)
       throws NoSuchAlgorithmException, InvalidKeySpecException {
     String hash = getEncodedHashWithPBKDF2SHA256(password, salt, iterations);
-    return String.format("%s:%d:%s:%s", "pbkdf2_sha256", iterations, salt, hash);
+    return "%s:%d:%s:%s".formatted("pbkdf2_sha256", iterations, salt, hash);
   }
 
   private static String getEncodedHashWithPBKDF2SHA256(String password, String salt, int iterations)

--- a/src/main/java/com/keeper/homepage/global/error/ExceptionAdvice.java
+++ b/src/main/java/com/keeper/homepage/global/error/ExceptionAdvice.java
@@ -95,6 +95,6 @@ public class ExceptionAdvice {
 
   public static String getErrorMessage(String invalidValue, String errorField,
       String errorMessage) {
-    return String.format("[%s] %s: %s", errorField, invalidValue, errorMessage);
+    return "[%s] %s: %s".formatted(errorField, invalidValue, errorMessage);
   }
 }

--- a/src/test/java/com/keeper/homepage/domain/auth/application/EmailAddressAuthServiceTest.java
+++ b/src/test/java/com/keeper/homepage/domain/auth/application/EmailAddressAuthServiceTest.java
@@ -16,7 +16,7 @@ class EmailAddressAuthServiceTest extends IntegrationTest {
   @DisplayName("알파벳과 숫자로 이루어진 인증 코드가 잘 생성되어야 하고, Redis에 해당 내용이 들어있어야 한다.")
   void should_generateSuccessfullyAndInRedis() {
     doNothing().when(emailAuthService).sendKeeperAuthCodeMail(anyString(), anyString());
-    String validEmail = String.format("%s@%s.%s", getRandomUUIDLengthWith(5),
+    String validEmail = "%s@%s.%s".formatted(getRandomUUIDLengthWith(5),
         getRandomUUIDLengthWith(5), getRandomUUIDLengthWith(3));
     assertThat(emailAuthRedisRepository.findById(validEmail)).isEmpty();
 


### PR DESCRIPTION
## 🔥 Related Issue

> close: #118 

## 📝 Description

> 이현님이 올려주신 이슈 내용대로 String.format을 JDK15에 추가된 formatted으로 변경했습니다.

```java
String a = String.format("keeper: %s", "keeper");
String b = "keeper: %s".formatted("keeper");
```

## ⭐️ Review Request

> 
