### PR TITLE
Feature/회원 탈퇴 기능

### DIFF
--- a/src/docs/asciidoc/member/member.adoc
+++ b/src/docs/asciidoc/member/member.adoc
@@ -233,7 +233,7 @@ include::{snippets}/update-member-type/request-fields.adoc[]
 
 include::{snippets}/update-member-type/http-response.adoc[]
 
-== *이메일 변경 기능*
+== *이메일 변경*
 
 === 요청
 
@@ -276,3 +276,25 @@ include::{snippets}/member-email-auth/request-fields.adoc[]
 ==== Response
 
 include::{snippets}/member-email-auth/http-response.adoc[]
+
+== *회원 삭제*
+
+=== 요청
+
+==== Request
+
+include::{snippets}/delete-member/http-request.adoc[]
+
+==== Request Cookies
+
+include::{snippets}/delete-member/request-cookies.adoc[]
+
+==== Request Fields
+
+include::{snippets}/delete-member/request-fields.adoc[]
+
+=== 응답
+
+==== Response
+
+include::{snippets}/delete-member/http-response.adoc[]

--- a/src/main/java/com/keeper/homepage/domain/member/api/MemberController.java
+++ b/src/main/java/com/keeper/homepage/domain/member/api/MemberController.java
@@ -159,7 +159,6 @@ public class MemberController {
       @LoginMember Member member,
       @RequestBody @Valid DeleteMemberRequest request) {
     memberService.deleteMember(member, request.getRawPassword());
-
     return ResponseEntity.noContent().build();
   }
 }

--- a/src/main/java/com/keeper/homepage/domain/member/api/MemberController.java
+++ b/src/main/java/com/keeper/homepage/domain/member/api/MemberController.java
@@ -7,6 +7,7 @@ import com.keeper.homepage.domain.auth.dto.response.EmailAuthResponse;
 import com.keeper.homepage.domain.member.application.MemberProfileService;
 import com.keeper.homepage.domain.member.application.MemberService;
 import com.keeper.homepage.domain.member.dto.request.ChangePasswordRequest;
+import com.keeper.homepage.domain.member.dto.request.DeleteMemberRequest;
 import com.keeper.homepage.domain.member.dto.request.ProfileUpdateRequest;
 import com.keeper.homepage.domain.member.dto.request.UpdateMemberEmailAddressRequest;
 import com.keeper.homepage.domain.member.dto.request.UpdateMemberTypeRequest;
@@ -148,7 +149,17 @@ public class MemberController {
       @LoginMember Member member,
       @RequestBody @Valid UpdateMemberEmailAddressRequest request
   ) {
-    memberProfileService.updateProfileEmailAddress(member, request.getEmail(), request.getAuth(), request.getPassword());
+    memberProfileService.updateProfileEmailAddress(member, request.getEmail(), request.getAuth(),
+        request.getPassword());
+    return ResponseEntity.noContent().build();
+  }
+
+  @PatchMapping
+  public ResponseEntity<Void> deleteMember(
+      @LoginMember Member member,
+      @RequestBody @Valid DeleteMemberRequest request) {
+    memberService.deleteMember(member, request.getRawPassword());
+
     return ResponseEntity.noContent().build();
   }
 }

--- a/src/main/java/com/keeper/homepage/domain/member/application/MemberProfileService.java
+++ b/src/main/java/com/keeper/homepage/domain/member/application/MemberProfileService.java
@@ -99,7 +99,7 @@ public class MemberProfileService {
         .toString();
   }
 
-  private void checkMemberPassword(Member member, String rawPassword) {
+  public void checkMemberPassword(Member member, String rawPassword) {
     if (member.getProfile().getPassword().isWrongPassword(rawPassword)) {
       throw new BusinessException(rawPassword, "rawPassword", ErrorCode.MEMBER_WRONG_PASSWORD);
     }

--- a/src/main/java/com/keeper/homepage/domain/member/application/MemberService.java
+++ b/src/main/java/com/keeper/homepage/domain/member/application/MemberService.java
@@ -1,6 +1,7 @@
 package com.keeper.homepage.domain.member.application;
 
 import static com.keeper.homepage.domain.member.application.convenience.MemberFindService.VIRTUAL_MEMBER_ID;
+import static com.keeper.homepage.global.error.ErrorCode.MEMBER_BOOK_NOT_EMPTY;
 import static com.keeper.homepage.global.error.ErrorCode.MEMBER_CANNOT_FOLLOW_ME;
 import static com.keeper.homepage.global.error.ErrorCode.MEMBER_TYPE_NOT_FOUND;
 
@@ -33,6 +34,7 @@ public class MemberService {
 
   private final MemberRepository memberRepository;
   private final MemberFindService memberFindService;
+  private final MemberProfileService memberProfileService;
   private final MemberTypeRepository memberTypeRepository;
 
   @Transactional
@@ -85,5 +87,19 @@ public class MemberService {
     memberIds.stream()
         .map(memberFindService::findById)
         .forEach(m -> m.updateType(findMemberType));
+  }
+
+  @Transactional
+  public void deleteMember(long memberId, String rawPassword) {
+    Member findMember = memberFindService.findById(memberId);
+    memberProfileService.checkMemberPassword(findMember, rawPassword);
+    checkBorrowedBook(findMember);
+
+  }
+
+  private void checkBorrowedBook(Member member) {
+    if (member.isBorrowBooks()) {
+      throw new BusinessException(member.getBookBorrowInfos(), "memberBorrowInfos", MEMBER_BOOK_NOT_EMPTY);
+    }
   }
 }

--- a/src/main/java/com/keeper/homepage/domain/member/application/MemberService.java
+++ b/src/main/java/com/keeper/homepage/domain/member/application/MemberService.java
@@ -97,7 +97,7 @@ public class MemberService {
   }
 
   private void checkBorrowedBook(Member member) {
-    if (member.isBorrowBooks()) {
+    if (member.hasAnyBorrowBooks()) {
       throw new BusinessException(member.getBookBorrowInfos(), "memberBorrowInfos", MEMBER_BOOK_NOT_EMPTY);
     }
   }

--- a/src/main/java/com/keeper/homepage/domain/member/application/MemberService.java
+++ b/src/main/java/com/keeper/homepage/domain/member/application/MemberService.java
@@ -90,11 +90,10 @@ public class MemberService {
   }
 
   @Transactional
-  public void deleteMember(long memberId, String rawPassword) {
-    Member findMember = memberFindService.findById(memberId);
-    memberProfileService.checkMemberPassword(findMember, rawPassword);
-    checkBorrowedBook(findMember);
-
+  public void deleteMember(Member member, String rawPassword) {
+    memberProfileService.checkMemberPassword(member, rawPassword);
+    checkBorrowedBook(member);
+    member.deleteMember();
   }
 
   private void checkBorrowedBook(Member member) {

--- a/src/main/java/com/keeper/homepage/domain/member/dto/request/DeleteMemberRequest.java
+++ b/src/main/java/com/keeper/homepage/domain/member/dto/request/DeleteMemberRequest.java
@@ -1,0 +1,21 @@
+package com.keeper.homepage.domain.member.dto.request;
+
+import jakarta.validation.constraints.NotEmpty;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class DeleteMemberRequest {
+
+  @NotEmpty(message = "비밀번호를 입력해주세요.")
+  private String rawPassword;
+
+  public static DeleteMemberRequest from(String rawPassword) {
+    return new DeleteMemberRequest(rawPassword);
+  }
+}

--- a/src/main/java/com/keeper/homepage/domain/member/entity/Member.java
+++ b/src/main/java/com/keeper/homepage/domain/member/entity/Member.java
@@ -409,10 +409,6 @@ public class Member {
 
   public void deleteMember() {
     this.getProfile().deleteMemberProfile();
-    this.generation = null;
-    this.totalAttendance = 0;
-    this.point = 0;
-    this.level = 0;
     this.isDeleted = true;
   }
 }

--- a/src/main/java/com/keeper/homepage/domain/member/entity/Member.java
+++ b/src/main/java/com/keeper/homepage/domain/member/entity/Member.java
@@ -66,11 +66,13 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
+import org.hibernate.annotations.Where;
 
 @DynamicInsert
 @DynamicUpdate
 @Getter
 @Entity
+@Where(clause = "is_deleted = false")
 @EqualsAndHashCode(of = {"id"})
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "member")
@@ -403,8 +405,9 @@ public class Member {
     this.memberType = memberType;
   }
 
-  public boolean isBorrowBooks() {
-    return !this.bookBorrowInfos.isEmpty();
+  public boolean hasAnyBorrowBooks() {
+    return this.bookBorrowInfos.stream()
+        .anyMatch(BookBorrowInfo::isInBorrowing);
   }
 
   public void deleteMember() {

--- a/src/main/java/com/keeper/homepage/domain/member/entity/Member.java
+++ b/src/main/java/com/keeper/homepage/domain/member/entity/Member.java
@@ -409,7 +409,7 @@ public class Member {
 
   public void deleteMember() {
     this.getProfile().deleteMemberProfile();
-    this.generation = Generation.generateGeneration(now());
+    this.generation = null;
     this.totalAttendance = 0;
     this.point = 0;
     this.level = 0;

--- a/src/main/java/com/keeper/homepage/domain/member/entity/Member.java
+++ b/src/main/java/com/keeper/homepage/domain/member/entity/Member.java
@@ -412,6 +412,9 @@ public class Member {
 
   public void deleteMember() {
     this.getProfile().deleteMemberProfile();
+    this.generation = Generation.generateGeneration(now());
+    this.totalAttendance = 0;
+    this.level = 0;
     this.isDeleted = true;
   }
 }

--- a/src/main/java/com/keeper/homepage/domain/member/entity/Member.java
+++ b/src/main/java/com/keeper/homepage/domain/member/entity/Member.java
@@ -10,6 +10,7 @@ import static com.keeper.homepage.domain.member.entity.type.MemberType.MemberTyp
 import static jakarta.persistence.CascadeType.ALL;
 import static jakarta.persistence.CascadeType.PERSIST;
 import static jakarta.persistence.CascadeType.REMOVE;
+import static java.time.LocalDate.*;
 
 import com.keeper.homepage.domain.attendance.entity.Attendance;
 import com.keeper.homepage.domain.comment.entity.Comment;
@@ -161,7 +162,7 @@ public class Member {
   @Builder
   private Member(Profile profile, Integer point, Integer level, Integer totalAttendance) {
     this.profile = profile;
-    this.generation = Generation.generateGeneration(LocalDate.now());
+    this.generation = Generation.generateGeneration(now());
     this.point = point;
     this.level = level;
     this.totalAttendance = totalAttendance;
@@ -400,5 +401,18 @@ public class Member {
 
   public void updateType(MemberType memberType) {
     this.memberType = memberType;
+  }
+
+  public boolean isBorrowBooks() {
+    return !this.bookBorrowInfos.isEmpty();
+  }
+
+  public void deleteMember() {
+    this.getProfile().deleteMemberProfile();
+    this.generation = Generation.generateGeneration(now());
+    this.totalAttendance = 0;
+    this.point = 0;
+    this.level = 0;
+    this.isDeleted = true;
   }
 }

--- a/src/main/java/com/keeper/homepage/domain/member/entity/embedded/Profile.java
+++ b/src/main/java/com/keeper/homepage/domain/member/entity/embedded/Profile.java
@@ -73,11 +73,6 @@ public class Profile {
   }
 
   public void deleteMemberProfile() {
-    this.loginId = LoginId.from("삭제");
-    this.emailAddress = EmailAddress.from("delete@delete.com");
-    this.password = Password.from("deletePassword");
-    this.realName = RealName.from("삭제");
-    this.birthday = null;
-    this.studentId = StudentId.from("0");
+    this.realName = RealName.from("탈퇴회원");
   }
 }

--- a/src/main/java/com/keeper/homepage/domain/member/entity/embedded/Profile.java
+++ b/src/main/java/com/keeper/homepage/domain/member/entity/embedded/Profile.java
@@ -73,6 +73,12 @@ public class Profile {
   }
 
   public void deleteMemberProfile() {
+    this.loginId = LoginId.from("delete");
+    this.emailAddress = EmailAddress.from("delete@delete.com");
+    this.password = Password.from("delete");
     this.realName = RealName.from("탈퇴회원");
+    this.birthday = null;
+    this.studentId = null;
+    this.thumbnail = null;
   }
 }

--- a/src/main/java/com/keeper/homepage/domain/member/entity/embedded/Profile.java
+++ b/src/main/java/com/keeper/homepage/domain/member/entity/embedded/Profile.java
@@ -1,5 +1,7 @@
 package com.keeper.homepage.domain.member.entity.embedded;
 
+import static java.time.LocalDate.*;
+
 import com.keeper.homepage.domain.thumbnail.entity.Thumbnail;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -68,5 +70,14 @@ public class Profile {
 
   public void updateEmailAddress(String newEmailAddress) {
     this.emailAddress = EmailAddress.from(newEmailAddress);
+  }
+
+  public void deleteMemberProfile() {
+    this.loginId = LoginId.from("삭제");
+    this.emailAddress = EmailAddress.from("삭제");
+    this.password = Password.from("삭제");
+    this.realName = RealName.from("삭제");
+    this.birthday = null;
+    this.studentId = StudentId.from("삭제");
   }
 }

--- a/src/main/java/com/keeper/homepage/domain/member/entity/embedded/Profile.java
+++ b/src/main/java/com/keeper/homepage/domain/member/entity/embedded/Profile.java
@@ -74,10 +74,10 @@ public class Profile {
 
   public void deleteMemberProfile() {
     this.loginId = LoginId.from("삭제");
-    this.emailAddress = EmailAddress.from("삭제");
-    this.password = Password.from("삭제");
+    this.emailAddress = EmailAddress.from("delete@delete.com");
+    this.password = Password.from("deletePassword");
     this.realName = RealName.from("삭제");
     this.birthday = null;
-    this.studentId = StudentId.from("삭제");
+    this.studentId = StudentId.from("0");
   }
 }

--- a/src/main/java/com/keeper/homepage/global/error/ErrorCode.java
+++ b/src/main/java/com/keeper/homepage/global/error/ErrorCode.java
@@ -25,6 +25,7 @@ public enum ErrorCode {
   MEMBER_JOB_IS_NOT_EXECUTIVE("해당 직책은 임원 직책이 아닙니다.", HttpStatus.BAD_REQUEST),
   MEMBER_CANNOT_FOLLOW_ME("스스로를 팔로우 할 수 없습니다.", HttpStatus.BAD_REQUEST),
   MEMBER_TYPE_NOT_FOUND("해당 회원 타입을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+  MEMBER_BOOK_NOT_EMPTY("아직 대여 중인 책이 있어 탈퇴가 불가능합니다.", HttpStatus.BAD_REQUEST),
   // ABOUT
   TITLE_TYPE_NOT_FOUND("해당 타입의 타이틀을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
   // SEMINAR

--- a/src/test/java/com/keeper/homepage/domain/member/api/MemberControllerTest.java
+++ b/src/test/java/com/keeper/homepage/domain/member/api/MemberControllerTest.java
@@ -41,6 +41,7 @@ import com.keeper.homepage.domain.member.dto.request.ProfileUpdateRequest;
 import com.keeper.homepage.domain.member.dto.request.UpdateMemberEmailAddressRequest;
 import com.keeper.homepage.domain.member.dto.request.UpdateMemberTypeRequest;
 import com.keeper.homepage.domain.member.entity.Member;
+import com.keeper.homepage.domain.member.entity.embedded.Password;
 import com.keeper.homepage.domain.member.entity.embedded.RealName;
 import jakarta.servlet.http.Cookie;
 import java.io.IOException;

--- a/src/test/java/com/keeper/homepage/domain/member/api/MemberControllerTest.java
+++ b/src/test/java/com/keeper/homepage/domain/member/api/MemberControllerTest.java
@@ -554,6 +554,4 @@ class MemberControllerTest extends MemberApiTestHelper {
           .andExpect(status().isBadRequest());
     }
   }
-
-
 }

--- a/src/test/java/com/keeper/homepage/domain/member/application/MemberServiceTest.java
+++ b/src/test/java/com/keeper/homepage/domain/member/application/MemberServiceTest.java
@@ -1,15 +1,24 @@
 package com.keeper.homepage.domain.member.application;
 
+import static com.keeper.homepage.domain.library.entity.BookBorrowStatus.*;
+import static com.keeper.homepage.domain.library.entity.BookBorrowStatus.BookBorrowStatusType.대출대기;
+import static com.keeper.homepage.domain.library.entity.BookBorrowStatus.BookBorrowStatusType.대출중;
 import static com.keeper.homepage.domain.member.entity.type.MemberType.MemberTypeEnum.*;
+import static com.keeper.homepage.global.error.ErrorCode.MEMBER_BOOK_NOT_EMPTY;
 import static com.keeper.homepage.global.error.ErrorCode.MEMBER_CANNOT_FOLLOW_ME;
+import static com.keeper.homepage.global.error.ErrorCode.MEMBER_WRONG_PASSWORD;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.keeper.homepage.IntegrationTest;
+import com.keeper.homepage.domain.library.entity.Book;
+import com.keeper.homepage.domain.library.entity.BookBorrowStatus;
 import com.keeper.homepage.domain.member.entity.Member;
+import com.keeper.homepage.domain.member.entity.embedded.Password;
 import com.keeper.homepage.domain.member.entity.friend.Friend;
 import com.keeper.homepage.domain.member.entity.type.MemberType.MemberTypeEnum;
+import com.keeper.homepage.global.config.password.PasswordFactory;
 import com.keeper.homepage.global.error.BusinessException;
 import java.util.HashSet;
 import java.util.List;
@@ -88,4 +97,67 @@ public class MemberServiceTest extends IntegrationTest {
       assertThat(findOtherMember.getMemberType().getType()).isEqualTo(휴면회원);
     }
   }
+
+  @Nested
+  @DisplayName("회원 탈퇴 기능 테스트")
+  class DeleteMemberTest {
+
+    private Member member;
+    private Book book;
+
+    @BeforeEach
+    void setUp() {
+      member = memberTestHelper.builder()
+          .password(Password.from("TruePassword"))
+          .build();
+    }
+
+    @Test
+    @DisplayName("회원 탈퇴 시 유저 정보는 '삭제'로 마킹되어야 한다.")
+    public void 회원_탈퇴_시_유저_정보는_삭제로_마킹되어야_한다() {
+      memberService.deleteMember(member, "TruePassword");
+
+      em.flush();
+      em.clear();
+
+      Member findMember = memberRepository.findById(member.getId())
+          .orElseThrow();
+
+      assertThat(findMember.getProfile().getLoginId().get()).isEqualTo("삭제");
+      assertThat(findMember.getProfile().getEmailAddress().get()).isEqualTo("delete@delete.com");
+      assertThat(findMember.getProfile().getRealName().get()).isEqualTo("삭제");
+      assertThat(findMember.getProfile().getBirthday()).isNull();
+      assertThat(findMember.getProfile().getStudentId().get()).isEqualTo("0");
+      assertThat(findMember.getProfile().getPassword().isWrongPassword("deletePassword")).isFalse();
+
+      assertThat(findMember.getTotalAttendance()).isEqualTo(0);
+      assertThat(findMember.getPoint()).isEqualTo(0);
+      assertThat(findMember.getLevel()).isEqualTo(0);
+      assertThat(findMember.getIsDeleted()).isEqualTo(true);
+
+    }
+
+    @Test
+    @DisplayName("비밀번호가 틀릴 시 예외를 던진다.")
+    public void 비밀번호가_틀릴_시_예외를_던진다() {
+      assertThrows(BusinessException.class,
+          () -> memberService.deleteMember(member, "FalsePassword"),
+          MEMBER_WRONG_PASSWORD.getMessage());
+    }
+
+    @Test
+    @DisplayName("대출 중인 도서가 있을 경우 예외를 던진다.")
+    public void 대출_중인_도서가_있을_경우_예외를_던진다() {
+      book = bookTestHelper.generate();
+      member.borrow(book, getBookBorrowStatusBy(대출대기));
+
+      em.flush();
+      em.clear();
+
+      assertThrows(BusinessException.class,
+          () -> memberService.deleteMember(member, "TruePassword"),
+          MEMBER_BOOK_NOT_EMPTY.getMessage());
+    }
+  }
+
 }

--- a/src/test/java/com/keeper/homepage/domain/member/application/MemberServiceTest.java
+++ b/src/test/java/com/keeper/homepage/domain/member/application/MemberServiceTest.java
@@ -113,7 +113,7 @@ public class MemberServiceTest extends IntegrationTest {
     }
 
     @Test
-    @DisplayName("회원 탈퇴 시 유저 정보는 '삭제'로 마킹되어야 한다.")
+    @DisplayName("회원 탈퇴 시 유저 이름은 '회원탈퇴'로 마킹되어야 한다.")
     public void 회원_탈퇴_시_유저_이름은_회원탈퇴로_마킹되어야_한다() {
       memberService.deleteMember(member, "TruePassword");
 
@@ -125,7 +125,6 @@ public class MemberServiceTest extends IntegrationTest {
 
       assertThat(findMember.getProfile().getRealName().get()).isEqualTo("탈퇴회원");
       assertThat(findMember.getIsDeleted()).isEqualTo(true);
-
     }
 
     @Test

--- a/src/test/java/com/keeper/homepage/domain/member/application/MemberServiceTest.java
+++ b/src/test/java/com/keeper/homepage/domain/member/application/MemberServiceTest.java
@@ -114,7 +114,7 @@ public class MemberServiceTest extends IntegrationTest {
 
     @Test
     @DisplayName("회원 탈퇴 시 유저 정보는 '삭제'로 마킹되어야 한다.")
-    public void 회원_탈퇴_시_유저_정보는_삭제로_마킹되어야_한다() {
+    public void 회원_탈퇴_시_유저_이름은_회원탈퇴로_마킹되어야_한다() {
       memberService.deleteMember(member, "TruePassword");
 
       em.flush();
@@ -123,16 +123,7 @@ public class MemberServiceTest extends IntegrationTest {
       Member findMember = memberRepository.findById(member.getId())
           .orElseThrow();
 
-      assertThat(findMember.getProfile().getLoginId().get()).isEqualTo("삭제");
-      assertThat(findMember.getProfile().getEmailAddress().get()).isEqualTo("delete@delete.com");
-      assertThat(findMember.getProfile().getRealName().get()).isEqualTo("삭제");
-      assertThat(findMember.getProfile().getBirthday()).isNull();
-      assertThat(findMember.getProfile().getStudentId().get()).isEqualTo("0");
-      assertThat(findMember.getProfile().getPassword().isWrongPassword("deletePassword")).isFalse();
-
-      assertThat(findMember.getTotalAttendance()).isEqualTo(0);
-      assertThat(findMember.getPoint()).isEqualTo(0);
-      assertThat(findMember.getLevel()).isEqualTo(0);
+      assertThat(findMember.getProfile().getRealName().get()).isEqualTo("탈퇴회원");
       assertThat(findMember.getIsDeleted()).isEqualTo(true);
 
     }


### PR DESCRIPTION
## 🔥 Related Issue

close: #64

## 📝 Description

회원 탈퇴 기능을 만들었습니다.

## ⭐️ Review Request

초반 커밋을 보시면 회원 아이디, 비밀번호, 이메일 등등 전부 다 탈퇴, 삭제 등으로 마킹을 했었는데 의견을 나눈 결과 is_delete를 업데이트하고 회원 이름만 탈퇴회원으로 마킹하도록 했습니다..!! (게시글에 탈퇴회원으로 표기되게끔) 다른 분들의 의견도 궁금합니다~ 어떻게 해야 할까요 ?.?

+) 9월 17일 수정
Column 값으로 사람을 특정할 수 있는 정보(login_id, email, pw, real_name, birth, student_id, thumbnail)만 마킹하도록 결정했습니다!
마킹 테스트를 할 때 네이티브 쿼리를 사용한 이유는 @Where 어노테이션이 적용되어서 계속 예외가 발생해서 그렇습니다! 이 테스트에서 JPQL도 사용해봤는데 @Where 어노테이션이 적용되서 아직까지는 문제 없는 것 같습니다!!
