### PR TITLE
Feature/회원 프로필 조회 수정

### DIFF
--- a/src/main/java/com/keeper/homepage/domain/member/api/MemberController.java
+++ b/src/main/java/com/keeper/homepage/domain/member/api/MemberController.java
@@ -120,9 +120,10 @@ public class MemberController {
 
   @GetMapping("/{memberId}/profile")
   public ResponseEntity<MemberProfileResponse> getMemberProfile(
+      @LoginMember Member me,
       @PathVariable @PositiveOrZero long memberId
   ) {
-    return ResponseEntity.ok(memberService.getMemberProfile(memberId));
+    return ResponseEntity.ok(memberService.getMemberProfile(me, memberId));
   }
 
   @PatchMapping("/types/{typeId}")

--- a/src/main/java/com/keeper/homepage/domain/member/api/MemberController.java
+++ b/src/main/java/com/keeper/homepage/domain/member/api/MemberController.java
@@ -136,12 +136,12 @@ public class MemberController {
   }
 
   @PostMapping("/email-auth")
-  public ResponseEntity<String> emailAuth(
+  public ResponseEntity<EmailAuthResponse> emailAuth(
       @RequestBody @Valid EmailAuthRequest request
   ) {
     memberProfileService.checkDuplicateEmailAddress(request.getEmail());
     memberProfileService.sendEmailChangeAuthCode(request.getEmail());
-    return ResponseEntity.ok("이메일 인증 번호를 보냈습니다.");
+    return ResponseEntity.ok(EmailAuthResponse.from(300));
   }
 
   @PatchMapping("/email")
@@ -149,7 +149,8 @@ public class MemberController {
       @LoginMember Member member,
       @RequestBody @Valid UpdateMemberEmailAddressRequest request
   ) {
-    memberProfileService.updateProfileEmailAddress(member, request.getEmail(), request.getAuth(), request.getPassword());
+    memberProfileService.updateProfileEmailAddress(member, request.getEmail(), request.getAuth(),
+        request.getPassword());
     return ResponseEntity.noContent().build();
   }
 }

--- a/src/main/java/com/keeper/homepage/domain/member/api/MemberController.java
+++ b/src/main/java/com/keeper/homepage/domain/member/api/MemberController.java
@@ -1,5 +1,7 @@
 package com.keeper.homepage.domain.member.api;
 
+import static com.keeper.homepage.domain.auth.application.EmailAuthService.EMAIL_EXPIRED_SECONDS;
+
 import com.keeper.homepage.domain.auth.application.CheckDuplicateService;
 import com.keeper.homepage.domain.auth.application.EmailAuthService;
 import com.keeper.homepage.domain.auth.dto.request.EmailAuthRequest;
@@ -139,9 +141,8 @@ public class MemberController {
   public ResponseEntity<EmailAuthResponse> emailAuth(
       @RequestBody @Valid EmailAuthRequest request
   ) {
-    memberProfileService.checkDuplicateEmailAddress(request.getEmail());
     memberProfileService.sendEmailChangeAuthCode(request.getEmail());
-    return ResponseEntity.ok(EmailAuthResponse.from(300));
+    return ResponseEntity.ok(EmailAuthResponse.from(EMAIL_EXPIRED_SECONDS));
   }
 
   @PatchMapping("/email")

--- a/src/main/java/com/keeper/homepage/domain/member/application/MemberProfileService.java
+++ b/src/main/java/com/keeper/homepage/domain/member/application/MemberProfileService.java
@@ -76,7 +76,7 @@ public class MemberProfileService {
     findMember.getProfile().updateEmailAddress(email);
   }
 
-  public void checkDuplicateEmailAddress(String newEmail) {
+  private void checkDuplicateEmailAddress(String newEmail) {
     memberRepository.findByProfileEmailAddress(EmailAddress.from(newEmail))
         .ifPresent((e) -> {
           throw new BusinessException(newEmail, "newEmail", ErrorCode.MEMBER_EMAIL_DUPLICATE);
@@ -90,6 +90,7 @@ public class MemberProfileService {
   }
 
   public void sendEmailChangeAuthCode(String email) {
+    checkDuplicateEmailAddress(email);
     String auth = generateRandomAuthCode();
     redisUtil.setDataExpire(EMAIL_AUTH_CODE_KEY + email, auth, AUTH_CODE_EXPIRE_MILLIS);
     mailUtil.sendMail(List.of(email), "KEEPER 이메일 인증 번호입니다.",

--- a/src/main/java/com/keeper/homepage/domain/member/application/MemberProfileService.java
+++ b/src/main/java/com/keeper/homepage/domain/member/application/MemberProfileService.java
@@ -69,11 +69,9 @@ public class MemberProfileService {
   @Transactional
   public void updateProfileEmailAddress(Member member, String email,
       String auth, String password) {
-    Member findMember = memberFindService.findById(member.getId());
-
-    checkMemberPassword(findMember, password);
+    checkMemberPassword(member, password);
     checkEmailAuth(email, auth);
-    findMember.getProfile().updateEmailAddress(email);
+    member.getProfile().updateEmailAddress(email);
   }
 
   private void checkDuplicateEmailAddress(String newEmail) {

--- a/src/main/java/com/keeper/homepage/domain/member/application/MemberProfileService.java
+++ b/src/main/java/com/keeper/homepage/domain/member/application/MemberProfileService.java
@@ -39,8 +39,6 @@ public class MemberProfileService {
   private final ThumbnailUtil thumbnailUtil;
   private final RedisUtil redisUtil;
   private final MailUtil mailUtil;
-  private final MemberFindService memberFindService;
-  private final EntityManager em;
 
   @Transactional
   public void updateProfileThumbnail(Member member, MultipartFile thumbnail) {

--- a/src/main/java/com/keeper/homepage/domain/member/application/MemberService.java
+++ b/src/main/java/com/keeper/homepage/domain/member/application/MemberService.java
@@ -38,7 +38,6 @@ public class MemberService {
   private final MemberRepository memberRepository;
   private final MemberFindService memberFindService;
   private final MemberTypeRepository memberTypeRepository;
-  private final FriendRepository friendRepository;
 
   @Transactional
   public void changePassword(Member me, String newPassword) {

--- a/src/main/java/com/keeper/homepage/domain/member/application/MemberService.java
+++ b/src/main/java/com/keeper/homepage/domain/member/application/MemberService.java
@@ -10,6 +10,7 @@ import com.keeper.homepage.domain.member.dao.friend.FriendRepository;
 import com.keeper.homepage.domain.member.dao.type.MemberTypeRepository;
 import com.keeper.homepage.domain.member.dto.response.MemberPointRankResponse;
 import com.keeper.homepage.domain.member.dto.response.MemberResponse;
+import com.keeper.homepage.domain.member.dto.response.profile.MemberFriendResponse;
 import com.keeper.homepage.domain.member.dto.response.profile.MemberProfileResponse;
 import com.keeper.homepage.domain.member.entity.Member;
 import com.keeper.homepage.domain.member.entity.embedded.RealName;
@@ -18,8 +19,10 @@ import com.keeper.homepage.domain.member.entity.type.MemberType;
 import com.keeper.homepage.global.error.BusinessException;
 import com.keeper.homepage.global.error.ErrorCode;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -35,6 +38,7 @@ public class MemberService {
   private final MemberRepository memberRepository;
   private final MemberFindService memberFindService;
   private final MemberTypeRepository memberTypeRepository;
+  private final FriendRepository friendRepository;
 
   @Transactional
   public void changePassword(Member me, String newPassword) {
@@ -73,7 +77,10 @@ public class MemberService {
   }
 
   public MemberProfileResponse getMemberProfile(Member me, long memberId) {
-    return MemberProfileResponse.of(memberFindService.findById(memberId), me);
+    Member member = memberRepository.findMemberProfileWithFetchJoin(memberId)
+        .orElseThrow();
+
+    return MemberProfileResponse.of(member, me);
   }
 
   @Transactional

--- a/src/main/java/com/keeper/homepage/domain/member/application/MemberService.java
+++ b/src/main/java/com/keeper/homepage/domain/member/application/MemberService.java
@@ -18,6 +18,7 @@ import com.keeper.homepage.domain.member.entity.type.MemberType;
 import com.keeper.homepage.global.error.BusinessException;
 import com.keeper.homepage.global.error.ErrorCode;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -71,10 +72,8 @@ public class MemberService {
     member.unfollow(other);
   }
 
-  public MemberProfileResponse getMemberProfile(long memberId) {
-    return MemberProfileResponse.of(
-        memberFindService.findById(memberId)
-    );
+  public MemberProfileResponse getMemberProfile(Member me, long memberId) {
+    return MemberProfileResponse.of(memberFindService.findById(memberId), me);
   }
 
   @Transactional

--- a/src/main/java/com/keeper/homepage/domain/member/dao/MemberRepository.java
+++ b/src/main/java/com/keeper/homepage/domain/member/dao/MemberRepository.java
@@ -11,6 +11,8 @@ import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
@@ -38,4 +40,11 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
   void deleteAllByIdNot(Long virtualId);
 
   List<Member> findAllByMemberType(MemberType type);
+
+  @Query("SELECT m FROM Member m " +
+      "JOIN FETCH m.memberType " +
+      "JOIN FETCH m.memberJob mj " +
+      "JOIN FETCH mj.memberJob " +
+      "WHERE m.id = :id")
+  Optional<Member> findMemberProfileWithFetchJoin(@Param("id") long id);
 }

--- a/src/main/java/com/keeper/homepage/domain/member/dao/friend/FriendRepository.java
+++ b/src/main/java/com/keeper/homepage/domain/member/dao/friend/FriendRepository.java
@@ -1,10 +1,7 @@
 package com.keeper.homepage.domain.member.dao.friend;
 
-import com.keeper.homepage.domain.member.entity.Member;
 import com.keeper.homepage.domain.member.entity.friend.Friend;
-import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
 public interface FriendRepository extends JpaRepository<Friend, Long> {
 }

--- a/src/main/java/com/keeper/homepage/domain/member/dto/response/profile/MemberFriendResponse.java
+++ b/src/main/java/com/keeper/homepage/domain/member/dto/response/profile/MemberFriendResponse.java
@@ -18,17 +18,6 @@ public class MemberFriendResponse {
   private String thumbnailPath;
   private String generation;
 
-  public MemberFriendResponse(Long id) {
-    this.id = id;
-  }
-
-  public MemberFriendResponse(Long id, String name, Float generation, String thumbnailPath) {
-    this.id = id;
-    this.name = name;
-    this.generation = generation.toString();
-    this.thumbnailPath = thumbnailPath;
-  }
-
   public static MemberFriendResponse from(Member member) {
     return MemberFriendResponse.builder()
         .id(member.getId())

--- a/src/main/java/com/keeper/homepage/domain/member/dto/response/profile/MemberFriendResponse.java
+++ b/src/main/java/com/keeper/homepage/domain/member/dto/response/profile/MemberFriendResponse.java
@@ -3,6 +3,7 @@ package com.keeper.homepage.domain.member.dto.response.profile;
 import static lombok.AccessLevel.PRIVATE;
 
 import com.keeper.homepage.domain.member.entity.Member;
+import com.keeper.homepage.domain.member.entity.embedded.Profile;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,6 +17,17 @@ public class MemberFriendResponse {
   private String name;
   private String thumbnailPath;
   private String generation;
+
+  public MemberFriendResponse(Long id) {
+    this.id = id;
+  }
+
+  public MemberFriendResponse(Long id, String name, Float generation, String thumbnailPath) {
+    this.id = id;
+    this.name = name;
+    this.generation = generation.toString();
+    this.thumbnailPath = thumbnailPath;
+  }
 
   public static MemberFriendResponse from(Member member) {
     return MemberFriendResponse.builder()

--- a/src/main/java/com/keeper/homepage/domain/member/dto/response/profile/MemberProfileResponse.java
+++ b/src/main/java/com/keeper/homepage/domain/member/dto/response/profile/MemberProfileResponse.java
@@ -16,7 +16,6 @@ import lombok.Getter;
 import lombok.Setter;
 
 @Getter
-@Setter
 @Builder
 @AllArgsConstructor(access = PRIVATE)
 public class MemberProfileResponse {

--- a/src/main/java/com/keeper/homepage/domain/member/dto/response/profile/MemberProfileResponse.java
+++ b/src/main/java/com/keeper/homepage/domain/member/dto/response/profile/MemberProfileResponse.java
@@ -39,7 +39,7 @@ public class MemberProfileResponse {
         .realName(member.getRealName())
         .birthday(member.getProfile().getBirthday())
         .thumbnailPath(member.getThumbnailPath())
-        .studentId(isProfileMine(member, me))
+        .studentId(getStudentIdIfMine(member, me))
         .generation(member.getGeneration())
         .point(member.getPoint())
         .memberType(member.getMemberType().getType().name())
@@ -49,7 +49,7 @@ public class MemberProfileResponse {
         .build();
   }
 
-  private static String isProfileMine(Member member, Member me) {
+  private static String getStudentIdIfMine(Member member, Member me) {
     return Objects.equals(member.getId(), me.getId()) ? member.getProfile().getStudentId().get() : "default";
   }
 

--- a/src/main/java/com/keeper/homepage/domain/member/dto/response/profile/MemberProfileResponse.java
+++ b/src/main/java/com/keeper/homepage/domain/member/dto/response/profile/MemberProfileResponse.java
@@ -8,6 +8,7 @@ import com.keeper.homepage.domain.member.entity.Member;
 import com.keeper.homepage.domain.member.entity.friend.Friend;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -23,6 +24,7 @@ public class MemberProfileResponse {
   private String realName;
   private LocalDate birthday;
   private String thumbnailPath;
+  private String studentId;
   private String generation;
   private int point;
   private String memberType;
@@ -30,13 +32,14 @@ public class MemberProfileResponse {
   private List<MemberFriendResponse> follower;
   private List<MemberFriendResponse> followee;
 
-  public static MemberProfileResponse of(Member member) {
+  public static MemberProfileResponse of(Member member, Member me) {
     return MemberProfileResponse.builder()
         .id(member.getId())
         .emailAddress(member.getProfile().getEmailAddress().get())
         .realName(member.getRealName())
         .birthday(member.getProfile().getBirthday())
         .thumbnailPath(member.getThumbnailPath())
+        .studentId(isProfileMine(member, me))
         .generation(member.getGeneration())
         .point(member.getPoint())
         .memberType(member.getMemberType().getType().name())
@@ -46,7 +49,16 @@ public class MemberProfileResponse {
         .build();
   }
 
+  private static String isProfileMine(Member member, Member me) {
+    return Objects.equals(member.getId(), me.getId()) ? member.getProfile().getStudentId().get() : "default";
+  }
+
   private static List<MemberFriendResponse> getFollower(Member member) {
+//    List<Long> followerIds = member.getFollowee().stream()
+//        .map(Friend::getFollower)
+//        .map(Member::getId)
+//        .toList();
+
     return member.getFollowee().stream()
         .map(Friend::getFollower)
         .map(MemberFriendResponse::from)

--- a/src/main/java/com/keeper/homepage/domain/member/dto/response/profile/MemberProfileResponse.java
+++ b/src/main/java/com/keeper/homepage/domain/member/dto/response/profile/MemberProfileResponse.java
@@ -13,8 +13,10 @@ import java.util.Set;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.Setter;
 
 @Getter
+@Setter
 @Builder
 @AllArgsConstructor(access = PRIVATE)
 public class MemberProfileResponse {
@@ -54,11 +56,6 @@ public class MemberProfileResponse {
   }
 
   private static List<MemberFriendResponse> getFollower(Member member) {
-//    List<Long> followerIds = member.getFollowee().stream()
-//        .map(Friend::getFollower)
-//        .map(Member::getId)
-//        .toList();
-
     return member.getFollowee().stream()
         .map(Friend::getFollower)
         .map(MemberFriendResponse::from)

--- a/src/main/java/com/keeper/homepage/domain/member/entity/Member.java
+++ b/src/main/java/com/keeper/homepage/domain/member/entity/Member.java
@@ -63,9 +63,11 @@ import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
 
+@BatchSize(size = 1000)
 @DynamicInsert
 @DynamicUpdate
 @Getter

--- a/src/main/java/com/keeper/homepage/domain/member/entity/embedded/Profile.java
+++ b/src/main/java/com/keeper/homepage/domain/member/entity/embedded/Profile.java
@@ -62,6 +62,7 @@ public class Profile {
     this.studentId = newProfile.studentId;
     this.birthday = newProfile.birthday;
   }
+
   public void updateThumbnail(Thumbnail thumbnail) {
     this.thumbnail = thumbnail;
   }

--- a/src/test/java/com/keeper/homepage/domain/member/api/MemberApiTestHelper.java
+++ b/src/test/java/com/keeper/homepage/domain/member/api/MemberApiTestHelper.java
@@ -37,6 +37,7 @@ public class MemberApiTestHelper extends IntegrationTest {
         fieldWithPath("realName").description("회원의 실명"),
         fieldWithPath("birthday").description("회원의 생일"),
         fieldWithPath("thumbnailPath").description("썸네일 경로"),
+        fieldWithPath("studentId").description("회원의 학번(본인이 아닐경우 default)"),
         fieldWithPath("generation").description("회원의 기수"),
         fieldWithPath("point").description("회원의 포인트 점수"),
         fieldWithPath("memberType").description("회원의 타입"),

--- a/src/test/java/com/keeper/homepage/domain/member/api/MemberControllerTest.java
+++ b/src/test/java/com/keeper/homepage/domain/member/api/MemberControllerTest.java
@@ -323,13 +323,23 @@ class MemberControllerTest extends MemberApiTestHelper {
     @Test
     @DisplayName("회원 프로필 조회를 성공해야 한다")
     void 회원_프로필_조회를_성공해야_한다() throws Exception {
-      memberService.follow(member, memberTestHelper.builder().realName(RealName.from("일일")).build().getId());
-      memberService.follow(memberTestHelper.builder().realName(RealName.from("삼삼")).build(), member.getId());
+      System.out.println("=================== 팔로잉 전 ===================");
+//      memberService.follow(member, memberTestHelper.builder().realName(RealName.from("일일")).build().getId());
+//      memberService.follow(member, memberTestHelper.builder().realName(RealName.from("일일")).build().getId());
+//      memberService.follow(member, memberTestHelper.builder().realName(RealName.from("일일")).build().getId());
+//      memberService.follow(memberTestHelper.builder().realName(RealName.from("삼삼")).build(), member.getId());
+//      memberService.follow(memberTestHelper.builder().realName(RealName.from("삼삼")).build(), member.getId());
+//      memberService.follow(memberTestHelper.builder().realName(RealName.from("삼삼")).build(), member.getId());
+      for (int i = 0; i < 1000; i++) {
+        memberService.follow(member, memberTestHelper.builder().realName(RealName.from("일일")).build().getId());
+        memberService.follow(memberTestHelper.builder().realName(RealName.from("삼삼")).build(), member.getId());
+      }
+
       String securedValue = getSecuredValue(MemberController.class, "getMemberProfile");
 
       em.flush();
       em.clear();
-
+      System.out.println("=============== AFTER ===============");
       mockMvc.perform(get("/members/{memberId}/profile", member.getId())
               .cookie(new Cookie(ACCESS_TOKEN.getTokenName(), memberToken))
               .contentType(MediaType.APPLICATION_JSON))

--- a/src/test/java/com/keeper/homepage/domain/member/api/MemberControllerTest.java
+++ b/src/test/java/com/keeper/homepage/domain/member/api/MemberControllerTest.java
@@ -324,16 +324,16 @@ class MemberControllerTest extends MemberApiTestHelper {
     @Test
     @DisplayName("회원 프로필 조회를 성공해야 한다")
     void 회원_프로필_조회를_성공해야_한다() throws Exception {
-      memberService.follow(member, memberTestHelper.builder().realName(RealName.from("일일")).build().getId());
-      memberService.follow(member, memberTestHelper.builder().realName(RealName.from("일일")).build().getId());
-      memberService.follow(member, memberTestHelper.builder().realName(RealName.from("일일")).build().getId());
-      memberService.follow(memberTestHelper.builder().realName(RealName.from("삼삼")).build(), member.getId());
-      memberService.follow(memberTestHelper.builder().realName(RealName.from("삼삼")).build(), member.getId());
-      memberService.follow(memberTestHelper.builder().realName(RealName.from("삼삼")).build(), member.getId());
-//      for (int i = 0; i < 1000; i++) {
-//        memberService.follow(member, memberTestHelper.builder().realName(RealName.from("일일")).build().getId());
-//        memberService.follow(memberTestHelper.builder().realName(RealName.from("삼삼")).build(), member.getId());
-//      }
+//      memberService.follow(member, memberTestHelper.builder().realName(RealName.from("일일")).build().getId());
+//      memberService.follow(member, memberTestHelper.builder().realName(RealName.from("일일")).build().getId());
+//      memberService.follow(member, memberTestHelper.builder().realName(RealName.from("일일")).build().getId());
+//      memberService.follow(memberTestHelper.builder().realName(RealName.from("삼삼")).build(), member.getId());
+//      memberService.follow(memberTestHelper.builder().realName(RealName.from("삼삼")).build(), member.getId());
+//      memberService.follow(memberTestHelper.builder().realName(RealName.from("삼삼")).build(), member.getId());
+      for (int i = 0; i < 1000; i++) {
+        memberService.follow(member, memberTestHelper.builder().realName(RealName.from("일일")).build().getId());
+        memberService.follow(memberTestHelper.builder().realName(RealName.from("삼삼")).build(), member.getId());
+      }
 
       String securedValue = getSecuredValue(MemberController.class, "getMemberProfile");
 

--- a/src/test/java/com/keeper/homepage/domain/member/api/MemberControllerTest.java
+++ b/src/test/java/com/keeper/homepage/domain/member/api/MemberControllerTest.java
@@ -311,40 +311,39 @@ class MemberControllerTest extends MemberApiTestHelper {
   class getMemberProfile {
 
     private Member member, otherMember;
-    private String memberToken;
+    private String memberToken, otherMemberToken;
 
     @BeforeEach
     void setUp() throws IOException {
       member = memberTestHelper.generate();
       otherMember = memberTestHelper.generate();
       memberToken = jwtTokenProvider.createAccessToken(ACCESS_TOKEN, member.getId(), ROLE_회원);
+      otherMemberToken = jwtTokenProvider.createAccessToken(ACCESS_TOKEN, otherMember.getId(), ROLE_회원);
     }
 
     @Test
     @DisplayName("회원 프로필 조회를 성공해야 한다")
     void 회원_프로필_조회를_성공해야_한다() throws Exception {
-      System.out.println("=================== 팔로잉 전 ===================");
-//      memberService.follow(member, memberTestHelper.builder().realName(RealName.from("일일")).build().getId());
-//      memberService.follow(member, memberTestHelper.builder().realName(RealName.from("일일")).build().getId());
-//      memberService.follow(member, memberTestHelper.builder().realName(RealName.from("일일")).build().getId());
-//      memberService.follow(memberTestHelper.builder().realName(RealName.from("삼삼")).build(), member.getId());
-//      memberService.follow(memberTestHelper.builder().realName(RealName.from("삼삼")).build(), member.getId());
-//      memberService.follow(memberTestHelper.builder().realName(RealName.from("삼삼")).build(), member.getId());
-      for (int i = 0; i < 1000; i++) {
-        memberService.follow(member, memberTestHelper.builder().realName(RealName.from("일일")).build().getId());
-        memberService.follow(memberTestHelper.builder().realName(RealName.from("삼삼")).build(), member.getId());
-      }
+      memberService.follow(member, memberTestHelper.builder().realName(RealName.from("일일")).build().getId());
+      memberService.follow(member, memberTestHelper.builder().realName(RealName.from("일일")).build().getId());
+      memberService.follow(member, memberTestHelper.builder().realName(RealName.from("일일")).build().getId());
+      memberService.follow(memberTestHelper.builder().realName(RealName.from("삼삼")).build(), member.getId());
+      memberService.follow(memberTestHelper.builder().realName(RealName.from("삼삼")).build(), member.getId());
+      memberService.follow(memberTestHelper.builder().realName(RealName.from("삼삼")).build(), member.getId());
+//      for (int i = 0; i < 1000; i++) {
+//        memberService.follow(member, memberTestHelper.builder().realName(RealName.from("일일")).build().getId());
+//        memberService.follow(memberTestHelper.builder().realName(RealName.from("삼삼")).build(), member.getId());
+//      }
 
       String securedValue = getSecuredValue(MemberController.class, "getMemberProfile");
 
       em.flush();
       em.clear();
-      System.out.println("=============== AFTER ===============");
+
       mockMvc.perform(get("/members/{memberId}/profile", member.getId())
               .cookie(new Cookie(ACCESS_TOKEN.getTokenName(), memberToken))
               .contentType(MediaType.APPLICATION_JSON))
           .andExpect(status().isOk())
-          .andDo(print())
           .andExpect(jsonPath("$.follower[0].name").value("삼삼"))
           .andExpect(jsonPath("$.followee[0].name").value("일일"))
           .andDo(document("get-member-profile",
@@ -359,6 +358,24 @@ class MemberControllerTest extends MemberApiTestHelper {
               responseFields(
                   getMemberProfileResponse()
               )));
+    }
+
+    @Test
+    @DisplayName("다른 회원의 프로필을 조회할 때는 학번이 노출되면 안된다.")
+    public void 다른_회원의_프로필_조회할_때는_학번이_노출되면_안된다() throws Exception {
+      memberService.follow(member, memberTestHelper.builder().realName(RealName.from("일일")).build().getId());
+      memberService.follow(memberTestHelper.builder().realName(RealName.from("삼삼")).build(), member.getId());
+
+      em.flush();
+      em.clear();
+
+      mockMvc.perform(get("/members/{memberId}/profile", member.getId())
+              .cookie(new Cookie(ACCESS_TOKEN.getTokenName(), otherMemberToken))
+              .contentType(MediaType.APPLICATION_JSON))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.follower[0].name").value("삼삼"))
+          .andExpect(jsonPath("$.followee[0].name").value("일일"))
+          .andExpect(jsonPath("$.studentId").value("default"));
     }
   }
 

--- a/src/test/java/com/keeper/homepage/domain/member/application/MemberProfileServiceTest.java
+++ b/src/test/java/com/keeper/homepage/domain/member/application/MemberProfileServiceTest.java
@@ -99,9 +99,6 @@ class MemberProfileServiceTest extends IntegrationTest {
     @Test
     @DisplayName("회원 이메일 변경에 성공해야 한다.")
     public void 회원_이메일_변경에_성공해야_한다() {
-      em.flush();
-      em.clear();
-
       memberProfileService.updateProfileEmailAddress(member, randomEmail,
           data, "truePassword");
 

--- a/src/test/java/com/keeper/homepage/domain/member/application/MemberProfileServiceTest.java
+++ b/src/test/java/com/keeper/homepage/domain/member/application/MemberProfileServiceTest.java
@@ -67,16 +67,14 @@ class MemberProfileServiceTest extends IntegrationTest {
 
     @BeforeEach
     void setUp() throws IOException {
-      randomEmail = memberTestHelper.generate()
-          .getProfile()
-          .getEmailAddress()
-          .get();
+      randomEmail = "afterUpdated@gmail.com";
 
       memberProfileService.sendEmailChangeAuthCode(randomEmail);
       data = redisUtil.getData("EMAIL_AUTH_" + randomEmail, String.class)
           .orElseThrow();
 
       member = memberTestHelper.builder()
+          .emailAddress(EmailAddress.from("beforeUpdated@gmail.com"))
           .password(Password.from("truePassword"))
           .build();
 
@@ -101,10 +99,17 @@ class MemberProfileServiceTest extends IntegrationTest {
     @Test
     @DisplayName("회원 이메일 변경에 성공해야 한다.")
     public void 회원_이메일_변경에_성공해야_한다() {
+      em.flush();
+      em.clear();
+
       memberProfileService.updateProfileEmailAddress(member, randomEmail,
           data, "truePassword");
 
-      assertThat(member.getProfile().getEmailAddress()).isEqualTo(EmailAddress.from(randomEmail));
+      em.flush();
+      em.clear();
+
+      Member updatedMember = memberFindService.findById(memberId);
+      assertThat(updatedMember.getProfile().getEmailAddress().get()).isEqualTo(EmailAddress.from(randomEmail).get());
     }
 
     @Test

--- a/src/test/java/com/keeper/homepage/domain/member/application/MemberProfileServiceTest.java
+++ b/src/test/java/com/keeper/homepage/domain/member/application/MemberProfileServiceTest.java
@@ -85,7 +85,7 @@ class MemberProfileServiceTest extends IntegrationTest {
     @DisplayName("이메일 중복 시 예외를 던져야 한다.")
     public void 이메일_중복_시_예외를_던져야_한다() {
       assertThrows(BusinessException.class,
-          () -> memberProfileService.checkDuplicateEmailAddress(member.getProfile()
+          () -> memberProfileService.sendEmailChangeAuthCode(member.getProfile()
               .getEmailAddress()
               .get()), MEMBER_EMAIL_DUPLICATE.getMessage());
     }

--- a/src/test/java/com/keeper/homepage/domain/member/application/MemberServiceTest.java
+++ b/src/test/java/com/keeper/homepage/domain/member/application/MemberServiceTest.java
@@ -5,9 +5,14 @@ import static com.keeper.homepage.global.error.ErrorCode.MEMBER_CANNOT_FOLLOW_ME
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 import com.keeper.homepage.IntegrationTest;
+import com.keeper.homepage.domain.member.dto.request.UpdateMemberEmailAddressRequest;
+import com.keeper.homepage.domain.member.dto.request.UpdateMemberEmailAddressRequest.UpdateMemberEmailAddressRequestBuilder;
 import com.keeper.homepage.domain.member.entity.Member;
+import com.keeper.homepage.domain.member.entity.embedded.EmailAddress;
+import com.keeper.homepage.domain.member.entity.embedded.Password;
 import com.keeper.homepage.domain.member.entity.friend.Friend;
 import com.keeper.homepage.domain.member.entity.type.MemberType.MemberTypeEnum;
 import com.keeper.homepage.global.error.BusinessException;
@@ -19,6 +24,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 public class MemberServiceTest extends IntegrationTest {
 
@@ -87,5 +93,45 @@ public class MemberServiceTest extends IntegrationTest {
       assertThat(findMember.getMemberType().getType()).isEqualTo(휴면회원);
       assertThat(findOtherMember.getMemberType().getType()).isEqualTo(휴면회원);
     }
+  }
+
+  @Nested
+  @DisplayName("회원 이메일 변경 테스트")
+  class UpdateEmailTest {
+
+    private Member member;
+    private UpdateMemberEmailAddressRequest request;
+
+    @BeforeEach
+    void setUp() {
+      member = memberTestHelper.builder()
+          .emailAddress(EmailAddress.from("beforeUpdated@gmail.com"))
+          .password(Password.from("truePassword"))
+          .build();
+
+      request = UpdateMemberEmailAddressRequest.builder()
+          .email("Updated@gmail.com")
+          .auth("123456789")
+          .password("truePassword")
+          .build();
+    }
+
+    @Test
+    @DisplayName("회원 이메일 변경을 성공해야 한다.")
+    public void 회원_이메일_변경을_성공해야_한다() {
+      em.flush();
+      em.clear();
+
+      doNothing().when(memberProfileService).checkEmailAuth(any(), any());
+      memberProfileService.updateProfileEmailAddress(member, request.getEmail(),
+          request.getAuth(), request.getPassword());
+
+      em.flush();
+      em.clear();
+
+      Member savedMember = memberFindService.findById(member.getId());
+      assertThat(savedMember.getProfile().getEmailAddress().get()).isEqualTo("Updated@gmail.com");
+    }
+
   }
 }

--- a/src/test/java/com/keeper/homepage/domain/member/application/MemberServiceTest.java
+++ b/src/test/java/com/keeper/homepage/domain/member/application/MemberServiceTest.java
@@ -119,9 +119,6 @@ public class MemberServiceTest extends IntegrationTest {
     @Test
     @DisplayName("회원 이메일 변경을 성공해야 한다.")
     public void 회원_이메일_변경을_성공해야_한다() {
-      em.flush();
-      em.clear();
-
       doNothing().when(memberProfileService).checkEmailAuth(any(), any());
       memberProfileService.updateProfileEmailAddress(member, request.getEmail(),
           request.getAuth(), request.getPassword());


### PR DESCRIPTION
## 🔥 Related Issue

## 📝 Description
1. 프로필 조회 시 발생하는 N+1 문제를 해결하였습니다. 영한킴 강의를 참고했고 강의 기준으로 V3.1 버전으로 맞췄습니다. 여러 가지 실험을 해봤는데 컬렉션 참고하는 경우는 @BatchSize를 거는게 가장 빠른 것으로 확인했습니다. (V4, V5 코드도 작성해보고 싶어 몇몇 코드에 주석이 되어있습니다. 머지될 때는 다 삭제한 후 깔끔하게 올리도록 하겠습니다~!)

2. 프로필 조회 API 응답 값에 회원의 학번이 추가 되었습니다. 예전 민감한 정보라 삭제했었는데 프론트 요청으로 본인 조회일 때만 본인 학번 정보를 포함해서 보내주는 방식으로 변경하였습니다. 본인이 아닐 경우 "default" 문자열로 띄워주기로 결정했습니다.

3. 프론트 요청으로 이메일 인증 코드 발송 API 응답으로 인증 코드 유효 시간 300초를 보내도록 수정했습니다.

+)
4. 이메일 변경 API가 정상적으로 작동되지 않는 것을 확인했고 수정 완료했습니다.

## ⭐️ Review Request

잘 부탁 드리겠습니다~! 감사합니다..!
