### PR TITLE
fix: 게시글 제목 + 내용 검색 시 카테고리 상관없이 검색하던 문제 수정

### DIFF
--- a/src/main/java/com/keeper/homepage/domain/post/dao/PostRepository.java
+++ b/src/main/java/com/keeper/homepage/domain/post/dao/PostRepository.java
@@ -93,8 +93,8 @@ public interface PostRepository extends JpaRepository<Post, Long> {
       + "WHERE p.category = :category "
       + "AND p.isNotice = false "
       + "AND p.isTemp = false "
-      + "AND LOWER(p.title) LIKE LOWER(concat('%', :search, '%')) "
-      + "OR LOWER(p.content) LIKE LOWER(concat('%', :search, '%'))"
+      + "AND (LOWER(p.title) LIKE LOWER(concat('%', :search, '%')) "
+      + "OR LOWER(p.content) LIKE LOWER(concat('%', :search, '%'))) "
       + "ORDER BY p.registerTime DESC")
   Page<Post> findAllRecentByCategoryAndTitleOrContent(@Param("category") Category category,
       @Param("search") String search, Pageable pageable);


### PR DESCRIPTION
## 🔥 Related Issue

> close: 없음.

## 📝 Description

@shkisme SQL에서 `OR`연산은 `AND`연산보다 우선순위가 밀리므로 아래의 기존 쿼리는 `content`에 데이터만 있다면 카테고리를 무시하고 데이터를 가져오는 쿼리였습니다.
```sql
WHERE p.category = :category # false (카테고리가 일치하지 않더라도)
AND p.isNotice = false 
AND p.isTemp = false 
AND LOWER(p.title) LIKE LOWER(concat('%', :search, '%')) 
OR LOWER(p.content) LIKE LOWER(concat('%', :search, '%')) # true (이게 true면 다 가져옴)
```
수정된 쿼리는 아래와 같습니다.
```sql
WHERE p.category = :category
AND p.isNotice = false 
AND p.isTemp = false 
AND (LOWER(p.title) LIKE LOWER(concat('%', :search, '%')) 
OR LOWER(p.content) LIKE LOWER(concat('%', :search, '%'))) # 괄호로 묶음
```
## ⭐️ Review Request

월요일 좋아....
