### PR TITLE
Feature/상벌점 회원 통계 목록 조회 기능 추가

### DIFF
--- a/src/docs/asciidoc/merit/merit.adoc
+++ b/src/docs/asciidoc/merit/merit.adoc
@@ -148,3 +148,25 @@ include::{snippets}/update-meritType/request-fields.adoc[]
 ==== Response
 
 include::{snippets}/update-meritType/http-response.adoc[]
+
+== *회원 통계 상벌점 목록 조회*
+
+=== 요청
+
+==== Request
+
+include::{snippets}/find-total-merit-logs/http-request.adoc[]
+
+==== Request Cookies
+
+include::{snippets}/find-total-merit-logs/request-cookies.adoc[]
+
+=== 응답
+
+==== Response
+
+include::{snippets}/find-total-merit-logs/http-response.adoc[]
+
+==== Response Fields
+
+include::{snippets}/find-total-merit-logs/response-fields.adoc[]

--- a/src/main/java/com/keeper/homepage/domain/merit/api/MeritController.java
+++ b/src/main/java/com/keeper/homepage/domain/merit/api/MeritController.java
@@ -3,9 +3,11 @@ package com.keeper.homepage.domain.merit.api;
 
 import com.keeper.homepage.domain.merit.application.MeritLogService;
 import com.keeper.homepage.domain.merit.application.MeritTypeService;
+import com.keeper.homepage.domain.merit.dao.MeritLogRepository;
 import com.keeper.homepage.domain.merit.dto.request.AddMeritTypeRequest;
 import com.keeper.homepage.domain.merit.dto.request.GiveMeritPointRequest;
 import com.keeper.homepage.domain.merit.dto.request.UpdateMeritTypeRequest;
+import com.keeper.homepage.domain.merit.dto.response.MeritLogsGroupByMemberResponse;
 import com.keeper.homepage.domain.merit.dto.response.MeritTypeResponse;
 import com.keeper.homepage.domain.merit.dto.response.SearchMemberMeritLogResponse;
 import com.keeper.homepage.domain.merit.dto.response.SearchMeritLogListResponse;
@@ -36,6 +38,7 @@ public class MeritController {
 
   private final MeritTypeService meritTypeService;
   private final MeritLogService meritLogService;
+  private final MeritLogRepository meritLogRepository;
 
   @GetMapping
   public ResponseEntity<Page<SearchMeritLogListResponse>> searchMeritLogList(
@@ -96,6 +99,14 @@ public class MeritController {
     return ResponseEntity.status(HttpStatus.CREATED)
         .location(URI.create("/merits/types/" + meritTypeId))
         .build();
+  }
+
+  @GetMapping("/members")
+  public ResponseEntity<Page<MeritLogsGroupByMemberResponse>> getAllTotalMeritLogs(
+      @RequestParam(defaultValue = "0") @PositiveOrZero int page,
+      @RequestParam(defaultValue = "10") @PositiveOrZero @Max(30) int size
+  ) {
+    return ResponseEntity.ok(meritLogRepository.findAllTotalMeritLogs(PageRequest.of(page, size)));
   }
 
 }

--- a/src/main/java/com/keeper/homepage/domain/merit/application/MeritLogService.java
+++ b/src/main/java/com/keeper/homepage/domain/merit/application/MeritLogService.java
@@ -10,6 +10,7 @@ import com.keeper.homepage.domain.merit.dao.MeritTypeRepository;
 import com.keeper.homepage.domain.merit.entity.MeritLog;
 import com.keeper.homepage.domain.merit.entity.MeritType;
 import com.keeper.homepage.global.error.BusinessException;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -77,7 +78,8 @@ public class MeritLogService {
     return meritLogRepository.findAllByMemberId(pageable, findMemberId);
   }
 
-  public Page<MeritLog> findMeritLogBySemester(Pageable pageable, LocalDateTime time) {
-    return meritLogRepository.findAllByTimeAfter(pageable, time);
+  public Page<MeritLog> findMeritLogByTime(Pageable pageable, LocalDateTime startTime) {
+    LocalDateTime endTime = startTime.plusMonths(6);
+    return meritLogRepository.findAllByTimeBetween(pageable, startTime, endTime);
   }
 }

--- a/src/main/java/com/keeper/homepage/domain/merit/application/MeritLogService.java
+++ b/src/main/java/com/keeper/homepage/domain/merit/application/MeritLogService.java
@@ -10,6 +10,7 @@ import com.keeper.homepage.domain.merit.dao.MeritTypeRepository;
 import com.keeper.homepage.domain.merit.entity.MeritLog;
 import com.keeper.homepage.domain.merit.entity.MeritType;
 import com.keeper.homepage.global.error.BusinessException;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -74,5 +75,9 @@ public class MeritLogService {
   public Page<MeritLog> findAllByMemberId(Pageable pageable, long memberId) {
     long findMemberId = memberFindService.findById(memberId).getId();
     return meritLogRepository.findAllByMemberId(pageable, findMemberId);
+  }
+
+  public Page<MeritLog> findMeritLogBySemester(Pageable pageable, LocalDateTime time) {
+    return meritLogRepository.findAllByTimeAfter(pageable, time);
   }
 }

--- a/src/main/java/com/keeper/homepage/domain/merit/application/MeritLogService.java
+++ b/src/main/java/com/keeper/homepage/domain/merit/application/MeritLogService.java
@@ -78,6 +78,4 @@ public class MeritLogService {
     return meritLogRepository.findAllByMemberId(pageable, findMemberId);
   }
 
-
-
 }

--- a/src/main/java/com/keeper/homepage/domain/merit/application/MeritLogService.java
+++ b/src/main/java/com/keeper/homepage/domain/merit/application/MeritLogService.java
@@ -78,8 +78,6 @@ public class MeritLogService {
     return meritLogRepository.findAllByMemberId(pageable, findMemberId);
   }
 
-  public Page<MeritLog> findMeritLogByTime(Pageable pageable, LocalDateTime startTime) {
-    LocalDateTime endTime = startTime.plusMonths(6);
-    return meritLogRepository.findAllByTimeBetween(pageable, startTime, endTime);
-  }
+
+
 }

--- a/src/main/java/com/keeper/homepage/domain/merit/dao/MeritLogRepository.java
+++ b/src/main/java/com/keeper/homepage/domain/merit/dao/MeritLogRepository.java
@@ -1,6 +1,7 @@
 package com.keeper.homepage.domain.merit.dao;
 
 import com.keeper.homepage.domain.merit.entity.MeritLog;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
@@ -15,5 +16,5 @@ public interface MeritLogRepository extends JpaRepository<MeritLog, Long> {
 
   long countByMemberId(long memberId);
 
-  Page<MeritLog> findAllByTimeAfter(Pageable pageable, LocalDateTime time);
+  Page<MeritLog> findAllByTimeBetween(Pageable pageable, LocalDateTime startTime, LocalDateTime endTime);
 }

--- a/src/main/java/com/keeper/homepage/domain/merit/dao/MeritLogRepository.java
+++ b/src/main/java/com/keeper/homepage/domain/merit/dao/MeritLogRepository.java
@@ -1,6 +1,7 @@
 package com.keeper.homepage.domain.merit.dao;
 
 import com.keeper.homepage.domain.merit.entity.MeritLog;
+import java.time.LocalDateTime;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -13,4 +14,6 @@ public interface MeritLogRepository extends JpaRepository<MeritLog, Long> {
   Optional<MeritLog> findByMemberId(long memberId);
 
   long countByMemberId(long memberId);
+
+  Page<MeritLog> findAllByTimeAfter(Pageable pageable, LocalDateTime time);
 }

--- a/src/main/java/com/keeper/homepage/domain/merit/dao/MeritLogRepository.java
+++ b/src/main/java/com/keeper/homepage/domain/merit/dao/MeritLogRepository.java
@@ -21,8 +21,8 @@ public interface MeritLogRepository extends JpaRepository<MeritLog, Long> {
   Page<MeritLog> findAllByTimeBetween(Pageable pageable, LocalDateTime startTime, LocalDateTime endTime);
 
   @Query("SELECT NEW com.keeper.homepage.domain.merit.dto.response.MeritLogsGroupByMemberResponse(m.memberId, m.memberRealName, m.memberGeneration, " +
-      "CASE WHEN m.meritType.merit > 0 THEN SUM(m.meritType.merit) ELSE 0 END, " +
-      "CASE WHEN m.meritType.merit < 0 THEN SUM(m.meritType.merit) ELSE 0 END) " +
+      "CAST(SUM(CASE WHEN m.meritType.merit > 0 THEN m.meritType.merit ELSE 0 END) AS INTEGER), " +
+      "CAST(SUM(CASE WHEN m.meritType.merit < 0 THEN m.meritType.merit ELSE 0 END) AS INTEGER)) " +
       "FROM MeritLog m GROUP BY m.memberId, m.memberRealName, m.memberGeneration")
   Page<MeritLogsGroupByMemberResponse> findAllTotalMeritLogs(Pageable pageable);
 }

--- a/src/main/java/com/keeper/homepage/domain/merit/dao/MeritLogRepository.java
+++ b/src/main/java/com/keeper/homepage/domain/merit/dao/MeritLogRepository.java
@@ -1,5 +1,6 @@
 package com.keeper.homepage.domain.merit.dao;
 
+import com.keeper.homepage.domain.merit.dto.response.MeritLogsGroupByMemberResponse;
 import com.keeper.homepage.domain.merit.entity.MeritLog;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -7,6 +8,7 @@ import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface MeritLogRepository extends JpaRepository<MeritLog, Long> {
 
@@ -17,4 +19,10 @@ public interface MeritLogRepository extends JpaRepository<MeritLog, Long> {
   long countByMemberId(long memberId);
 
   Page<MeritLog> findAllByTimeBetween(Pageable pageable, LocalDateTime startTime, LocalDateTime endTime);
+
+  @Query("SELECT NEW com.keeper.homepage.domain.merit.dto.response.MeritLogsGroupByMemberResponse(m.memberId, m.memberRealName, m.memberGeneration, " +
+      "CASE WHEN m.meritType.merit > 0 THEN SUM(m.meritType.merit) ELSE 0 END, " +
+      "CASE WHEN m.meritType.merit < 0 THEN SUM(m.meritType.merit) ELSE 0 END) " +
+      "FROM MeritLog m GROUP BY m.memberId, m.memberRealName, m.memberGeneration")
+  Page<MeritLogsGroupByMemberResponse> findAllTotalMeritLogs(Pageable pageable);
 }

--- a/src/main/java/com/keeper/homepage/domain/merit/dao/MeritLogRepository.java
+++ b/src/main/java/com/keeper/homepage/domain/merit/dao/MeritLogRepository.java
@@ -18,8 +18,6 @@ public interface MeritLogRepository extends JpaRepository<MeritLog, Long> {
 
   long countByMemberId(long memberId);
 
-  Page<MeritLog> findAllByTimeBetween(Pageable pageable, LocalDateTime startTime, LocalDateTime endTime);
-
   @Query("SELECT NEW com.keeper.homepage.domain.merit.dto.response.MeritLogsGroupByMemberResponse(m.memberId, m.memberRealName, m.memberGeneration, " +
       "CAST(SUM(CASE WHEN m.meritType.merit > 0 THEN m.meritType.merit ELSE 0 END) AS INTEGER), " +
       "CAST(SUM(CASE WHEN m.meritType.merit < 0 THEN m.meritType.merit ELSE 0 END) AS INTEGER)) " +

--- a/src/main/java/com/keeper/homepage/domain/merit/dto/response/MeritLogsGroupByMemberResponse.java
+++ b/src/main/java/com/keeper/homepage/domain/merit/dto/response/MeritLogsGroupByMemberResponse.java
@@ -1,0 +1,23 @@
+package com.keeper.homepage.domain.merit.dto.response;
+
+import lombok.Getter;
+
+@Getter
+public class MeritLogsGroupByMemberResponse {
+
+  private Long memberId;
+  private String memberName;
+  private String generation;
+  private Integer merit;
+  private Integer demerit;
+
+  public MeritLogsGroupByMemberResponse(Long memberId, String memberName, String generation,
+      Integer merit, Integer demerit) {
+    this.memberId = memberId;
+    this.memberName = memberName;
+    this.generation = generation;
+    this.merit = merit;
+    this.demerit = demerit;
+  }
+
+}

--- a/src/main/java/com/keeper/homepage/domain/merit/entity/MeritLog.java
+++ b/src/main/java/com/keeper/homepage/domain/merit/entity/MeritLog.java
@@ -44,11 +44,16 @@ public class MeritLog {
   private MeritType meritType;
 
   @Builder
-  public MeritLog(Long memberId, String memberRealName, String memberGeneration, MeritType meritType) {
+  public MeritLog(Long memberId, String memberRealName, String memberGeneration,
+      MeritType meritType) {
     this.memberId = memberId;
     this.memberRealName = memberRealName;
     this.memberGeneration = memberGeneration;
     this.time = LocalDateTime.now();
     this.meritType = meritType;
+  }
+
+  public void updateTime(LocalDateTime time) {
+    this.time = time;
   }
 }

--- a/src/main/java/com/keeper/homepage/domain/merit/entity/MeritLog.java
+++ b/src/main/java/com/keeper/homepage/domain/merit/entity/MeritLog.java
@@ -52,8 +52,4 @@ public class MeritLog {
     this.time = LocalDateTime.now();
     this.meritType = meritType;
   }
-
-  public void updateTime(LocalDateTime time) {
-    this.time = time;
-  }
 }

--- a/src/main/java/com/keeper/homepage/domain/point/api/PointController.java
+++ b/src/main/java/com/keeper/homepage/domain/point/api/PointController.java
@@ -45,12 +45,12 @@ public class PointController {
 
   @GetMapping
   public ResponseEntity<Page<FindAllPointLogResponse>> findAllPointLogs(
-      @RequestParam(defaultValue = "0") @PositiveOrZero int size,
-      @RequestParam(defaultValue = "10") @PositiveOrZero @Max(30) int page,
+      @RequestParam(defaultValue = "0") @PositiveOrZero int page,
+      @RequestParam(defaultValue = "10") @PositiveOrZero @Max(30) int size,
       @LoginMember Member member
   ) {
     return ResponseEntity.ok(
-        pointLogService.findAllPointLogs(PageRequest.of(size, page), member.getId())
+        pointLogService.findAllPointLogs(PageRequest.of(page, size), member.getId())
             .map(FindAllPointLogResponse::from)
     );
   }

--- a/src/test/java/com/keeper/homepage/domain/merit/api/MeritApiTestHelper.java
+++ b/src/test/java/com/keeper/homepage/domain/merit/api/MeritApiTestHelper.java
@@ -39,5 +39,15 @@ public class MeritApiTestHelper extends IntegrationTest {
     };
   }
 
+  FieldDescriptor[] getAllTotalMeritLogsResponse() {
+    return new FieldDescriptor[]{
+        fieldWithPath("memberId").description("회원의 ID"),
+        fieldWithPath("memberName").description("회원의 이름"),
+        fieldWithPath("generation").description("회원의 기수"),
+        fieldWithPath("merit").description("상점"),
+        fieldWithPath("demerit").description("벌점")
+    };
+  }
+
 
 }

--- a/src/test/java/com/keeper/homepage/domain/merit/api/MeritApiTestHelper.java
+++ b/src/test/java/com/keeper/homepage/domain/merit/api/MeritApiTestHelper.java
@@ -48,6 +48,4 @@ public class MeritApiTestHelper extends IntegrationTest {
         fieldWithPath("demerit").description("벌점")
     };
   }
-
-
 }

--- a/src/test/java/com/keeper/homepage/domain/merit/application/MeritLogServiceTest.java
+++ b/src/test/java/com/keeper/homepage/domain/merit/application/MeritLogServiceTest.java
@@ -89,20 +89,4 @@ class MeritLogServiceTest extends IntegrationTest {
     }
   }
 
-  @Nested
-  @DisplayName("상벌점 조회 테스트")
-  class FindMeritLogTest {
-
-    private MeritLog summerMeritLog, summerOtherMeritLog, winterMeritLog, winterOtherMeritLog;
-
-    @BeforeEach
-    void setUp() {
-      summerMeritLog = meritLogTestHelper.generate();
-      summerOtherMeritLog = meritLogTestHelper.generate();
-      winterMeritLog = meritLogTestHelper.generate();
-      winterOtherMeritLog = meritLogTestHelper.generate();
-    }
-
-  }
-
 }

--- a/src/test/java/com/keeper/homepage/domain/merit/application/MeritLogServiceTest.java
+++ b/src/test/java/com/keeper/homepage/domain/merit/application/MeritLogServiceTest.java
@@ -6,6 +6,8 @@ import com.keeper.homepage.IntegrationTest;
 import com.keeper.homepage.domain.member.entity.Member;
 import com.keeper.homepage.domain.merit.entity.MeritLog;
 import com.keeper.homepage.domain.merit.entity.MeritType;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -86,4 +88,39 @@ class MeritLogServiceTest extends IntegrationTest {
           .contains(meritLogId, otherMeritLogId);
     }
   }
+
+  @Nested
+  @DisplayName("상벌점 조회 테스트")
+  class FindMeritLogTest {
+
+    private MeritLog summerMeritLog, summerOtherMeritLog, winterMeritLog, winterOtherMeritLog;
+
+    @BeforeEach
+    void setUp() {
+      summerMeritLog = meritLogTestHelper.generate();
+      summerOtherMeritLog = meritLogTestHelper.generate();
+      winterMeritLog = meritLogTestHelper.generate();
+      winterOtherMeritLog = meritLogTestHelper.generate();
+    }
+
+    @Test
+    @DisplayName("학기별 조회를 성공해야 한다.")
+    public void 학기별_조회를_성공해야_한다() {
+      summerMeritLog.updateTime(LocalDateTime.of(2023,6,1,0,0));
+      winterMeritLog.updateTime(LocalDateTime.of(2023,12,1,0,0));
+      summerOtherMeritLog.updateTime(LocalDateTime.of(2023,6,1,0,0));
+      winterOtherMeritLog.updateTime(LocalDateTime.of(2024,1,1,0,0));
+
+      em.flush();
+      em.clear();
+
+      LocalDateTime startTime = LocalDateTime.of(2023, 3, 1,0,0);
+      Page<MeritLog> pages = meritLogService.findMeritLogByTime(PageRequest.of(0, 10), startTime);
+
+      assertThat(pages.map(MeritLog::getId).toList()).contains(summerMeritLog.getId(), summerOtherMeritLog.getId());
+      assertThat(pages.map(MeritLog::getId).toList()).doesNotContain(winterMeritLog.getId(),
+          winterOtherMeritLog.getId());
+    }
+  }
+
 }

--- a/src/test/java/com/keeper/homepage/domain/merit/application/MeritLogServiceTest.java
+++ b/src/test/java/com/keeper/homepage/domain/merit/application/MeritLogServiceTest.java
@@ -103,24 +103,6 @@ class MeritLogServiceTest extends IntegrationTest {
       winterOtherMeritLog = meritLogTestHelper.generate();
     }
 
-    @Test
-    @DisplayName("학기별 조회를 성공해야 한다.")
-    public void 학기별_조회를_성공해야_한다() {
-      summerMeritLog.updateTime(LocalDateTime.of(2023,6,1,0,0));
-      winterMeritLog.updateTime(LocalDateTime.of(2023,12,1,0,0));
-      summerOtherMeritLog.updateTime(LocalDateTime.of(2023,6,1,0,0));
-      winterOtherMeritLog.updateTime(LocalDateTime.of(2024,1,1,0,0));
-
-      em.flush();
-      em.clear();
-
-      LocalDateTime startTime = LocalDateTime.of(2023, 3, 1,0,0);
-      Page<MeritLog> pages = meritLogService.findMeritLogByTime(PageRequest.of(0, 10), startTime);
-
-      assertThat(pages.map(MeritLog::getId).toList()).contains(summerMeritLog.getId(), summerOtherMeritLog.getId());
-      assertThat(pages.map(MeritLog::getId).toList()).doesNotContain(winterMeritLog.getId(),
-          winterOtherMeritLog.getId());
-    }
   }
 
 }

--- a/src/test/java/com/keeper/homepage/domain/merit/dao/MeritLogRepositoryTest.java
+++ b/src/test/java/com/keeper/homepage/domain/merit/dao/MeritLogRepositoryTest.java
@@ -5,7 +5,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.keeper.homepage.IntegrationTest;
 import com.keeper.homepage.domain.member.entity.Member;
+import com.keeper.homepage.domain.merit.dto.response.MeritLogsGroupByMemberResponse;
 import com.keeper.homepage.domain.merit.entity.MeritLog;
+import com.keeper.homepage.domain.merit.entity.MeritType;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -58,5 +61,79 @@ public class MeritLogRepositoryTest extends IntegrationTest {
     }
   }
 
+  @Nested
+  @DisplayName("회원 통계 상벌점 목록 조회 테스트")
+  class GetTotalMeritLogsTest {
 
+    private MeritType meritType, demeritType;
+    private Member member, otherMember;
+    @BeforeEach
+    void setUp() {
+      meritType = meritTypeHelper.builder().merit(5).build();
+      demeritType = meritTypeHelper.builder().merit(-3).build();
+      member = memberTestHelper.generate();
+      otherMember = memberTestHelper.generate();
+
+      meritLogTestHelper.builder()
+          .memberId(member.getId())
+          .memberRealName(member.getRealName())
+          .memberGeneration(member.getGeneration())
+          .meritType(meritType)
+          .build();
+
+      meritLogTestHelper.builder()
+          .memberId(member.getId())
+          .memberRealName(member.getRealName())
+          .memberGeneration(member.getGeneration())
+          .meritType(demeritType)
+          .build();
+
+      meritLogTestHelper.builder()
+          .memberId(otherMember.getId())
+          .memberRealName(otherMember.getRealName())
+          .memberGeneration(otherMember.getGeneration())
+          .meritType(meritType)
+          .build();
+
+      meritLogTestHelper.builder()
+          .memberId(otherMember.getId())
+          .memberRealName(otherMember.getRealName())
+          .memberGeneration(otherMember.getGeneration())
+          .meritType(meritType)
+          .build();
+
+      meritLogTestHelper.builder()
+          .memberId(otherMember.getId())
+          .memberRealName(otherMember.getRealName())
+          .memberGeneration(otherMember.getGeneration())
+          .meritType(demeritType)
+          .build();
+    }
+
+    @Test
+    @DisplayName("MeritLogsGroupByMemberResponse Dto에 맞게 조회되어야 한다.")
+    public void MeritLogsGroupByMemberResponse_Dto에_맞게_조회되어야_한다() {
+      em.flush();
+      em.clear();
+
+      Page<MeritLogsGroupByMemberResponse> result = meritLogRepository.findAllTotalMeritLogs(
+          PageRequest.of(0, 10));
+
+      assertThat(result.map(MeritLogsGroupByMemberResponse::getMemberId).toList())
+          .containsExactly(member.getId(), otherMember.getId());
+
+      assertThat(result.map(MeritLogsGroupByMemberResponse::getMemberName).toList())
+          .containsExactly(member.getRealName(), otherMember.getRealName());
+
+      assertThat(result.map(MeritLogsGroupByMemberResponse::getGeneration).toList())
+          .containsExactly(member.getGeneration(), otherMember.getGeneration());
+
+      assertThat(result.map(MeritLogsGroupByMemberResponse::getMerit).toList())
+          .containsExactly(5, 10);
+
+      assertThat(result.map(MeritLogsGroupByMemberResponse::getDemerit).toList())
+          .containsExactly(-3, -3);
+    }
+
+  }
 }


### PR DESCRIPTION
## 🔥 Related Issue
close: #343

## 📝 Description
회원 통계 상벌점 목록 조회 기능을 추가했습니다!

## ⭐️ Review Request
예전에는 merit와 demerit 컬럼이 있었는데 현재는 merit로 통합이 됐습니다. 그래서 상점만 받으면 될 줄 알았는데 상벌점 구분해서 넘겨달라고 하셨습니다! 

집계함수를 사용해서 완성은 했지만 아직 데이터베이스 수업도 안듣고 이번에 처음 사용해서 조금 찝찝하네요... 더 좋은 방법이 있을까요?.?

+) 쿼리DSL 강의를 들어봤는데 너무 좋은 거 같습니다..! 이번 회원 통계 목록 조회 기능이랑 상벌점 사유 수정 중에 사유 이름을 변경하지 않으면 이미 존재하는 사유로 판단되어 수정이 안 되는 이슈에도 적용하면 좋을 거 같다라는 생각이 드네요..! 
혹시 R2 프로젝트에 DSL 도입 안 될까요..?? 👀