### PR TITLE
Feature/출석 백엔드에서 처리

### DIFF
--- a/src/docs/asciidoc/attendance/attendance.adoc
+++ b/src/docs/asciidoc/attendance/attendance.adoc
@@ -13,24 +13,6 @@ endif::[]
 
 link:../keeper.html[API 목록으로 돌아가기]
 
-== *출석*
-
-=== 요청
-
-==== Request
-
-include::{snippets}/create-attendance/http-request.adoc[]
-
-==== Request Cookies
-
-include::{snippets}/create-attendance/request-cookies.adoc[]
-
-=== 응답
-
-==== Response
-
-include::{snippets}/create-attendance/http-response.adoc[]
-
 == *당일 출석 랭킹 조회*
 
 NOTE: 당일의 출석 시간이 빠른 순서대로 정렬되어 조회됩니다.

--- a/src/main/java/com/keeper/homepage/domain/attendance/api/AttendanceController.java
+++ b/src/main/java/com/keeper/homepage/domain/attendance/api/AttendanceController.java
@@ -14,12 +14,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.format.annotation.DateTimeFormat;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -31,15 +29,6 @@ import org.springframework.web.bind.annotation.RestController;
 public class AttendanceController {
 
   private final AttendanceService attendanceService;
-
-  @PostMapping
-  public ResponseEntity<Void> create(
-      @LoginMember Member member
-  ) {
-    attendanceService.create(member);
-    return ResponseEntity.status(HttpStatus.CREATED)
-        .build();
-  }
 
   @GetMapping("/today-rank")
   public ResponseEntity<Page<AttendanceRankResponse>> getTodayRanks(

--- a/src/main/java/com/keeper/homepage/domain/attendance/application/AttendanceService.java
+++ b/src/main/java/com/keeper/homepage/domain/attendance/application/AttendanceService.java
@@ -43,8 +43,12 @@ public class AttendanceService {
     checkAlreadyAttendance(member);
 
     LocalDateTime now = LocalDateTime.now();
-    int randomPoint = getRandomPoint();
+
     int rank = getTodayRank(now.toLocalDate());
+    String key = "attendance:member:" + member.getId();
+    redisUtil.setDataExpire(key, rank, RedisUtil.toMidNight());
+
+    int randomPoint = getRandomPoint();
     int rankPoint = getRankPoint(rank);
     int continuousDay = getContinuousDay(member, now.toLocalDate());
     int continuousPoint = getContinuousPoint(continuousDay);

--- a/src/main/java/com/keeper/homepage/domain/attendance/application/AttendanceService.java
+++ b/src/main/java/com/keeper/homepage/domain/attendance/application/AttendanceService.java
@@ -1,6 +1,5 @@
 package com.keeper.homepage.domain.attendance.application;
 
-import static com.keeper.homepage.global.error.ErrorCode.ATTENDANCE_ALREADY;
 import static com.keeper.homepage.global.error.ErrorCode.ATTENDANCE_NOT_FOUND;
 
 import com.keeper.homepage.domain.attendance.dao.AttendanceRepository;
@@ -40,8 +39,6 @@ public class AttendanceService {
 
   @Transactional
   public void create(Member member) {
-    checkAlreadyAttendance(member);
-
     LocalDateTime now = LocalDateTime.now();
 
     int rank = getTodayRank(now.toLocalDate());
@@ -68,12 +65,6 @@ public class AttendanceService {
         .build();
     attendanceRepository.save(attendance);
     member.addPoint(attendance.getTotalPoint(), ATTENDANCE_POINT_MESSAGE);
-  }
-
-  private void checkAlreadyAttendance(Member member) {
-    if (attendanceRepository.existsByMemberAndDate(member, LocalDate.now())) {
-      throw new BusinessException(member.getId(), "memberId", ATTENDANCE_ALREADY);
-    }
   }
 
   private int getRandomPoint() {

--- a/src/main/java/com/keeper/homepage/domain/attendance/application/AttendanceService.java
+++ b/src/main/java/com/keeper/homepage/domain/attendance/application/AttendanceService.java
@@ -38,11 +38,12 @@ public class AttendanceService {
   public static final int DAILY_POINT = 1000;
 
   @Transactional
-  public void create(Member member) {
+  public void create(long memberId) {
+    Member member = memberFindService.findById(memberId);
     LocalDateTime now = LocalDateTime.now();
 
     int rank = getTodayRank(now.toLocalDate());
-    String key = "attendance:member:" + member.getId();
+    String key = "attendance:member:" + memberId;
     redisUtil.setDataExpire(key, rank, RedisUtil.toMidNight());
 
     int randomPoint = getRandomPoint();

--- a/src/main/java/com/keeper/homepage/domain/post/application/PostService.java
+++ b/src/main/java/com/keeper/homepage/domain/post/application/PostService.java
@@ -244,6 +244,7 @@ public class PostService {
       throw new BusinessException(post.getId(), "postId", POST_INACCESSIBLE);
     }
     thumbnailUtil.deleteFileAndEntityIfExist(post.getThumbnail());
+    post.deleteThumbnail();
   }
 
   @Transactional

--- a/src/main/java/com/keeper/homepage/domain/post/entity/Post.java
+++ b/src/main/java/com/keeper/homepage/domain/post/entity/Post.java
@@ -202,4 +202,8 @@ public class Post extends BaseEntity {
   public CategoryType getCategoryType() {
     return this.category.getType();
   }
+
+  public void deleteThumbnail() {
+    this.thumbnail = null;
+  }
 }

--- a/src/main/java/com/keeper/homepage/global/config/interceptor/AttendanceInterceptor.java
+++ b/src/main/java/com/keeper/homepage/global/config/interceptor/AttendanceInterceptor.java
@@ -11,7 +11,6 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
-import org.springframework.web.servlet.ModelAndView;
 
 @Component
 @RequiredArgsConstructor
@@ -21,8 +20,7 @@ public class AttendanceInterceptor implements HandlerInterceptor {
   private final RedisUtil redisUtil;
 
   @Override
-  public void postHandle(HttpServletRequest request, HttpServletResponse response, Object handler,
-      ModelAndView modelAndView) throws Exception {
+  public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
     Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
     if (!(authentication instanceof AnonymousAuthenticationToken)) {
@@ -34,5 +32,6 @@ public class AttendanceInterceptor implements HandlerInterceptor {
         attendanceService.create(memberId);
       }
     }
+    return true;
   }
 }

--- a/src/main/java/com/keeper/homepage/global/config/interceptor/AttendanceInterceptor.java
+++ b/src/main/java/com/keeper/homepage/global/config/interceptor/AttendanceInterceptor.java
@@ -1,0 +1,42 @@
+package com.keeper.homepage.global.config.interceptor;
+
+import static com.keeper.homepage.global.error.ErrorCode.MEMBER_NOT_FOUND;
+
+import com.keeper.homepage.domain.attendance.application.AttendanceService;
+import com.keeper.homepage.domain.member.dao.MemberRepository;
+import com.keeper.homepage.domain.member.entity.Member;
+import com.keeper.homepage.global.error.BusinessException;
+import com.keeper.homepage.global.util.redis.RedisUtil;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.ModelAndView;
+
+@Component
+@RequiredArgsConstructor
+public class AttendanceInterceptor implements HandlerInterceptor {
+
+  private final AttendanceService attendanceService;
+  private final MemberRepository memberRepository;
+  private final RedisUtil redisUtil;
+
+  @Override
+  public void postHandle(HttpServletRequest request, HttpServletResponse response, Object handler,
+      ModelAndView modelAndView) throws Exception {
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    long memberId = Long.parseLong(authentication.getName());
+
+    String key = "attendance:member:" + memberId;
+    Optional<String> data = redisUtil.getData(key, String.class);
+    if (data.isEmpty()) {
+      Member member = memberRepository.findById(memberId)
+          .orElseThrow(() -> new BusinessException(memberId, "memberId", MEMBER_NOT_FOUND));
+      attendanceService.create(member);
+    }
+  }
+}

--- a/src/main/java/com/keeper/homepage/global/config/interceptor/AttendanceInterceptor.java
+++ b/src/main/java/com/keeper/homepage/global/config/interceptor/AttendanceInterceptor.java
@@ -1,7 +1,6 @@
 package com.keeper.homepage.global.config.interceptor;
 
 import com.keeper.homepage.domain.attendance.application.AttendanceService;
-import com.keeper.homepage.domain.member.dao.MemberRepository;
 import com.keeper.homepage.global.util.redis.RedisUtil;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -19,7 +18,6 @@ import org.springframework.web.servlet.ModelAndView;
 public class AttendanceInterceptor implements HandlerInterceptor {
 
   private final AttendanceService attendanceService;
-  private final MemberRepository memberRepository;
   private final RedisUtil redisUtil;
 
   @Override

--- a/src/main/java/com/keeper/homepage/global/config/interceptor/AttendanceInterceptor.java
+++ b/src/main/java/com/keeper/homepage/global/config/interceptor/AttendanceInterceptor.java
@@ -1,11 +1,7 @@
 package com.keeper.homepage.global.config.interceptor;
 
-import static com.keeper.homepage.global.error.ErrorCode.MEMBER_NOT_FOUND;
-
 import com.keeper.homepage.domain.attendance.application.AttendanceService;
 import com.keeper.homepage.domain.member.dao.MemberRepository;
-import com.keeper.homepage.domain.member.entity.Member;
-import com.keeper.homepage.global.error.BusinessException;
 import com.keeper.homepage.global.util.redis.RedisUtil;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -37,9 +33,7 @@ public class AttendanceInterceptor implements HandlerInterceptor {
       String key = "attendance:member:" + memberId;
       Optional<String> data = redisUtil.getData(key, String.class);
       if (data.isEmpty()) {
-        Member member = memberRepository.findById(memberId)
-            .orElseThrow(() -> new BusinessException(memberId, "memberId", MEMBER_NOT_FOUND));
-        attendanceService.create(member);
+        attendanceService.create(memberId);
       }
     }
   }

--- a/src/main/java/com/keeper/homepage/global/config/web/WebMvcConfiguration.java
+++ b/src/main/java/com/keeper/homepage/global/config/web/WebMvcConfiguration.java
@@ -57,7 +57,7 @@ public class WebMvcConfiguration implements WebMvcConfigurer {
   @Override
   public void addInterceptors(InterceptorRegistry registry) {
     registry.addInterceptor(attendanceInterceptor)
-        .excludePathPatterns("/docs/**", "/keeper_files/**", "/auth-test", "/sign-up/**", "/error", "/about/**",
+        .excludePathPatterns("/docs/**", "/keeper_files/**", "/auth-test/**", "/sign-up/**", "/error", "/about/**",
             "/sign-in/**", "/posts/recent", "/posts/trend");
   }
 }

--- a/src/main/java/com/keeper/homepage/global/config/web/WebMvcConfiguration.java
+++ b/src/main/java/com/keeper/homepage/global/config/web/WebMvcConfiguration.java
@@ -25,6 +25,8 @@ public class WebMvcConfiguration implements WebMvcConfigurer {
   private final LoginMemberArgumentResolver loginMemberArgumentResolver;
   private final AttendanceInterceptor attendanceInterceptor;
 
+  private static final String[] ATTENDANCE_PATH = {"/about/**", "/members/**", "/attendances/**"};
+
   @Override
   public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
     resolvers.add(loginMemberArgumentResolver);
@@ -57,6 +59,6 @@ public class WebMvcConfiguration implements WebMvcConfigurer {
   @Override
   public void addInterceptors(InterceptorRegistry registry) {
     registry.addInterceptor(attendanceInterceptor)
-        .addPathPatterns("/about/**", "/members/**", "/attendances/**");
+        .addPathPatterns(ATTENDANCE_PATH);
   }
 }

--- a/src/main/java/com/keeper/homepage/global/config/web/WebMvcConfiguration.java
+++ b/src/main/java/com/keeper/homepage/global/config/web/WebMvcConfiguration.java
@@ -57,7 +57,6 @@ public class WebMvcConfiguration implements WebMvcConfigurer {
   @Override
   public void addInterceptors(InterceptorRegistry registry) {
     registry.addInterceptor(attendanceInterceptor)
-        .excludePathPatterns("/docs/**", "/keeper_files/**", "/auth-test/**", "/sign-up/**", "/error", "/about/**",
-            "/sign-in/**", "/posts/recent", "/posts/trend");
+        .addPathPatterns("/about/**", "/members/**", "/attendances/**");
   }
 }

--- a/src/main/java/com/keeper/homepage/global/config/web/WebMvcConfiguration.java
+++ b/src/main/java/com/keeper/homepage/global/config/web/WebMvcConfiguration.java
@@ -6,6 +6,7 @@ import com.keeper.homepage.domain.library.converter.BookDepartmentTypeConverter;
 import com.keeper.homepage.domain.library.converter.BookSearchTypeConverter;
 import com.keeper.homepage.domain.library.converter.BorrowLogTypeConverter;
 import com.keeper.homepage.domain.library.converter.BorrowStatusDtoConverter;
+import com.keeper.homepage.global.config.interceptor.AttendanceInterceptor;
 import com.keeper.homepage.global.config.security.annotation.LoginMemberArgumentResolver;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -13,6 +14,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.format.FormatterRegistry;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -21,6 +23,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 public class WebMvcConfiguration implements WebMvcConfigurer {
 
   private final LoginMemberArgumentResolver loginMemberArgumentResolver;
+  private final AttendanceInterceptor attendanceInterceptor;
 
   @Override
   public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
@@ -49,5 +52,12 @@ public class WebMvcConfiguration implements WebMvcConfigurer {
         .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
         .allowedHeaders("headers")
         .maxAge(3000);
+  }
+
+  @Override
+  public void addInterceptors(InterceptorRegistry registry) {
+    registry.addInterceptor(attendanceInterceptor)
+        .excludePathPatterns("/docs/**", "/keeper_files/**", "/auth-test", "/sign-up/**", "/error", "/about/**",
+            "/sign-in/**", "/posts/recent", "/posts/trend");
   }
 }

--- a/src/main/java/com/keeper/homepage/global/error/ErrorCode.java
+++ b/src/main/java/com/keeper/homepage/global/error/ErrorCode.java
@@ -82,7 +82,6 @@ public enum ErrorCode {
   // FILE
   FILE_NOT_FOUND("해당 파일은 존재하지 않습니다.", HttpStatus.BAD_REQUEST),
   // ATTENDANCE
-  ATTENDANCE_ALREADY("이미 출석을 완료했습니다.", HttpStatus.BAD_REQUEST),
   ATTENDANCE_NOT_FOUND("출석 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
   // CTF
   CTF_CONTEST_NOT_FOUND("해당 대회는 끝났거나 없는 대회입니다.", HttpStatus.BAD_REQUEST),

--- a/src/test/java/com/keeper/homepage/domain/attendance/api/AttendanceControllerTest.java
+++ b/src/test/java/com/keeper/homepage/domain/attendance/api/AttendanceControllerTest.java
@@ -18,7 +18,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.keeper.homepage.IntegrationTest;
-import com.keeper.homepage.domain.attendance.entity.Attendance;
 import com.keeper.homepage.domain.member.entity.Member;
 import jakarta.servlet.http.Cookie;
 import java.time.LocalDate;
@@ -116,13 +115,6 @@ public class AttendanceControllerTest extends IntegrationTest {
   @DisplayName("출석 조회 테스트")
   class GetAttendanceTest {
 
-    private Attendance attendance;
-
-    @BeforeEach
-    void setUp() {
-      attendance = attendanceTestHelper.builder().member(member).build();
-    }
-
     @Test
     @DisplayName("유효한 요청일 경우 오늘 출석 포인트 조회는 성공한다.")
     public void 유효한_요청일_경우_오늘_출석_포인트_조회는_성공한다() throws Exception {
@@ -131,10 +123,6 @@ public class AttendanceControllerTest extends IntegrationTest {
       mockMvc.perform(get("/attendances/point")
               .cookie(new Cookie(ACCESS_TOKEN.getTokenName(), memberToken)))
           .andExpect(status().isOk())
-          .andExpect(jsonPath("$.point").value(attendance.getPoint()))
-          .andExpect(jsonPath("$.continuousPoint").value(attendance.getContinuousPoint()))
-          .andExpect(jsonPath("$.rankPoint").value(attendance.getRankPoint()))
-          .andExpect(jsonPath("$.randomPoint").value(attendance.getRandomPoint()))
           .andDo(document("get-today-attendance-point",
               requestCookies(
                   cookieWithName(ACCESS_TOKEN.getTokenName())
@@ -157,9 +145,6 @@ public class AttendanceControllerTest extends IntegrationTest {
               .cookie(new Cookie(ACCESS_TOKEN.getTokenName(), memberToken)))
           .andExpect(status().isOk())
           .andExpect(jsonPath("$.totalAttendance").value(member.getTotalAttendance()))
-          .andExpect(jsonPath("$.continuousDay").value(attendance.getContinuousDay()))
-          .andExpect(jsonPath("$.todayRank").value(attendance.getRank()))
-          .andExpect(jsonPath("$.todayPoint").value(attendance.getTotalPoint()))
           .andDo(document("get-attendance-info",
               requestCookies(
                   cookieWithName(ACCESS_TOKEN.getTokenName())
@@ -188,7 +173,6 @@ public class AttendanceControllerTest extends IntegrationTest {
               .cookie(new Cookie(ACCESS_TOKEN.getTokenName(), memberToken)))
           .andExpect(status().isOk())
           .andExpect(jsonPath("$[0].value").value(1))
-          .andExpect(jsonPath("$[0].day").value(String.valueOf(attendance.getDate())))
           .andDo(document("get-total-attendance",
               requestCookies(
                   cookieWithName(ACCESS_TOKEN.getTokenName())

--- a/src/test/java/com/keeper/homepage/domain/attendance/api/AttendanceControllerTest.java
+++ b/src/test/java/com/keeper/homepage/domain/attendance/api/AttendanceControllerTest.java
@@ -9,7 +9,6 @@ import static org.springframework.restdocs.cookies.CookieDocumentation.cookieWit
 import static org.springframework.restdocs.cookies.CookieDocumentation.requestCookies;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
@@ -45,26 +44,6 @@ public class AttendanceControllerTest extends IntegrationTest {
 
     params.add("page", "0");
     params.add("size", "3");
-  }
-
-  @Nested
-  @DisplayName("출석 테스트")
-  class AttendanceTest {
-
-    @Test
-    @DisplayName("유효한 요청일 경우 출석은 성공한다.")
-    public void 유효한_요청일_경우_출석은_성공한다() throws Exception {
-      String securedValue = getSecuredValue(AttendanceController.class, "create");
-
-      mockMvc.perform(post("/attendances")
-              .cookie(new Cookie(ACCESS_TOKEN.getTokenName(), memberToken)))
-          .andExpect(status().isCreated())
-          .andDo(document("create-attendance",
-              requestCookies(
-                  cookieWithName(ACCESS_TOKEN.getTokenName())
-                      .description("ACCESS TOKEN %s".formatted(securedValue))
-              )));
-    }
   }
 
   @Nested

--- a/src/test/java/com/keeper/homepage/domain/attendance/application/AttendanceServiceTest.java
+++ b/src/test/java/com/keeper/homepage/domain/attendance/application/AttendanceServiceTest.java
@@ -1,11 +1,9 @@
 package com.keeper.homepage.domain.attendance.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.keeper.homepage.IntegrationTest;
 import com.keeper.homepage.domain.member.entity.Member;
-import com.keeper.homepage.global.error.BusinessException;
 import java.time.LocalDate;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
@@ -24,8 +22,8 @@ public class AttendanceServiceTest extends IntegrationTest {
       Member member1 = memberTestHelper.generate();
       Member member2 = memberTestHelper.generate();
       redisUtil.flushAll();
-      attendanceService.create(member1);
-      attendanceService.create(member2);
+      attendanceService.create(member1.getId());
+      attendanceService.create(member2.getId());
 
       LocalDate now = LocalDate.now();
       Optional<String> data = redisUtil.getData("attendance:" + now, String.class);
@@ -38,20 +36,9 @@ public class AttendanceServiceTest extends IntegrationTest {
     @DisplayName("출석할 경우 포인트 내역도 성공적으로 남아야 한다.")
     public void 출석할_경우_포인트_내역도_성공적으로_남아야_한다() throws Exception {
       Member member = memberTestHelper.generate();
-      attendanceService.create(member);
+      attendanceService.create(member.getId());
 
       assertThat(pointLogRepository.findByMember(member)).isNotEmpty();
-    }
-
-    @Test
-    @DisplayName("오늘 이미 출석한 경우 출석은 실패한다.")
-    public void 오늘_이미_출석한_경우_출석은_실패한다() throws Exception {
-      Member member = memberTestHelper.generate();
-      attendanceService.create(member);
-
-      assertThrows(BusinessException.class, () -> {
-        attendanceService.create(member);
-      });
     }
   }
 }


### PR DESCRIPTION
## 🔥 Related Issue

> close: #348

## 📝 Description

회원 출석에 관한 처리를 백엔드에서 하도록 추가 구현하였습니다. `Interceptor`를 활용하여 구현했는데 잘 구현한 건지 확인 부탁드립니당..!
참고로 출석은 `메인`, `회원`, `출석` 도메인의 api 요청에 대해서만 출석 처리를 하는 것으로 의논하였습니다.

## ⭐️ Review Request

3-2 개강을 했습니당... 🫠
