### PR TITLE
Feature/족보 게시글 관련 처리

### DIFF
--- a/src/docs/asciidoc/post/post.adoc
+++ b/src/docs/asciidoc/post/post.adoc
@@ -365,6 +365,8 @@ include::{snippets}/get-trend-posts/response-fields.adoc[]
 
 == *게시글의 첨부파일 목록 조회*
 
+NOTE: 시험게시판 게시글의 첨부파일 목록을 최초 조회 시 포인트가 차감됩니다. 단, 본인의 게시글일 경우 포인트는 차감되지 않습니다.
+
 === 요청
 
 ==== Request

--- a/src/main/java/com/keeper/homepage/domain/post/application/PostService.java
+++ b/src/main/java/com/keeper/homepage/domain/post/application/PostService.java
@@ -198,7 +198,7 @@ public class PostService {
   public List<FileResponse> getFiles(Member member, long postId) {
     Post post = validPostFindService.findById(postId);
 
-    if (post.isCategory(시험게시판) && !member.isRead(post)) {
+    if (post.isCategory(시험게시판) && !member.isRead(post) && !post.isMine(member)) {
       member.read(post);
       member.minusPoint(EXAM_READ_DEDUCTION_POINT, EXAM_READ_POINT_MESSAGE);
     }

--- a/src/main/java/com/keeper/homepage/domain/post/application/PostService.java
+++ b/src/main/java/com/keeper/homepage/domain/post/application/PostService.java
@@ -133,6 +133,10 @@ public class PostService {
     if (post.isCategory(익명게시판)) {
       return PostDetailResponse.of(post, ANONYMOUS_NAME, null, isLike, isDislike, previousPost, nextPost);
     }
+    if (post.isCategory(시험게시판) && !post.isMine(member)) {
+      boolean isRead = member.isRead(post);
+      return PostDetailResponse.of(post, isLike, isDislike, isRead, previousPost, nextPost);
+    }
     return PostDetailResponse.of(post, isLike, isDislike, previousPost, nextPost);
   }
 
@@ -337,6 +341,10 @@ public class PostService {
   private PostResponse getPostResponse(Post post) {
     if (post.isCategory(익명게시판)) {
       return PostResponse.of(post, ANONYMOUS_NAME, null);
+    }
+    if (post.isCategory(시험게시판)) {
+      int fileCount = post.getPostHasFiles().size();
+      return PostResponse.of(post, fileCount);
     }
     return PostResponse.from(post);
   }

--- a/src/main/java/com/keeper/homepage/domain/post/dto/response/PostDetailResponse.java
+++ b/src/main/java/com/keeper/homepage/domain/post/dto/response/PostDetailResponse.java
@@ -31,6 +31,7 @@ public class PostDetailResponse {
   private Boolean isTemp;
   private Boolean isLike;
   private Boolean isDislike;
+  private Boolean isRead;
 
   @JsonFormat(pattern = "yyyy-MM-dd")
   private LocalDateTime registerTime;
@@ -41,7 +42,33 @@ public class PostDetailResponse {
   private AdjacentPostResponse previousPost;
   private AdjacentPostResponse nextPost;
 
-  public static PostDetailResponse of(Post post, boolean isLike, boolean isDislike, Post previousPost,
+  public static PostDetailResponse of(Post post, boolean isLike, boolean isDislike, Post previousPost, Post nextPost) {
+    return PostDetailResponse.builder()
+        .categoryId(post.getCategory().getId())
+        .categoryName(post.getCategory().getType().toString())
+        .title(post.getTitle())
+        .writerId(post.getMember().getId())
+        .writerName(post.getMember().getRealName())
+        .writerThumbnailPath(post.getMember().getThumbnailPath())
+        .registerTime(post.getRegisterTime())
+        .updateTime(post.getUpdateTime())
+        .visitCount(post.getVisitCount())
+        .thumbnailPath(post.getThumbnailPath())
+        .content(post.getContent())
+        .likeCount(post.getPostLikes().size())
+        .dislikeCount(post.getPostDislikes().size())
+        .allowComment(post.allowComment())
+        .isNotice(post.isNotice())
+        .isSecret(post.isSecret())
+        .isTemp(post.isTemp())
+        .isLike(isLike)
+        .isDislike(isDislike)
+        .previousPost(previousPost != null ? AdjacentPostResponse.from(previousPost) : null)
+        .nextPost(nextPost != null ? AdjacentPostResponse.from(nextPost) : null)
+        .build();
+  }
+
+  public static PostDetailResponse of(Post post, boolean isLike, boolean isDislike, boolean isRead, Post previousPost,
       Post nextPost) {
     return PostDetailResponse.builder()
         .categoryId(post.getCategory().getId())
@@ -63,6 +90,7 @@ public class PostDetailResponse {
         .isTemp(post.isTemp())
         .isLike(isLike)
         .isDislike(isDislike)
+        .isRead(isRead)
         .previousPost(previousPost != null ? AdjacentPostResponse.from(previousPost) : null)
         .nextPost(nextPost != null ? AdjacentPostResponse.from(nextPost) : null)
         .build();

--- a/src/main/java/com/keeper/homepage/domain/post/dto/response/PostResponse.java
+++ b/src/main/java/com/keeper/homepage/domain/post/dto/response/PostResponse.java
@@ -24,6 +24,7 @@ public class PostResponse {
   private Boolean isSecret;
   private String thumbnailPath;
   private Integer likeCount;
+  private Integer fileCount;
 
   @JsonFormat(pattern = "yyyy-MM-dd")
   private LocalDateTime registerTime;
@@ -40,6 +41,23 @@ public class PostResponse {
         .isSecret(post.isSecret())
         .thumbnailPath(post.getThumbnailPath())
         .likeCount(post.getPostLikes().size())
+        .registerTime(post.getRegisterTime())
+        .build();
+  }
+
+  public static PostResponse of(Post post, int fileCount) {
+    return PostResponse.builder()
+        .id(post.getId())
+        .title(post.getTitle())
+        .writerId(post.getMember().getId())
+        .writerName(post.getWriterRealName())
+        .writerThumbnailPath(post.getMember().getThumbnailPath())
+        .visitCount(post.getVisitCount())
+        .commentCount(post.getComments().size())
+        .isSecret(post.isSecret())
+        .thumbnailPath(post.getThumbnailPath())
+        .likeCount(post.getPostLikes().size())
+        .fileCount(fileCount)
         .registerTime(post.getRegisterTime())
         .build();
   }

--- a/src/test/java/com/keeper/homepage/domain/post/api/PostApiTestHelper.java
+++ b/src/test/java/com/keeper/homepage/domain/post/api/PostApiTestHelper.java
@@ -156,6 +156,7 @@ public class PostApiTestHelper extends IntegrationTest {
         fieldWithPath("isSecret").description("비밀글 여부"),
         fieldWithPath("thumbnailPath").description("게시글 썸네일 주소").optional(),
         fieldWithPath("likeCount").description("게시글 좋아요 수"),
+        fieldWithPath("fileCount").description("게시글 파일 수 (시험 게시판에서만 응답)").optional(),
         fieldWithPath("registerTime").description("게시글 등록 시간")
     };
   }

--- a/src/test/java/com/keeper/homepage/domain/post/api/PostControllerTest.java
+++ b/src/test/java/com/keeper/homepage/domain/post/api/PostControllerTest.java
@@ -611,8 +611,8 @@ public class PostControllerTest extends PostApiTestHelper {
   }
 
   @Nested
-  @DisplayName("게시글 목록 조회")
-  class FindPosts {
+  @DisplayName("공지 게시글 목록 조회")
+  class FindNoticePosts {
 
     @BeforeEach
     void setUp() {
@@ -892,6 +892,7 @@ public class PostControllerTest extends PostApiTestHelper {
                   pageHelper(getTempPostsResponse())
               )));
     }
+
   }
 
   @Nested

--- a/src/test/java/com/keeper/homepage/domain/post/api/PostControllerTest.java
+++ b/src/test/java/com/keeper/homepage/domain/post/api/PostControllerTest.java
@@ -393,6 +393,7 @@ public class PostControllerTest extends PostApiTestHelper {
                   fieldWithPath("isTemp").description("임시 저장글 여부"),
                   fieldWithPath("isLike").description("좋아요 했는지 여부"),
                   fieldWithPath("isDislike").description("싫어요 했는지 여부"),
+                  fieldWithPath("isRead").description("게시글 열람 여부 (시험 게시판에서만 응답)"),
                   fieldWithPath("previousPost.postId").description("이전 게시글 ID"),
                   fieldWithPath("previousPost.title").description("이전 게시글 제목"),
                   fieldWithPath("nextPost.postId").description("다음 게시글 ID"),
@@ -650,6 +651,7 @@ public class PostControllerTest extends PostApiTestHelper {
                   fieldWithPath("posts[].isSecret").description("게시글 비밀글 여부"),
                   fieldWithPath("posts[].thumbnailPath").description("게시글 썸네일 주소").optional(),
                   fieldWithPath("posts[].likeCount").description("게시글 좋아요 수"),
+                  fieldWithPath("posts[].fileCount").description("게시글 파일 수 (시험 게시판에서만 응답)").optional(),
                   fieldWithPath("posts[].registerTime").description("게시글 작성 시간")
               )));
     }

--- a/src/test/java/com/keeper/homepage/domain/post/application/PostServiceTest.java
+++ b/src/test/java/com/keeper/homepage/domain/post/application/PostServiceTest.java
@@ -569,5 +569,18 @@ public class PostServiceTest extends IntegrationTest {
       assertThat(posts.getContent().stream().map(PostResponse::getId).toList()).contains(postId1);
       assertThat(posts.getContent().stream().map(PostResponse::getId).toList()).contains(postId2);
     }
+
+    @Test
+    @DisplayName("시험 게시글의 파일 개수 응답은 성공적으로 조회되어야 한다.")
+    public void 시험_게시글의_파일_개수_응답은_성공적으로_조회되어야_한다() throws Exception {
+      postId = postService.create(post, 시험게시판.getId(), thumbnail, List.of(thumbnail));
+      em.flush();
+      em.clear();
+
+      Page<PostResponse> posts = postService.getPosts(시험게시판.getId(), null, null, PageRequest.of(0, 5));
+
+      assertThat(posts).hasSize(1);
+      assertThat(posts.getContent().get(0).getFileCount()).isEqualTo(1);
+    }
   }
 }


### PR DESCRIPTION
## 🔥 Related Issue

> close: #없음

## 📝 Description

- 시험 게시판 목록 조회 응답으로 `fileCount` (첨부파일 개수) 추가
- 시험 게시글 조회 응답으로 `isRead` (열람 여부) 추가
- 본인 게시글의 첨부파일 조회 시에는 포인트 차감되지 않도록 수정

시험 게시글을 제외한 다른 카테고리 게시글의 `fileCount`, `isRead`는 null로 보냅니다.

## ⭐️ Review Request

> 리뷰어에게 전달하고 싶은 내용을 적어주세요.
