### PR TITLE
Feature/상벌점 기능 추가 및 버그 수정

### DIFF
--- a/src/docs/asciidoc/merit/merit.adoc
+++ b/src/docs/asciidoc/merit/merit.adoc
@@ -83,6 +83,24 @@ include::{snippets}/create-meritLog/request-fields.adoc[]
 
 include::{snippets}/create-meritLog/http-response.adoc[]
 
+== *상벌점 로그 삭제*
+
+=== 요청
+
+==== Request
+
+include::{snippets}/delete-merit-log/http-request.adoc[]
+
+==== Request Cookies
+
+include::{snippets}/delete-merit-log/request-cookies.adoc[]
+
+=== 응답
+
+==== Response
+
+include::{snippets}/delete-merit-log/http-response.adoc[]
+
 == *상벌점 타입 조회*
 
 === 요청

--- a/src/main/java/com/keeper/homepage/domain/merit/api/MeritController.java
+++ b/src/main/java/com/keeper/homepage/domain/merit/api/MeritController.java
@@ -23,6 +23,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -111,6 +112,12 @@ public class MeritController {
       @RequestParam(defaultValue = "10") @PositiveOrZero @Max(30) int size
   ) {
     return ResponseEntity.ok(meritLogRepository.findAllTotalMeritLogs(PageRequest.of(page, size)));
+  }
+
+  @DeleteMapping("/{meritLogId}")
+  public ResponseEntity<Void> deleteMeritLog(@PathVariable long meritLogId) {
+    meritLogService.deleteMeritLog(meritLogId);
+    return ResponseEntity.noContent().build();
   }
 
 }

--- a/src/main/java/com/keeper/homepage/domain/merit/api/MeritController.java
+++ b/src/main/java/com/keeper/homepage/domain/merit/api/MeritController.java
@@ -14,11 +14,13 @@ import com.keeper.homepage.domain.merit.dto.response.SearchMemberMeritLogRespons
 import com.keeper.homepage.domain.merit.dto.response.SearchMeritLogListResponse;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.PositiveOrZero;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;
@@ -58,11 +60,14 @@ public class MeritController {
   @GetMapping("/members/{memberId}")
   public ResponseEntity<Page<SearchMemberMeritLogResponse>> findMeritLogByMemberId(
       @PathVariable long memberId,
+      @RequestParam(defaultValue = "ASC") @Pattern(regexp = "^(ASC|DESC)$") String sort,
       @RequestParam(defaultValue = "0") @PositiveOrZero int page,
       @RequestParam(defaultValue = "10") @PositiveOrZero @Max(30) int size
   ) {
     return ResponseEntity.ok(
-        meritLogService.findAllByMemberId(PageRequest.of(page, size), memberId)
+        meritLogService.findAllByMemberId(
+                PageRequest.of(page, size,
+                    Sort.Direction.fromString(sort), "MeritType.merit"), memberId)
             .map(SearchMemberMeritLogResponse::from));
   }
 

--- a/src/main/java/com/keeper/homepage/domain/merit/api/MeritController.java
+++ b/src/main/java/com/keeper/homepage/domain/merit/api/MeritController.java
@@ -21,6 +21,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;
@@ -46,6 +47,14 @@ public class MeritController {
   private final MeritLogService meritLogService;
   private final MeritLogRepository meritLogRepository;
 
+  // 1. SearchMeritLogListResponse 수정 -> is_merit 컬럼 추가 -> 0
+  // 2. SearchMemberMeritLogResponse 수정 -> is_merit 컬럼 추가 -> 0
+  // 3. MeritTypeResponse 수정 -> is_merit 컬럼 추가 -> 0
+  // 4. AddMeritTypeRequest 수정 -> is_merit 컬럼 추가 -> 0
+  // 5. meritTypeService.addMeritType 수정 -> is_merit 컬럼도 DB에 밀어넣기 -> 0
+  // 6. UpdateMeritTypeRequest 수정 -> is_merit 컬럼 추가 -> 0
+  // 7. meritTypeService.updateMeritType 수정 -> is_merit 컬럼도 수정 ->
+
   @GetMapping
   public ResponseEntity<Page<SearchMeritLogListResponse>> searchMeritLogList(
       @RequestBody @Valid SearchMeritLogListRequest request,
@@ -68,7 +77,7 @@ public class MeritController {
     return ResponseEntity.ok(
         meritLogService.findAllByMemberId(
                 PageRequest.of(page, size,
-                    Sort.Direction.fromString(sort), "MeritType.merit"), memberId)
+                    Direction.fromString(sort), "MeritType.merit"), memberId)
             .map(SearchMemberMeritLogResponse::from));
   }
 
@@ -95,7 +104,7 @@ public class MeritController {
   public ResponseEntity<Void> registerMeritType(
       @RequestBody @Valid AddMeritTypeRequest request
   ) {
-    meritTypeService.addMeritType(request.getScore(), request.getReason());
+    meritTypeService.addMeritType(request.getScore(), request.getReason(), request.getIsMerit());
     return ResponseEntity.status(HttpStatus.CREATED).build();
   }
 
@@ -106,7 +115,8 @@ public class MeritController {
     meritTypeService.updateMeritType(
         meritTypeId,
         request.getScore(),
-        request.getReason());
+        request.getReason(),
+        request.getIsMerit());
     return ResponseEntity.status(HttpStatus.CREATED)
         .location(URI.create("/merits/types/" + meritTypeId))
         .build();

--- a/src/main/java/com/keeper/homepage/domain/merit/api/MeritController.java
+++ b/src/main/java/com/keeper/homepage/domain/merit/api/MeritController.java
@@ -6,6 +6,7 @@ import com.keeper.homepage.domain.merit.application.MeritTypeService;
 import com.keeper.homepage.domain.merit.dao.MeritLogRepository;
 import com.keeper.homepage.domain.merit.dto.request.AddMeritTypeRequest;
 import com.keeper.homepage.domain.merit.dto.request.GiveMeritPointRequest;
+import com.keeper.homepage.domain.merit.dto.request.SearchMeritLogListRequest;
 import com.keeper.homepage.domain.merit.dto.request.UpdateMeritTypeRequest;
 import com.keeper.homepage.domain.merit.dto.response.MeritLogsGroupByMemberResponse;
 import com.keeper.homepage.domain.merit.dto.response.MeritTypeResponse;
@@ -21,6 +22,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -30,6 +32,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@Validated
 @RestController
 @RequestMapping("/merits")
 @RequiredArgsConstructor
@@ -42,11 +45,12 @@ public class MeritController {
 
   @GetMapping
   public ResponseEntity<Page<SearchMeritLogListResponse>> searchMeritLogList(
+      @RequestBody @Valid SearchMeritLogListRequest request,
       @RequestParam(defaultValue = "0") @PositiveOrZero int page,
       @RequestParam(defaultValue = "10") @PositiveOrZero @Max(30) int size
   ) {
     return ResponseEntity
-        .ok(meritLogService.findAll(PageRequest.of(page, size))
+        .ok(meritLogService.findAllByMeritType(PageRequest.of(page, size), request.getMeritType())
             .map(SearchMeritLogListResponse::from));
   }
 

--- a/src/main/java/com/keeper/homepage/domain/merit/api/MeritController.java
+++ b/src/main/java/com/keeper/homepage/domain/merit/api/MeritController.java
@@ -60,7 +60,7 @@ public class MeritController {
   @GetMapping("/members/{memberId}")
   public ResponseEntity<Page<SearchMemberMeritLogResponse>> findMeritLogByMemberId(
       @PathVariable long memberId,
-      @RequestParam(defaultValue = "ASC") @Pattern(regexp = "^(ASC|DESC)$") String sort,
+      @RequestParam(defaultValue = "DESC") @Pattern(regexp = "^(ASC|DESC)$") String sort,
       @RequestParam(defaultValue = "0") @PositiveOrZero int page,
       @RequestParam(defaultValue = "10") @PositiveOrZero @Max(30) int size
   ) {

--- a/src/main/java/com/keeper/homepage/domain/merit/api/MeritController.java
+++ b/src/main/java/com/keeper/homepage/domain/merit/api/MeritController.java
@@ -60,7 +60,8 @@ public class MeritController {
   @GetMapping("/members/{memberId}")
   public ResponseEntity<Page<SearchMemberMeritLogResponse>> findMeritLogByMemberId(
       @PathVariable long memberId,
-      @RequestParam(defaultValue = "DESC") @Pattern(regexp = "^(ASC|DESC)$") String sort,
+      @RequestParam(defaultValue = "DESC")
+      @Pattern(regexp = "^(ASC|DESC)$", message = "올바른 정렬 타입을 입력해주세요.") String sort,
       @RequestParam(defaultValue = "0") @PositiveOrZero int page,
       @RequestParam(defaultValue = "10") @PositiveOrZero @Max(30) int size
   ) {

--- a/src/main/java/com/keeper/homepage/domain/merit/application/MeritLogService.java
+++ b/src/main/java/com/keeper/homepage/domain/merit/application/MeritLogService.java
@@ -69,8 +69,12 @@ public class MeritLogService {
         .build());
   }
 
-  public Page<MeritLog> findAll(Pageable pageable) {
-    return meritLogRepository.findAll(pageable);
+  public Page<MeritLog> findAllByMeritType(Pageable pageable, String meritType) {
+    return switch (meritType) {
+      case "MERIT" -> meritLogRepository.findMeritLogs(pageable);
+      case "DEMERIT" -> meritLogRepository.findDeMeritLogs(pageable);
+      default -> meritLogRepository.findAll(pageable);
+    };
   }
 
   public Page<MeritLog> findAllByMemberId(Pageable pageable, long memberId) {

--- a/src/main/java/com/keeper/homepage/domain/merit/application/MeritLogService.java
+++ b/src/main/java/com/keeper/homepage/domain/merit/application/MeritLogService.java
@@ -83,6 +83,7 @@ public class MeritLogService {
     return meritLogRepository.findAllByMemberId(pageable, findMemberId);
   }
 
+  @Transactional
   public void deleteMeritLog(long meritLogId) {
     meritLogRepository.findById(meritLogId)
         .orElseThrow(() -> new BusinessException(meritLogId, "meritLogId", MERIT_LOG_NOT_FOUND));

--- a/src/main/java/com/keeper/homepage/domain/merit/application/MeritLogService.java
+++ b/src/main/java/com/keeper/homepage/domain/merit/application/MeritLogService.java
@@ -1,6 +1,7 @@
 package com.keeper.homepage.domain.merit.application;
 
 
+import static com.keeper.homepage.global.error.ErrorCode.MERIT_LOG_NOT_FOUND;
 import static com.keeper.homepage.global.error.ErrorCode.MERIT_TYPE_NOT_FOUND;
 
 import com.keeper.homepage.domain.member.application.convenience.MemberFindService;
@@ -82,4 +83,10 @@ public class MeritLogService {
     return meritLogRepository.findAllByMemberId(pageable, findMemberId);
   }
 
+  public void deleteMeritLog(long meritLogId) {
+    meritLogRepository.findById(meritLogId)
+        .orElseThrow(() -> new BusinessException(meritLogId, "meritLogId", MERIT_LOG_NOT_FOUND));
+
+    meritLogRepository.deleteById(meritLogId);
+  }
 }

--- a/src/main/java/com/keeper/homepage/domain/merit/application/MeritTypeService.java
+++ b/src/main/java/com/keeper/homepage/domain/merit/application/MeritTypeService.java
@@ -6,6 +6,7 @@ import static com.keeper.homepage.global.error.ErrorCode.MERIT_TYPE_NOT_FOUND;
 import com.keeper.homepage.domain.merit.dao.MeritTypeRepository;
 import com.keeper.homepage.domain.merit.entity.MeritType;
 import com.keeper.homepage.global.error.BusinessException;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -48,12 +49,12 @@ public class MeritTypeService {
   }
 
   private void checkDuplicateMeritTypeDetail(String reason, long meritTypeId) {
-    Long findMeritTypeId = meritTypeRepository.findByDetail(reason)
-        .orElseThrow()
-        .getId();
-
-    if (findMeritTypeId != meritTypeId) {
-      throw new BusinessException(reason, "Detail", MERIT_TYPE_DETAIL_DUPLICATE);
-    }
+    meritTypeRepository.findByDetail(reason)
+        .ifPresent(meritType -> {
+          if (meritType.getId() != meritTypeId) {
+            throw new BusinessException(reason, "Detail", MERIT_TYPE_DETAIL_DUPLICATE);
+          }
+        });
   }
 }
+

--- a/src/main/java/com/keeper/homepage/domain/merit/application/MeritTypeService.java
+++ b/src/main/java/com/keeper/homepage/domain/merit/application/MeritTypeService.java
@@ -22,7 +22,6 @@ public class MeritTypeService {
   @Transactional
   public Long addMeritType(int score, String reason) {
     checkDuplicateMeritTypeDetail(reason);
-
     return meritTypeRepository.save(MeritType.builder()
         .merit(score)
         .detail(reason)
@@ -42,9 +41,19 @@ public class MeritTypeService {
 
   @Transactional
   public void updateMeritType(long meritTypeId, int score, String reason) {
-    checkDuplicateMeritTypeDetail(reason);
     MeritType meritType = meritTypeRepository.findById(meritTypeId)
         .orElseThrow(() -> new BusinessException(meritTypeId, "meritType", MERIT_TYPE_NOT_FOUND));
+    checkDuplicateMeritTypeDetail(reason, meritTypeId);
     meritType.update(score, reason);
+  }
+
+  private void checkDuplicateMeritTypeDetail(String reason, long meritTypeId) {
+    Long findMeritTypeId = meritTypeRepository.findByDetail(reason)
+        .orElseThrow()
+        .getId();
+
+    if (findMeritTypeId != meritTypeId) {
+      throw new BusinessException(reason, "Detail", MERIT_TYPE_DETAIL_DUPLICATE);
+    }
   }
 }

--- a/src/main/java/com/keeper/homepage/domain/merit/application/MeritTypeService.java
+++ b/src/main/java/com/keeper/homepage/domain/merit/application/MeritTypeService.java
@@ -21,11 +21,12 @@ public class MeritTypeService {
   private final MeritTypeRepository meritTypeRepository;
 
   @Transactional
-  public Long addMeritType(int score, String reason) {
+  public Long addMeritType(int score, String reason, boolean isMerit) {
     checkDuplicateMeritTypeDetail(reason);
     return meritTypeRepository.save(MeritType.builder()
         .merit(score)
         .detail(reason)
+        .isMerit(isMerit)
         .build()).getId();
   }
 
@@ -41,11 +42,11 @@ public class MeritTypeService {
   }
 
   @Transactional
-  public void updateMeritType(long meritTypeId, int score, String reason) {
+  public void updateMeritType(long meritTypeId, int score, String reason, boolean isMerit) {
     MeritType meritType = meritTypeRepository.findById(meritTypeId)
         .orElseThrow(() -> new BusinessException(meritTypeId, "meritType", MERIT_TYPE_NOT_FOUND));
     checkDuplicateMeritTypeDetail(reason, meritType.getId());
-    meritType.update(score, reason);
+    meritType.update(score, reason, isMerit);
   }
 
   private void checkDuplicateMeritTypeDetail(String reason, long meritTypeId) {

--- a/src/main/java/com/keeper/homepage/domain/merit/application/MeritTypeService.java
+++ b/src/main/java/com/keeper/homepage/domain/merit/application/MeritTypeService.java
@@ -43,7 +43,7 @@ public class MeritTypeService {
   public void updateMeritType(long meritTypeId, int score, String reason) {
     MeritType meritType = meritTypeRepository.findById(meritTypeId)
         .orElseThrow(() -> new BusinessException(meritTypeId, "meritType", MERIT_TYPE_NOT_FOUND));
-    checkDuplicateMeritTypeDetail(reason, meritTypeId);
+    checkDuplicateMeritTypeDetail(reason, meritType.getId());
     meritType.update(score, reason);
   }
 

--- a/src/main/java/com/keeper/homepage/domain/merit/dao/MeritLogRepository.java
+++ b/src/main/java/com/keeper/homepage/domain/merit/dao/MeritLogRepository.java
@@ -23,4 +23,10 @@ public interface MeritLogRepository extends JpaRepository<MeritLog, Long> {
       "CAST(SUM(CASE WHEN m.meritType.merit < 0 THEN m.meritType.merit ELSE 0 END) AS INTEGER)) " +
       "FROM MeritLog m GROUP BY m.memberId, m.memberRealName, m.memberGeneration")
   Page<MeritLogsGroupByMemberResponse> findAllTotalMeritLogs(Pageable pageable);
+
+  @Query("SELECT m FROM MeritLog m WHERE m.meritType.merit > 0")
+  Page<MeritLog> findMeritLogs(Pageable pageable);
+
+  @Query("SELECT m FROM MeritLog m WHERE m.meritType.merit < 0")
+  Page<MeritLog> findDeMeritLogs(Pageable pageable);
 }

--- a/src/main/java/com/keeper/homepage/domain/merit/dao/MeritLogRepository.java
+++ b/src/main/java/com/keeper/homepage/domain/merit/dao/MeritLogRepository.java
@@ -19,10 +19,10 @@ public interface MeritLogRepository extends JpaRepository<MeritLog, Long> {
   long countByMemberId(long memberId);
 
   @Query(
-      "SELECT NEW com.keeper.homepage.domain.merit.dto.response.MeritLogsGroupByMemberResponse(m.memberId, m.memberRealName, m.memberGeneration, m.meritType.isMerit, " +
-          "CAST(SUM(CASE WHEN m.meritType.merit > 0 THEN m.meritType.merit ELSE 0 END) AS INTEGER), " +
-          "CAST(SUM(CASE WHEN m.meritType.merit < 0 THEN m.meritType.merit ELSE 0 END) AS INTEGER)) " +
-          "FROM MeritLog m GROUP BY m.memberId, m.memberRealName, m.memberGeneration, m.meritType.isMerit")
+      "SELECT NEW com.keeper.homepage.domain.merit.dto.response.MeritLogsGroupByMemberResponse(m.memberId, m.memberRealName, m.memberGeneration, " +
+          "CAST(SUM(CASE WHEN m.meritType.isMerit = true THEN m.meritType.merit ELSE 0 END) AS INTEGER), " +
+          "CAST(SUM(CASE WHEN m.meritType.isMerit = false THEN m.meritType.merit ELSE 0 END) AS INTEGER)) " +
+          "FROM MeritLog m GROUP BY m.memberId, m.memberRealName, m.memberGeneration")
   Page<MeritLogsGroupByMemberResponse> findAllTotalMeritLogs(Pageable pageable);
 
   @Query("SELECT m FROM MeritLog m WHERE m.meritType.merit > 0")

--- a/src/main/java/com/keeper/homepage/domain/merit/dao/MeritLogRepository.java
+++ b/src/main/java/com/keeper/homepage/domain/merit/dao/MeritLogRepository.java
@@ -18,10 +18,11 @@ public interface MeritLogRepository extends JpaRepository<MeritLog, Long> {
 
   long countByMemberId(long memberId);
 
-  @Query("SELECT NEW com.keeper.homepage.domain.merit.dto.response.MeritLogsGroupByMemberResponse(m.memberId, m.memberRealName, m.memberGeneration, " +
-      "CAST(SUM(CASE WHEN m.meritType.merit > 0 THEN m.meritType.merit ELSE 0 END) AS INTEGER), " +
-      "CAST(SUM(CASE WHEN m.meritType.merit < 0 THEN m.meritType.merit ELSE 0 END) AS INTEGER)) " +
-      "FROM MeritLog m GROUP BY m.memberId, m.memberRealName, m.memberGeneration")
+  @Query(
+      "SELECT NEW com.keeper.homepage.domain.merit.dto.response.MeritLogsGroupByMemberResponse(m.memberId, m.memberRealName, m.memberGeneration, m.meritType.isMerit, " +
+          "CAST(SUM(CASE WHEN m.meritType.merit > 0 THEN m.meritType.merit ELSE 0 END) AS INTEGER), " +
+          "CAST(SUM(CASE WHEN m.meritType.merit < 0 THEN m.meritType.merit ELSE 0 END) AS INTEGER)) " +
+          "FROM MeritLog m GROUP BY m.memberId, m.memberRealName, m.memberGeneration, m.meritType.isMerit")
   Page<MeritLogsGroupByMemberResponse> findAllTotalMeritLogs(Pageable pageable);
 
   @Query("SELECT m FROM MeritLog m WHERE m.meritType.merit > 0")

--- a/src/main/java/com/keeper/homepage/domain/merit/dto/request/AddMeritTypeRequest.java
+++ b/src/main/java/com/keeper/homepage/domain/merit/dto/request/AddMeritTypeRequest.java
@@ -19,13 +19,17 @@ public class AddMeritTypeRequest {
   @NotNull(message = "상벌점 점수를 입력해주세요.")
   private Integer score;
 
-  @NotEmpty(message = "상벌점 타입에 대해서 입력해주세요.")
+  @NotEmpty(message = "상벌점 사유에 대해서 입력해주세요.")
   private String reason;
+
+  @NotNull(message = "상벌점 타입에 대해서 입력해주세요.")
+  private Boolean isMerit;
 
   public AddMeritTypeRequest from(MeritType meritType) {
     return AddMeritTypeRequest.builder()
         .score(meritType.getMerit())
         .reason(meritType.getDetail())
+        .isMerit(meritType.getIsMerit())
         .build();
   }
 

--- a/src/main/java/com/keeper/homepage/domain/merit/dto/request/SearchMeritLogListRequest.java
+++ b/src/main/java/com/keeper/homepage/domain/merit/dto/request/SearchMeritLogListRequest.java
@@ -1,0 +1,25 @@
+package com.keeper.homepage.domain.merit.dto.request;
+
+import static lombok.AccessLevel.*;
+
+import com.keeper.homepage.domain.merit.entity.MeritLog;
+import jakarta.validation.constraints.Pattern;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = PRIVATE)
+@AllArgsConstructor(access = PRIVATE)
+public class SearchMeritLogListRequest {
+
+  @Pattern(regexp = "^(MERIT|DEMERIT|ALL)$", message = "조회 타입을 올바르게 입력해주세요.")
+  private String meritType;
+
+  public static SearchMeritLogListRequest from(String meritType) {
+    return new SearchMeritLogListRequest(meritType);
+  }
+
+}

--- a/src/main/java/com/keeper/homepage/domain/merit/dto/request/UpdateMeritTypeRequest.java
+++ b/src/main/java/com/keeper/homepage/domain/merit/dto/request/UpdateMeritTypeRequest.java
@@ -20,10 +20,14 @@ public class UpdateMeritTypeRequest {
   @NotEmpty(message = "변경할 사유에 대해서 입력해주세요.")
   private String reason;
 
+  @NotNull(message = "변경할 상벌점 타입에 대해서 입력해주세요.")
+  private Boolean isMerit;
+
   public UpdateMeritTypeRequest toEntity() {
     return UpdateMeritTypeRequest.builder()
         .score(score)
         .reason(reason)
+        .isMerit(isMerit)
         .build();
   }
 

--- a/src/main/java/com/keeper/homepage/domain/merit/dto/response/MeritLogsGroupByMemberResponse.java
+++ b/src/main/java/com/keeper/homepage/domain/merit/dto/response/MeritLogsGroupByMemberResponse.java
@@ -10,16 +10,14 @@ public class MeritLogsGroupByMemberResponse {
   private String generation;
   private Integer merit;
   private Integer demerit;
-  private Boolean isMerit;
 
   public MeritLogsGroupByMemberResponse(Long memberId, String memberName, String generation,
-      Boolean isMerit, Integer merit, Integer demerit) {
+      Integer merit, Integer demerit) {
     this.memberId = memberId;
     this.memberName = memberName;
     this.generation = generation;
     this.merit = merit;
     this.demerit = demerit;
-    this.isMerit = isMerit;
   }
 
 }

--- a/src/main/java/com/keeper/homepage/domain/merit/dto/response/MeritLogsGroupByMemberResponse.java
+++ b/src/main/java/com/keeper/homepage/domain/merit/dto/response/MeritLogsGroupByMemberResponse.java
@@ -10,14 +10,16 @@ public class MeritLogsGroupByMemberResponse {
   private String generation;
   private Integer merit;
   private Integer demerit;
+  private Boolean isMerit;
 
   public MeritLogsGroupByMemberResponse(Long memberId, String memberName, String generation,
-      Integer merit, Integer demerit) {
+      Boolean isMerit, Integer merit, Integer demerit) {
     this.memberId = memberId;
     this.memberName = memberName;
     this.generation = generation;
     this.merit = merit;
     this.demerit = demerit;
+    this.isMerit = isMerit;
   }
 
 }

--- a/src/main/java/com/keeper/homepage/domain/merit/dto/response/MeritTypeResponse.java
+++ b/src/main/java/com/keeper/homepage/domain/merit/dto/response/MeritTypeResponse.java
@@ -14,7 +14,7 @@ public class MeritTypeResponse {
   private long id;
   private int score;
   private String detail;
-  private boolean isMerit;
+  private Boolean isMerit;
 
   public static MeritTypeResponse from(MeritType meritType) {
     return MeritTypeResponse.builder()

--- a/src/main/java/com/keeper/homepage/domain/merit/dto/response/MeritTypeResponse.java
+++ b/src/main/java/com/keeper/homepage/domain/merit/dto/response/MeritTypeResponse.java
@@ -14,12 +14,14 @@ public class MeritTypeResponse {
   private long id;
   private int score;
   private String detail;
+  private boolean isMerit;
 
   public static MeritTypeResponse from(MeritType meritType) {
     return MeritTypeResponse.builder()
         .id(meritType.getId())
         .score(meritType.getMerit())
         .detail(meritType.getDetail())
+        .isMerit(meritType.getIsMerit())
         .build();
   }
 

--- a/src/main/java/com/keeper/homepage/domain/merit/dto/response/SearchMemberMeritLogResponse.java
+++ b/src/main/java/com/keeper/homepage/domain/merit/dto/response/SearchMemberMeritLogResponse.java
@@ -18,7 +18,7 @@ public class SearchMemberMeritLogResponse {
   private LocalDateTime giveTime;
   private int score;
   private long meritTypeId;
-  private boolean isMerit;
+  private Boolean isMerit;
   private String reason;
 
   public static SearchMemberMeritLogResponse from(MeritLog meritLog) {

--- a/src/main/java/com/keeper/homepage/domain/merit/dto/response/SearchMemberMeritLogResponse.java
+++ b/src/main/java/com/keeper/homepage/domain/merit/dto/response/SearchMemberMeritLogResponse.java
@@ -18,6 +18,7 @@ public class SearchMemberMeritLogResponse {
   private LocalDateTime giveTime;
   private int score;
   private long meritTypeId;
+  private boolean isMerit;
   private String reason;
 
   public static SearchMemberMeritLogResponse from(MeritLog meritLog) {
@@ -26,6 +27,7 @@ public class SearchMemberMeritLogResponse {
         .giveTime(meritLog.getTime())
         .score(meritLog.getMeritType().getMerit())
         .meritTypeId(meritLog.getMeritType().getId())
+        .isMerit(meritLog.getMeritType().getIsMerit())
         .reason(meritLog.getMeritType().getDetail())
         .build();
   }

--- a/src/main/java/com/keeper/homepage/domain/merit/dto/response/SearchMeritLogListResponse.java
+++ b/src/main/java/com/keeper/homepage/domain/merit/dto/response/SearchMeritLogListResponse.java
@@ -21,6 +21,7 @@ public class SearchMeritLogListResponse {
   private String awarderGeneration;
   private int score;
   private long meritTypeId;
+  private boolean isMerit;
   private String reason;
 
   public static SearchMeritLogListResponse from(MeritLog meritLog) {
@@ -31,6 +32,7 @@ public class SearchMeritLogListResponse {
         .awarderGeneration(meritLog.getMemberGeneration())
         .score(meritLog.getMeritType().getMerit())
         .meritTypeId(meritLog.getMeritType().getId())
+        .isMerit(meritLog.getMeritType().getIsMerit())
         .reason(meritLog.getMeritType().getDetail())
         .build();
   }

--- a/src/main/java/com/keeper/homepage/domain/merit/dto/response/SearchMeritLogListResponse.java
+++ b/src/main/java/com/keeper/homepage/domain/merit/dto/response/SearchMeritLogListResponse.java
@@ -21,7 +21,7 @@ public class SearchMeritLogListResponse {
   private String awarderGeneration;
   private int score;
   private long meritTypeId;
-  private boolean isMerit;
+  private Boolean isMerit;
   private String reason;
 
   public static SearchMeritLogListResponse from(MeritLog meritLog) {

--- a/src/main/java/com/keeper/homepage/domain/merit/entity/MeritType.java
+++ b/src/main/java/com/keeper/homepage/domain/merit/entity/MeritType.java
@@ -25,17 +25,18 @@ public class MeritType {
   private String detail;
 
   @Column(name = "is_merit", nullable = false)
-  private boolean is_merit;
+  private Boolean isMerit;
 
   @Builder
-  public MeritType(Integer merit, String detail, boolean is_merit) {
+  public MeritType(Integer merit, String detail, boolean isMerit) {
     this.merit = merit;
     this.detail = detail;
-    this.is_merit = is_merit;
+    this.isMerit = isMerit;
   }
 
-  public void update(Integer score, String reason) {
+  public void update(Integer score, String reason, boolean isMerit) {
     this.merit = score;
     this.detail = reason;
+    this.isMerit = isMerit;
   }
 }

--- a/src/main/java/com/keeper/homepage/domain/merit/entity/MeritType.java
+++ b/src/main/java/com/keeper/homepage/domain/merit/entity/MeritType.java
@@ -24,10 +24,14 @@ public class MeritType {
   @Column(name = "detail", nullable = false)
   private String detail;
 
+  @Column(name = "is_merit", nullable = false)
+  private boolean is_merit;
+
   @Builder
-  public MeritType(Integer merit, String detail) {
+  public MeritType(Integer merit, String detail, boolean is_merit) {
     this.merit = merit;
     this.detail = detail;
+    this.is_merit = is_merit;
   }
 
   public void update(Integer score, String reason) {

--- a/src/main/java/com/keeper/homepage/global/error/ErrorCode.java
+++ b/src/main/java/com/keeper/homepage/global/error/ErrorCode.java
@@ -88,6 +88,7 @@ public enum ErrorCode {
   // MERIT
   MERIT_TYPE_NOT_FOUND("해당 상벌점 타입을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
   MERIT_TYPE_DETAIL_DUPLICATE("해당 상벌점 타입의 사유가 존재합니다.", HttpStatus.CONFLICT),
+  MERIT_LOG_NOT_FOUND("해당 상벌점 내역을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
   // ELECTION
   ELECTION_NOT_FOUND("존재하지 않는 선거입니다.", HttpStatus.NOT_FOUND),
   ELECTION_CANNOT_DELETE("비공개 상태 선거만 삭제 가능합니다.", HttpStatus.BAD_REQUEST),

--- a/src/test/java/com/keeper/homepage/domain/merit/MeritTypeHelper.java
+++ b/src/test/java/com/keeper/homepage/domain/merit/MeritTypeHelper.java
@@ -24,6 +24,7 @@ public class MeritTypeHelper {
 
     private Integer merit;
     private String detail;
+    private Boolean isMerit;
 
     private MeritTypeBuilder() {
     }
@@ -38,9 +39,15 @@ public class MeritTypeHelper {
       return this;
     }
 
+    public MeritTypeBuilder isMerit(boolean isMerit) {
+      this.isMerit = isMerit;
+      return this;
+    }
+
     public MeritType build() {
       return meritTypeRepository.save(MeritType.builder()
           .merit(merit != null ? merit : 3)
+          .isMerit(isMerit != null ? isMerit : true)
           .detail(detail != null ? detail : UUID.randomUUID().toString())
           .build());
     }

--- a/src/test/java/com/keeper/homepage/domain/merit/api/MeritApiTestHelper.java
+++ b/src/test/java/com/keeper/homepage/domain/merit/api/MeritApiTestHelper.java
@@ -47,6 +47,7 @@ public class MeritApiTestHelper extends IntegrationTest {
         fieldWithPath("memberId").description("회원의 ID"),
         fieldWithPath("memberName").description("회원의 이름"),
         fieldWithPath("generation").description("회원의 기수"),
+        fieldWithPath("isMerit").description("상벌점 타입"),
         fieldWithPath("merit").description("상점"),
         fieldWithPath("demerit").description("벌점")
     };

--- a/src/test/java/com/keeper/homepage/domain/merit/api/MeritApiTestHelper.java
+++ b/src/test/java/com/keeper/homepage/domain/merit/api/MeritApiTestHelper.java
@@ -15,7 +15,8 @@ public class MeritApiTestHelper extends IntegrationTest {
         fieldWithPath("awarderGeneration").description("수상자의 학번"),
         fieldWithPath("score").description("상벌점 점수"),
         fieldWithPath("meritTypeId").description("상벌점 타입의 ID"),
-        fieldWithPath("reason").description("상벌점의 사유")
+        fieldWithPath("reason").description("상벌점의 사유"),
+        fieldWithPath("isMerit").description("상벌점 타입")
     };
   }
 
@@ -26,7 +27,8 @@ public class MeritApiTestHelper extends IntegrationTest {
         fieldWithPath("giveTime").description("상벌점 로그의 생성시간"),
         fieldWithPath("score").description("상벌점 점수"),
         fieldWithPath("meritTypeId").description("상벌점 타입의 ID"),
-        fieldWithPath("reason").description("상벌점의 사유")
+        fieldWithPath("reason").description("상벌점의 사유"),
+        fieldWithPath("isMerit").description("상벌점 타입")
     };
   }
 
@@ -35,7 +37,8 @@ public class MeritApiTestHelper extends IntegrationTest {
     return new FieldDescriptor[]{
         fieldWithPath("id").description("상벌점 타입의 ID"),
         fieldWithPath("score").description("상벌점 점수"),
-        fieldWithPath("detail").description("상벌점의 사유")
+        fieldWithPath("detail").description("상벌점의 사유"),
+        fieldWithPath("isMerit").description("상벌점 타입")
     };
   }
 

--- a/src/test/java/com/keeper/homepage/domain/merit/api/MeritApiTestHelper.java
+++ b/src/test/java/com/keeper/homepage/domain/merit/api/MeritApiTestHelper.java
@@ -47,7 +47,6 @@ public class MeritApiTestHelper extends IntegrationTest {
         fieldWithPath("memberId").description("회원의 ID"),
         fieldWithPath("memberName").description("회원의 이름"),
         fieldWithPath("generation").description("회원의 기수"),
-        fieldWithPath("isMerit").description("상벌점 타입"),
         fieldWithPath("merit").description("상점"),
         fieldWithPath("demerit").description("벌점")
     };

--- a/src/test/java/com/keeper/homepage/domain/merit/api/MeritControllerTest.java
+++ b/src/test/java/com/keeper/homepage/domain/merit/api/MeritControllerTest.java
@@ -186,7 +186,25 @@ public class MeritControllerTest extends MeritApiTestHelper {
     @DisplayName("회원별 상벌점 목록 조회를 성공해야 한다.")
     void 회원별_상벌점_목록_조회를_성공해야_한다() throws Exception {
       String securedValue = getSecuredValue(MeritController.class, "findMeritLogByMemberId");
-      meritLogTestHelper.builder().memberId(member.getId()).build();
+      meritLogTestHelper.builder()
+          .memberId(member.getId())
+          .meritType(meritTypeHelper.builder().merit(3).build())
+          .build();
+
+      meritLogTestHelper.builder()
+          .memberId(member.getId())
+          .meritType(meritTypeHelper.builder().merit(2).build())
+          .build();
+
+      meritLogTestHelper.builder()
+          .memberId(member.getId())
+          .meritType(meritTypeHelper.builder().merit(-1).build())
+          .build();
+
+      meritLogTestHelper.builder()
+          .memberId(member.getId())
+          .meritType(meritTypeHelper.builder().merit(-3).build())
+          .build();
 
       mockMvc.perform(
               get("/merits/members/{memberId}", member.getId())
@@ -246,7 +264,6 @@ public class MeritControllerTest extends MeritApiTestHelper {
     @DisplayName("일반회원은 상벌점 목록 조회를 할 수 없다.")
     void 일반회원은_상벌점_목록_조회를_할_수_없다() throws Exception {
       SearchMeritLogListRequest request = SearchMeritLogListRequest.from("ALL");
-
       mockMvc.perform(get("/merits")
               .cookie(new Cookie(ACCESS_TOKEN.getTokenName(), userAccessToken))
               .contentType(MediaType.APPLICATION_JSON)
@@ -255,11 +272,9 @@ public class MeritControllerTest extends MeritApiTestHelper {
           .andExpect(jsonPath("$.message").exists());
     }
 
-
     @Test
     @DisplayName("상벌점 부여 로그 생성을 성공해야 한다.")
     void 상벌점_부여_로그_생성을_성공해야_한다() throws Exception {
-
       String securedValue = getSecuredValue(MeritController.class, "registerMerit");
       GiveMeritPointRequest request = GiveMeritPointRequest.builder()
           .awarderId(member.getId())

--- a/src/test/java/com/keeper/homepage/domain/merit/api/MeritControllerTest.java
+++ b/src/test/java/com/keeper/homepage/domain/merit/api/MeritControllerTest.java
@@ -26,6 +26,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.keeper.homepage.domain.member.entity.Member;
 import com.keeper.homepage.domain.merit.dto.request.AddMeritTypeRequest;
 import com.keeper.homepage.domain.merit.dto.request.GiveMeritPointRequest;
+import com.keeper.homepage.domain.merit.dto.request.SearchMeritLogListRequest;
 import com.keeper.homepage.domain.merit.dto.request.UpdateMeritTypeRequest;
 import com.keeper.homepage.domain.merit.entity.MeritType;
 import io.jsonwebtoken.io.IOException;
@@ -222,9 +223,12 @@ public class MeritControllerTest extends MeritApiTestHelper {
     @DisplayName("상벌점 목록 조회를 성공해야 한다.")
     void 상벌점_목록_조회를_성공해야_한다() throws Exception {
       String securedValue = getSecuredValue(MeritController.class, "searchMeritLogList");
+      SearchMeritLogListRequest request = SearchMeritLogListRequest.from("ALL");
 
       mockMvc.perform(get("/merits")
-              .cookie(new Cookie(ACCESS_TOKEN.getTokenName(), adminAccessToken)))
+              .cookie(new Cookie(ACCESS_TOKEN.getTokenName(), adminAccessToken))
+              .contentType(MediaType.APPLICATION_JSON)
+              .content(asJsonString(request)))
           .andExpect(status().isOk())
           .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8))
           .andDo(document("search-meritLog",
@@ -240,8 +244,12 @@ public class MeritControllerTest extends MeritApiTestHelper {
     @Test
     @DisplayName("일반회원은 상벌점 목록 조회를 할 수 없다.")
     void 일반회원은_상벌점_목록_조회를_할_수_없다() throws Exception {
+      SearchMeritLogListRequest request = SearchMeritLogListRequest.from("ALL");
+
       mockMvc.perform(get("/merits")
-              .cookie(new Cookie(ACCESS_TOKEN.getTokenName(), userAccessToken)))
+              .cookie(new Cookie(ACCESS_TOKEN.getTokenName(), userAccessToken))
+              .contentType(MediaType.APPLICATION_JSON)
+              .content(asJsonString(request)))
           .andExpect(status().isForbidden())
           .andExpect(jsonPath("$.message").exists());
     }

--- a/src/test/java/com/keeper/homepage/domain/merit/api/MeritControllerTest.java
+++ b/src/test/java/com/keeper/homepage/domain/merit/api/MeritControllerTest.java
@@ -19,6 +19,7 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.requestF
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -363,4 +364,32 @@ public class MeritControllerTest extends MeritApiTestHelper {
     }
 
   }
+
+  @Nested
+  @DisplayName("상벌점 내역 삭제 테스트")
+  class DeleteMeritLogTest {
+
+    long meritLogId;
+
+    @BeforeEach
+    void setUp() {
+      meritLogId = meritLogTestHelper.generate().getId();
+    }
+
+    @Test
+    @DisplayName("상벌점 내역 삭제를 성공해야 한다.")
+    public void 상벌점_내역_삭제를_성공해야_한다() throws Exception {
+      String securedValue = getSecuredValue(MeritController.class, "deleteMeritLog");
+
+      mockMvc.perform(delete("/merits/{meritLogId}", meritLogId)
+              .cookie(new Cookie(ACCESS_TOKEN.getTokenName(), adminAccessToken)))
+          .andExpect(status().isNoContent())
+          .andDo(document("delete-merit-log",
+              requestCookies(
+                  cookieWithName(ACCESS_TOKEN.getTokenName())
+                      .description("ACCESS TOKEN %s".formatted(securedValue))
+              )));
+    }
+  }
+
 }

--- a/src/test/java/com/keeper/homepage/domain/merit/api/MeritControllerTest.java
+++ b/src/test/java/com/keeper/homepage/domain/merit/api/MeritControllerTest.java
@@ -96,6 +96,7 @@ public class MeritControllerTest extends MeritApiTestHelper {
       AddMeritTypeRequest request = AddMeritTypeRequest.builder()
           .score(3)
           .reason("우수기술문서 작성")
+          .isMerit(true)
           .build();
 
       mockMvc.perform(post("/merits/types")
@@ -110,7 +111,8 @@ public class MeritControllerTest extends MeritApiTestHelper {
               ),
               requestFields(
                   fieldWithPath("score").description("상벌점 점수를 입력해주세요."),
-                  fieldWithPath("reason").description("상벌점 사유를 입력해주세요.")
+                  fieldWithPath("reason").description("상벌점 사유를 입력해주세요."),
+                  fieldWithPath("isMerit").description("상벌점 타입을 입력해주세요")
               )));
     }
 
@@ -120,6 +122,7 @@ public class MeritControllerTest extends MeritApiTestHelper {
       AddMeritTypeRequest request = AddMeritTypeRequest.builder()
           .score(3)
           .reason("우수기술문서 작성")
+          .isMerit(true)
           .build();
 
       mockMvc.perform(post("/merits/types")
@@ -135,8 +138,9 @@ public class MeritControllerTest extends MeritApiTestHelper {
     void 상벌점_부여_로그_수정을_성공해야_한다() throws Exception {
       String securedValue = getSecuredValue(MeritController.class, "updateMeritType");
       UpdateMeritTypeRequest request = UpdateMeritTypeRequest.builder()
-          .score(5)
+          .score(-5)
           .reason("거짓 스터디")
+          .isMerit(false)
           .build();
 
       mockMvc.perform(put("/merits/types/{meritTypeId}", meritType.getId())
@@ -151,7 +155,8 @@ public class MeritControllerTest extends MeritApiTestHelper {
               ),
               requestFields(
                   fieldWithPath("score").description("수정할 점수"),
-                  fieldWithPath("reason").description("수정할 사유")
+                  fieldWithPath("reason").description("수정할 사유"),
+                  fieldWithPath("isMerit").description("수정할 상벌점 타입")
               )));
     }
 
@@ -159,8 +164,9 @@ public class MeritControllerTest extends MeritApiTestHelper {
     @DisplayName("일반회원은 상벌점 타입 수정을 성공할 수 없다.")
     void 일반회원은_상벌점_타입_수정을_성공할_수_없다() throws Exception {
       UpdateMeritTypeRequest request = UpdateMeritTypeRequest.builder()
-          .score(5)
+          .score(-5)
           .reason("거짓 스터디")
+          .isMerit(false)
           .build();
 
       mockMvc.perform(put("/merits/types/{meritTypeId}", meritType.getId())

--- a/src/test/java/com/keeper/homepage/domain/merit/application/MeritLogServiceTest.java
+++ b/src/test/java/com/keeper/homepage/domain/merit/application/MeritLogServiceTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 
 class MeritLogServiceTest extends IntegrationTest {
 
@@ -99,7 +100,8 @@ class MeritLogServiceTest extends IntegrationTest {
       em.flush();
       em.clear();
 
-      Page<MeritLog> meritLogPage = meritLogService.findAllByMemberId(PageRequest.of(0, 10),
+      Page<MeritLog> meritLogPage = meritLogService.findAllByMemberId(
+          PageRequest.of(0, 10, Sort.Direction.fromString("DESC"), "MeritType.merit"),
           giver.getId());
 
       assertThat(meritLogPage

--- a/src/test/java/com/keeper/homepage/domain/merit/application/MeritLogServiceTest.java
+++ b/src/test/java/com/keeper/homepage/domain/merit/application/MeritLogServiceTest.java
@@ -8,6 +8,7 @@ import com.keeper.homepage.domain.merit.entity.MeritLog;
 import com.keeper.homepage.domain.merit.entity.MeritType;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -108,4 +109,35 @@ class MeritLogServiceTest extends IntegrationTest {
     }
   }
 
+  @Nested
+  @DisplayName("상벌점 내역 삭제 테스트")
+  class DeleteMeritLogTest {
+
+    MeritLog meritLog, otherMeritLog;
+
+    @BeforeEach
+    void setUp() {
+      meritLog = meritLogTestHelper.generate();
+      otherMeritLog = meritLogTestHelper.generate();
+    }
+
+    @Test
+    @DisplayName("상벌점 내역 삭제를 성공해야 한다.")
+    public void 상벌점_내역_삭제를_성공해야_한다() {
+      em.flush();
+      em.clear();
+
+      meritLogService.deleteMeritLog(otherMeritLog.getId());
+
+      em.flush();
+      em.clear();
+
+      List<MeritLog> meritLogs = meritLogRepository.findAll();
+
+      assertThat(meritLogs.stream()
+          .map(MeritLog::getId)
+          .toList())
+          .containsExactly(meritLog.getId());
+    }
+  }
 }

--- a/src/test/java/com/keeper/homepage/domain/merit/application/MeritLogServiceTest.java
+++ b/src/test/java/com/keeper/homepage/domain/merit/application/MeritLogServiceTest.java
@@ -56,18 +56,37 @@ class MeritLogServiceTest extends IntegrationTest {
     @Test
     @DisplayName("상벌점 페이지를 조회할 수 있어야 한다.")
     void 상벌점_페이지를_조회할_수_있어야_한다() {
-      meritLogId = meritLogTestHelper.generate().getId();
-      otherMeritLogId = meritLogTestHelper.generate().getId();
+      final String MERIT_TYPE = "MERIT";
+      final String DEMERIT_TYPE = "DEMERIT";
+      final String ALL_TYPE = "ALL";
+
+      MeritType meritType = meritTypeHelper.builder().merit(3).build();
+      MeritType demeritType = meritTypeHelper.builder().merit(-3).build();
+
+      meritLogId = meritLogTestHelper.builder().meritType(meritType).build().getId();
+      otherMeritLogId = meritLogTestHelper.builder().meritType(demeritType).build().getId();
 
       em.flush();
       em.clear();
 
-      Page<MeritLog> meritLogs = meritLogService.findAll(PageRequest.of(0, 10));
+      Page<MeritLog> meritLogs = meritLogService.findAllByMeritType(PageRequest.of(0, 10), MERIT_TYPE);
+      Page<MeritLog> demeritLogs = meritLogService.findAllByMeritType(PageRequest.of(0, 10), DEMERIT_TYPE);
+      Page<MeritLog> allLogs = meritLogService.findAllByMeritType(PageRequest.of(0, 10), ALL_TYPE);
 
       assertThat(meritLogs
           .map(MeritLog::getId)
-          .toList()).contains(meritLogId, otherMeritLogId);
+          .toList())
+          .containsExactly(meritLogId);
 
+      assertThat(demeritLogs
+          .map(MeritLog::getId)
+          .toList())
+          .containsExactly(otherMeritLogId);
+
+      assertThat(allLogs
+          .map(MeritLog::getId)
+          .toList())
+          .containsExactly(meritLogId, otherMeritLogId);
     }
 
     @Test

--- a/src/test/java/com/keeper/homepage/domain/merit/application/MeritTypeServiceTest.java
+++ b/src/test/java/com/keeper/homepage/domain/merit/application/MeritTypeServiceTest.java
@@ -38,8 +38,8 @@ class MeritTypeServiceTest extends IntegrationTest {
     @Test
     @DisplayName("상벌점 타입 추가가 성공해야 한다.")
     void 상벌점_타입_추가가_성공해야_한다() {
-      meritTypeId = meritTypeService.addMeritType(3, "우수기술문서 작성");
-      otherMeritTypeId = meritTypeService.addMeritType(-3, "무단 결석");
+      meritTypeId = meritTypeService.addMeritType(3, "우수기술문서 작성", true);
+      otherMeritTypeId = meritTypeService.addMeritType(-3, "무단 결석", true);
 
       em.flush();
       em.clear();
@@ -67,10 +67,11 @@ class MeritTypeServiceTest extends IntegrationTest {
       em.flush();
       em.clear();
 
-      meritTypeService.updateMeritType(meritType.getId(), -1, "수정된 사유");
+      meritTypeService.updateMeritType(meritType.getId(), -1, "수정된 사유", false);
       MeritType updatedMeritType = meritTypeRepository.findById(meritType.getId()).orElseThrow();
       assertThat(updatedMeritType.getMerit()).isEqualTo(-1);
       assertThat(updatedMeritType.getDetail()).isEqualTo("수정된 사유");
+      assertThat(updatedMeritType.getIsMerit()).isEqualTo(false);
     }
 
     @Test
@@ -81,11 +82,12 @@ class MeritTypeServiceTest extends IntegrationTest {
       em.flush();
       em.clear();
 
-      meritTypeService.updateMeritType(meritType.getId(), 2, "변경 전 사유");
+      meritTypeService.updateMeritType(meritType.getId(), 2, "변경 전 사유", true);
       MeritType findMeritType = meritTypeRepository.findById(meritType.getId())
           .orElseThrow();
       assertThat(findMeritType.getMerit()).isEqualTo(2);
       assertThat(findMeritType.getDetail()).isEqualTo("변경 전 사유");
+      assertThat(findMeritType.getDetail()).isEqualTo(true);
     }
 
     @Test
@@ -98,7 +100,7 @@ class MeritTypeServiceTest extends IntegrationTest {
       em.clear();
 
       assertThrows(BusinessException.class,
-          () -> meritTypeService.updateMeritType(otherMeritType.getId(), 3, "변경 전 사유"),
+          () -> meritTypeService.updateMeritType(otherMeritType.getId(), 3, "변경 전 사유", true),
           MERIT_TYPE_DETAIL_DUPLICATE.getMessage());
     }
   }

--- a/src/test/java/com/keeper/homepage/domain/merit/application/MeritTypeServiceTest.java
+++ b/src/test/java/com/keeper/homepage/domain/merit/application/MeritTypeServiceTest.java
@@ -62,11 +62,13 @@ class MeritTypeServiceTest extends IntegrationTest {
     @Test
     @DisplayName("상벌점 수정이 성공해야 한다.")
     void 상벌점_수정이_성공해야_한다() {
+      MeritType meritType = meritTypeHelper.generate();
+
       em.flush();
       em.clear();
 
-      meritTypeService.updateMeritType(meritTypeId, -1, "수정된 사유");
-      MeritType updatedMeritType = meritTypeRepository.findById(meritTypeId).orElseThrow();
+      meritTypeService.updateMeritType(meritType.getId(), -1, "수정된 사유");
+      MeritType updatedMeritType = meritTypeRepository.findById(meritType.getId()).orElseThrow();
       assertThat(updatedMeritType.getMerit()).isEqualTo(-1);
       assertThat(updatedMeritType.getDetail()).isEqualTo("수정된 사유");
     }

--- a/src/test/java/com/keeper/homepage/domain/merit/application/MeritTypeServiceTest.java
+++ b/src/test/java/com/keeper/homepage/domain/merit/application/MeritTypeServiceTest.java
@@ -87,7 +87,7 @@ class MeritTypeServiceTest extends IntegrationTest {
           .orElseThrow();
       assertThat(findMeritType.getMerit()).isEqualTo(2);
       assertThat(findMeritType.getDetail()).isEqualTo("변경 전 사유");
-      assertThat(findMeritType.getDetail()).isEqualTo(true);
+      assertThat(findMeritType.getIsMerit()).isTrue();
     }
 
     @Test

--- a/src/test/java/com/keeper/homepage/domain/merit/dao/MeritLogRepositoryTest.java
+++ b/src/test/java/com/keeper/homepage/domain/merit/dao/MeritLogRepositoryTest.java
@@ -69,8 +69,8 @@ public class MeritLogRepositoryTest extends IntegrationTest {
     private Member member, otherMember;
     @BeforeEach
     void setUp() {
-      meritType = meritTypeHelper.builder().merit(5).build();
-      demeritType = meritTypeHelper.builder().merit(-3).build();
+      meritType = meritTypeHelper.builder().merit(5).isMerit(true).build();
+      demeritType = meritTypeHelper.builder().merit(-3).isMerit(false).build();
       member = memberTestHelper.generate();
       otherMember = memberTestHelper.generate();
 


### PR DESCRIPTION
## 🔥 Related Issue

> close: #354

## 📝 Description

1. 상벌점 로그 조회 API에서 MERIT, DEMERIT, ALL을 클라이언트에게 입력 받아서 상점/벌점/전체로 조회되도록 필터링을 추가했습니다.
2. 회원별 상벌점 로그 조회 API에서 ASC, DESC(기본값)을 클라이언트에게 입력 받아서 정렬하는 기능을 추가했습니다.
3. 상벌점 내역 삭제 기능을 추가했습니다.
4. 상벌점 타입 수정 API에서 사유 이름을 변경하지 않으면 이미 존재하는 사유로 판단되는 버그를 수정했습니다.

## ⭐️ Review Request

4번 버그를 수정하는데 더 좋은 방법이 있을까요?~?
잘 부탁드리겠습니다..!!!
