### PR TITLE
Feature/회원 탈퇴 기능 수정

### DIFF
--- a/src/main/java/com/keeper/homepage/domain/member/entity/embedded/Profile.java
+++ b/src/main/java/com/keeper/homepage/domain/member/entity/embedded/Profile.java
@@ -1,6 +1,7 @@
 package com.keeper.homepage.domain.member.entity.embedded;
 
 import static java.time.LocalDate.*;
+import static java.util.UUID.*;
 
 import com.keeper.homepage.domain.thumbnail.entity.Thumbnail;
 import jakarta.persistence.CascadeType;
@@ -11,6 +12,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
 import java.time.LocalDate;
+import java.util.Random;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -74,13 +76,36 @@ public class Profile {
   }
 
   public void deleteMemberProfile() {
-    final String uuid = UUID.randomUUID().toString();
-    this.loginId = LoginId.from(uuid);
-    this.emailAddress = EmailAddress.from(uuid);
-    this.studentId = StudentId.from(uuid);
+    this.loginId = LoginId.from(generateRandomString(80));
+    this.emailAddress = EmailAddress.from(generateRandomString(5) + '@' + generateRandomString(5) + ".com");
+    this.studentId = StudentId.from(generateRandomDigitString(45));
     this.password = Password.from("delete");
     this.realName = RealName.from("탈퇴회원");
     this.birthday = null;
     this.thumbnail = null;
+  }
+
+  public static final Random RANDOM = new Random();
+
+  private String generateRandomString(int length) {
+    char leftLimit = '0';
+    char rightLimit = 'z';
+
+    return Profile.RANDOM.ints(leftLimit, rightLimit + 1)
+        .filter(i -> Character.isAlphabetic(i) || Character.isDigit(i))
+        .limit(length)
+        .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
+        .toString();
+  }
+
+  private String generateRandomDigitString(int length) {
+    final Random random = new Random();
+    char leftLimit = '0';
+    char rightLimit = '9';
+
+    return random.ints(leftLimit, rightLimit + 1)
+        .limit(length)
+        .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
+        .toString();
   }
 }

--- a/src/main/java/com/keeper/homepage/domain/member/entity/embedded/Profile.java
+++ b/src/main/java/com/keeper/homepage/domain/member/entity/embedded/Profile.java
@@ -11,6 +11,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
 import java.time.LocalDate;
+import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -73,12 +74,13 @@ public class Profile {
   }
 
   public void deleteMemberProfile() {
-    this.loginId = LoginId.from("delete");
-    this.emailAddress = EmailAddress.from("delete@delete.com");
+    final String uuid = UUID.randomUUID().toString();
+    this.loginId = LoginId.from(uuid);
+    this.emailAddress = EmailAddress.from(uuid);
+    this.studentId = StudentId.from(uuid);
     this.password = Password.from("delete");
     this.realName = RealName.from("탈퇴회원");
     this.birthday = null;
-    this.studentId = null;
     this.thumbnail = null;
   }
 }

--- a/src/test/java/com/keeper/homepage/domain/member/application/MemberServiceTest.java
+++ b/src/test/java/com/keeper/homepage/domain/member/application/MemberServiceTest.java
@@ -126,12 +126,12 @@ public class MemberServiceTest extends IntegrationTest {
           .setParameter("id", member.getId())
           .getSingleResult();
 
-      assertThat(findMember.getProfile().getLoginId().get().length()).isEqualTo(80);
-      assertThat(findMember.getProfile().getEmailAddress().get().length()).isEqualTo(15);
+      assertThat(findMember.getProfile().getLoginId().get()).hasSize(80);
+      assertThat(findMember.getProfile().getEmailAddress().get()).hasSize(15);
       assertThat(findMember.getProfile().getPassword().isWrongPassword("delete")).isFalse();
       assertThat(findMember.getProfile().getRealName().get()).isEqualTo("탈퇴회원");
       assertThat(findMember.getProfile().getBirthday()).isNull();
-      assertThat(findMember.getProfile().getStudentId().get().length()).isEqualTo(45);
+      assertThat(findMember.getProfile().getStudentId().get()).hasSize(45);
       assertThat(findMember.getProfile().getThumbnail()).isNull();
     }
 

--- a/src/test/java/com/keeper/homepage/domain/member/application/MemberServiceTest.java
+++ b/src/test/java/com/keeper/homepage/domain/member/application/MemberServiceTest.java
@@ -126,12 +126,12 @@ public class MemberServiceTest extends IntegrationTest {
           .setParameter("id", member.getId())
           .getSingleResult();
 
-      assertThat(findMember.getProfile().getLoginId().get()).isEqualTo("delete");
-      assertThat(findMember.getProfile().getEmailAddress().get()).isEqualTo("delete@delete.com");
+      assertThat(findMember.getProfile().getLoginId().get().length()).isEqualTo(80);
+      assertThat(findMember.getProfile().getEmailAddress().get().length()).isEqualTo(15);
       assertThat(findMember.getProfile().getPassword().isWrongPassword("delete")).isFalse();
       assertThat(findMember.getProfile().getRealName().get()).isEqualTo("탈퇴회원");
       assertThat(findMember.getProfile().getBirthday()).isNull();
-      assertThat(findMember.getProfile().getStudentId()).isNull();
+      assertThat(findMember.getProfile().getStudentId().get().length()).isEqualTo(45);
       assertThat(findMember.getProfile().getThumbnail()).isNull();
     }
 


### PR DESCRIPTION
## 🔥 Related Issue

close: #361

## 📝 Description

1. 회원 DB의 login_id, email_address, student_id가 UNIQUE로 설정되어 두번째 탈퇴부터는 500 상태 메시지를 응답했습니다. 
UUID로 해결하려고 했으나 email과 student_id는 정규표현식으로 형태에 맞게 마킹을 해야 해서 @gusah009 선배님께서 작성해주신 memberTestHelp의 코드를 끌어다 와서 사용했습니다..!!

## ⭐️ Review Request

잘 부탁드리겠습니다~!!
