### PR TITLE
Feature/회원 탈퇴 기능 수정 및 관리자용 탈퇴 api 구현

### DIFF
--- a/src/docs/asciidoc/member/member.adoc
+++ b/src/docs/asciidoc/member/member.adoc
@@ -298,3 +298,25 @@ include::{snippets}/delete-member/request-fields.adoc[]
 ==== Response
 
 include::{snippets}/delete-member/http-response.adoc[]
+
+== *관리자용 회원 삭제*
+
+=== 요청
+
+==== Request
+
+include::{snippets}/admin-delete-member/http-request.adoc[]
+
+==== Request Cookies
+
+include::{snippets}/admin-delete-member/request-cookies.adoc[]
+
+==== Path Parameters
+
+include::{snippets}/admin-delete-member/path-parameters.adoc[]
+
+=== 응답
+
+==== Response
+
+include::{snippets}/admin-delete-member/http-response.adoc[]

--- a/src/main/java/com/keeper/homepage/domain/comment/dao/CommentRepository.java
+++ b/src/main/java/com/keeper/homepage/domain/comment/dao/CommentRepository.java
@@ -2,14 +2,16 @@ package com.keeper.homepage.domain.comment.dao;
 
 import com.keeper.homepage.domain.comment.entity.Comment;
 import com.keeper.homepage.domain.member.entity.Member;
-import com.keeper.homepage.domain.post.entity.Post;
-import java.util.List;
-import java.util.Map;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
-  Long countByMember(Member member);
-
-  List<Comment> findAllByPost(Post post);
+  @Modifying
+  @Query("UPDATE Comment c "
+      + "SET c.member = :virtualMember "
+      + "WHERE c.member = :member")
+  void updateMember(@Param("member") Member member, @Param("virtualMember") Member virtualMember);
 }

--- a/src/main/java/com/keeper/homepage/domain/comment/dao/CommentRepository.java
+++ b/src/main/java/com/keeper/homepage/domain/comment/dao/CommentRepository.java
@@ -13,5 +13,5 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
   @Query("UPDATE Comment c "
       + "SET c.member = :virtualMember "
       + "WHERE c.member = :member")
-  void updateMember(@Param("member") Member member, @Param("virtualMember") Member virtualMember);
+  void updateVirtualMember(@Param("member") Member member, @Param("virtualMember") Member virtualMember);
 }

--- a/src/main/java/com/keeper/homepage/domain/ctf/dao/CtfContestRepository.java
+++ b/src/main/java/com/keeper/homepage/domain/ctf/dao/CtfContestRepository.java
@@ -22,6 +22,6 @@ public interface CtfContestRepository extends JpaRepository<CtfContest, Long> {
   @Query("UPDATE CtfContest c "
       + "SET c.creator = :virtualMember "
       + "WHERE c.creator = :member")
-  void updateCreator(@Param("member") Member member, @Param("virtualMember") Member virtualMember);
+  void updateVirtualMember(@Param("member") Member member, @Param("virtualMember") Member virtualMember);
 
 }

--- a/src/main/java/com/keeper/homepage/domain/ctf/dao/CtfContestRepository.java
+++ b/src/main/java/com/keeper/homepage/domain/ctf/dao/CtfContestRepository.java
@@ -1,10 +1,14 @@
 package com.keeper.homepage.domain.ctf.dao;
 
 import com.keeper.homepage.domain.ctf.entity.CtfContest;
+import com.keeper.homepage.domain.member.entity.Member;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface CtfContestRepository extends JpaRepository<CtfContest, Long> {
 
@@ -13,4 +17,11 @@ public interface CtfContestRepository extends JpaRepository<CtfContest, Long> {
   Optional<CtfContest> findByIdAndIdNot(long contestId, long virtualId);
 
   Page<CtfContest> findAllByIdNot(long virtualId, Pageable pageable);
+
+  @Modifying
+  @Query("UPDATE CtfContest c "
+      + "SET c.creator = :virtualMember "
+      + "WHERE c.creator = :member")
+  void updateCreator(@Param("member") Member member, @Param("virtualMember") Member virtualMember);
+
 }

--- a/src/main/java/com/keeper/homepage/domain/ctf/dao/challenge/CtfChallengeRepository.java
+++ b/src/main/java/com/keeper/homepage/domain/ctf/dao/challenge/CtfChallengeRepository.java
@@ -13,6 +13,6 @@ public interface CtfChallengeRepository extends JpaRepository<CtfChallenge, Long
   @Query("UPDATE CtfChallenge c "
       + "SET c.creator = :virtualMember "
       + "WHERE c.creator = :member")
-  void updateCreator(@Param("member") Member member, @Param("virtualMember") Member virtualMember);
+  void updateVirtualMember(@Param("member") Member member, @Param("virtualMember") Member virtualMember);
 
 }

--- a/src/main/java/com/keeper/homepage/domain/ctf/dao/challenge/CtfChallengeRepository.java
+++ b/src/main/java/com/keeper/homepage/domain/ctf/dao/challenge/CtfChallengeRepository.java
@@ -1,8 +1,18 @@
 package com.keeper.homepage.domain.ctf.dao.challenge;
 
 import com.keeper.homepage.domain.ctf.entity.challenge.CtfChallenge;
+import com.keeper.homepage.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface CtfChallengeRepository extends JpaRepository<CtfChallenge, Long> {
+
+  @Modifying
+  @Query("UPDATE CtfChallenge c "
+      + "SET c.creator = :virtualMember "
+      + "WHERE c.creator = :member")
+  void updateCreator(@Param("member") Member member, @Param("virtualMember") Member virtualMember);
 
 }

--- a/src/main/java/com/keeper/homepage/domain/ctf/dao/team/CtfTeamRepository.java
+++ b/src/main/java/com/keeper/homepage/domain/ctf/dao/team/CtfTeamRepository.java
@@ -21,6 +21,6 @@ public interface CtfTeamRepository extends JpaRepository<CtfTeam, Long> {
   @Query("UPDATE CtfTeam c "
       + "SET c.creator = :virtualMember "
       + "WHERE c.creator = :member")
-  void updateCreator(@Param("member") Member member, @Param("virtualMember") Member virtualMember);
+  void updateVirtualMember(@Param("member") Member member, @Param("virtualMember") Member virtualMember);
 
 }

--- a/src/main/java/com/keeper/homepage/domain/ctf/dao/team/CtfTeamRepository.java
+++ b/src/main/java/com/keeper/homepage/domain/ctf/dao/team/CtfTeamRepository.java
@@ -2,14 +2,25 @@ package com.keeper.homepage.domain.ctf.dao.team;
 
 import com.keeper.homepage.domain.ctf.entity.CtfContest;
 import com.keeper.homepage.domain.ctf.entity.team.CtfTeam;
+import com.keeper.homepage.domain.member.entity.Member;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface CtfTeamRepository extends JpaRepository<CtfTeam, Long> {
 
   Optional<CtfTeam> findByIdAndIdNot(long teamId, long virtualId);
 
   Page<CtfTeam> findAllByCtfContestAndNameIgnoreCaseContaining(CtfContest ctfContest, String search, Pageable pageable);
+
+  @Modifying
+  @Query("UPDATE CtfTeam c "
+      + "SET c.creator = :virtualMember "
+      + "WHERE c.creator = :member")
+  void updateCreator(@Param("member") Member member, @Param("virtualMember") Member virtualMember);
+
 }

--- a/src/main/java/com/keeper/homepage/domain/ctf/entity/CtfContest.java
+++ b/src/main/java/com/keeper/homepage/domain/ctf/entity/CtfContest.java
@@ -71,4 +71,8 @@ public class CtfContest extends BaseEntity {
   public void close() {
     this.isJoinable = false;
   }
+
+  public void changeCreator(Member member) {
+    this.creator = member;
+  }
 }

--- a/src/main/java/com/keeper/homepage/domain/ctf/entity/challenge/CtfChallenge.java
+++ b/src/main/java/com/keeper/homepage/domain/ctf/entity/challenge/CtfChallenge.java
@@ -124,4 +124,8 @@ public class CtfChallenge extends BaseEntity {
     this.ctfDynamicChallengeInfo = ctfDynamicChallengeInfo;
     ctfDynamicChallengeInfo.setCtfChallenge(this);
   }
+
+  public void changeCreator(Member member) {
+    this.creator = member;
+  }
 }

--- a/src/main/java/com/keeper/homepage/domain/ctf/entity/team/CtfTeam.java
+++ b/src/main/java/com/keeper/homepage/domain/ctf/entity/team/CtfTeam.java
@@ -81,4 +81,8 @@ public class CtfTeam extends BaseEntity {
     this.name = name;
     this.description = description;
   }
+
+  public void changeCreator(Member member) {
+    this.creator = member;
+  }
 }

--- a/src/main/java/com/keeper/homepage/domain/election/dao/ElectionRepository.java
+++ b/src/main/java/com/keeper/homepage/domain/election/dao/ElectionRepository.java
@@ -1,15 +1,25 @@
 package com.keeper.homepage.domain.election.dao;
 
 import com.keeper.homepage.domain.election.entity.Election;
+import com.keeper.homepage.domain.member.entity.Member;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ElectionRepository extends JpaRepository<Election, Long> {
 
   Optional<Election> findByIdAndIdNot(Long electionId, Long virtualId);
 
   Page<Election> findAllByIdNot(long virtualId, Pageable pageable);
+
+  @Modifying
+  @Query("UPDATE Election e "
+      + "SET e.member = :virtualMember "
+      + "WHERE e.member = :member")
+  void updateMember(@Param("member") Member member, @Param("virtualMember") Member virtualMember);
 
 }

--- a/src/main/java/com/keeper/homepage/domain/election/dao/ElectionRepository.java
+++ b/src/main/java/com/keeper/homepage/domain/election/dao/ElectionRepository.java
@@ -20,6 +20,6 @@ public interface ElectionRepository extends JpaRepository<Election, Long> {
   @Query("UPDATE Election e "
       + "SET e.member = :virtualMember "
       + "WHERE e.member = :member")
-  void updateMember(@Param("member") Member member, @Param("virtualMember") Member virtualMember);
+  void updateVirtualMember(@Param("member") Member member, @Param("virtualMember") Member virtualMember);
 
 }

--- a/src/main/java/com/keeper/homepage/domain/election/entity/Election.java
+++ b/src/main/java/com/keeper/homepage/domain/election/entity/Election.java
@@ -89,4 +89,8 @@ public class Election {
     this.isAvailable = false;
   }
 
+  public void changeMember(Member member) {
+    this.member = member;
+  }
+
 }

--- a/src/main/java/com/keeper/homepage/domain/game/dao/GameRepository.java
+++ b/src/main/java/com/keeper/homepage/domain/game/dao/GameRepository.java
@@ -12,4 +12,6 @@ public interface GameRepository extends JpaRepository<Game, Long> {
   Optional<Game> findByMemberAndPlayDate(Member member, LocalDate playDate);
 
   List<Game> findAllByPlayDate(LocalDate playDate);
+
+  void deleteAllByMember(Member member);
 }

--- a/src/main/java/com/keeper/homepage/domain/member/api/MemberController.java
+++ b/src/main/java/com/keeper/homepage/domain/member/api/MemberController.java
@@ -4,6 +4,7 @@ import com.keeper.homepage.domain.auth.application.EmailAuthService;
 import com.keeper.homepage.domain.auth.dto.request.EmailAuthRequest;
 import com.keeper.homepage.domain.member.application.MemberProfileService;
 import com.keeper.homepage.domain.member.application.MemberService;
+import com.keeper.homepage.domain.member.dto.request.AdminDeleteMemberRequest;
 import com.keeper.homepage.domain.member.dto.request.ChangePasswordRequest;
 import com.keeper.homepage.domain.member.dto.request.DeleteMemberRequest;
 import com.keeper.homepage.domain.member.dto.request.ProfileUpdateRequest;
@@ -23,6 +24,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.annotation.Secured;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -123,6 +125,7 @@ public class MemberController {
     return ResponseEntity.ok(memberService.getMemberProfile(memberId));
   }
 
+  @Secured({"ROLE_회장", "ROLE_서기"})
   @PatchMapping("/types/{typeId}")
   public ResponseEntity<Void> updateMemberType(
       @PathVariable long typeId,
@@ -156,6 +159,15 @@ public class MemberController {
       @LoginMember Member member,
       @RequestBody @Valid DeleteMemberRequest request) {
     memberService.deleteMember(member, request.getRawPassword());
+    return ResponseEntity.noContent().build();
+  }
+
+  @Secured({"ROLE_회장", "ROLE_서기"})
+  @DeleteMapping("/admin")
+  public ResponseEntity<Void> deleteMemberByAdmin(
+      @RequestBody @Valid AdminDeleteMemberRequest request
+  ) {
+    memberService.deleteMemberByAdmin(request.getMemberIds());
     return ResponseEntity.noContent().build();
   }
 }

--- a/src/main/java/com/keeper/homepage/domain/member/api/MemberController.java
+++ b/src/main/java/com/keeper/homepage/domain/member/api/MemberController.java
@@ -1,9 +1,7 @@
 package com.keeper.homepage.domain.member.api;
 
-import com.keeper.homepage.domain.auth.application.CheckDuplicateService;
 import com.keeper.homepage.domain.auth.application.EmailAuthService;
 import com.keeper.homepage.domain.auth.dto.request.EmailAuthRequest;
-import com.keeper.homepage.domain.auth.dto.response.EmailAuthResponse;
 import com.keeper.homepage.domain.member.application.MemberProfileService;
 import com.keeper.homepage.domain.member.application.MemberService;
 import com.keeper.homepage.domain.member.dto.request.ChangePasswordRequest;
@@ -32,7 +30,6 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -154,7 +151,7 @@ public class MemberController {
     return ResponseEntity.noContent().build();
   }
 
-  @PatchMapping
+  @DeleteMapping
   public ResponseEntity<Void> deleteMember(
       @LoginMember Member member,
       @RequestBody @Valid DeleteMemberRequest request) {

--- a/src/main/java/com/keeper/homepage/domain/member/application/MemberService.java
+++ b/src/main/java/com/keeper/homepage/domain/member/application/MemberService.java
@@ -7,24 +7,19 @@ import static com.keeper.homepage.global.error.ErrorCode.MEMBER_TYPE_NOT_FOUND;
 
 import com.keeper.homepage.domain.member.application.convenience.MemberFindService;
 import com.keeper.homepage.domain.member.dao.MemberRepository;
-import com.keeper.homepage.domain.member.dao.friend.FriendRepository;
 import com.keeper.homepage.domain.member.dao.type.MemberTypeRepository;
 import com.keeper.homepage.domain.member.dto.response.MemberPointRankResponse;
 import com.keeper.homepage.domain.member.dto.response.MemberResponse;
 import com.keeper.homepage.domain.member.dto.response.profile.MemberProfileResponse;
 import com.keeper.homepage.domain.member.entity.Member;
 import com.keeper.homepage.domain.member.entity.embedded.RealName;
-import com.keeper.homepage.domain.member.entity.friend.Friend;
 import com.keeper.homepage.domain.member.entity.type.MemberType;
 import com.keeper.homepage.global.error.BusinessException;
-import com.keeper.homepage.global.error.ErrorCode;
 import java.util.List;
-import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
@@ -93,7 +88,7 @@ public class MemberService {
   public void deleteMember(Member member, String rawPassword) {
     memberProfileService.checkMemberPassword(member, rawPassword);
     checkBorrowedBook(member);
-    member.deleteMember();
+    // TODO: 회원 delete
   }
 
   private void checkBorrowedBook(Member member) {

--- a/src/main/java/com/keeper/homepage/domain/member/application/MemberService.java
+++ b/src/main/java/com/keeper/homepage/domain/member/application/MemberService.java
@@ -100,4 +100,14 @@ public class MemberService {
       throw new BusinessException(member.getBookBorrowInfos(), "memberBorrowInfos", MEMBER_BOOK_NOT_EMPTY);
     }
   }
+
+  @Transactional
+  public void deleteMemberByAdmin(List<Long> memberIds) {
+    for (long memberId : memberIds) {
+      Member member = memberFindService.findById(memberId);
+      checkBorrowedBook(member);
+
+      memberDeleteService.delete(member);
+    }
+  }
 }

--- a/src/main/java/com/keeper/homepage/domain/member/application/MemberService.java
+++ b/src/main/java/com/keeper/homepage/domain/member/application/MemberService.java
@@ -5,6 +5,7 @@ import static com.keeper.homepage.global.error.ErrorCode.MEMBER_BOOK_NOT_EMPTY;
 import static com.keeper.homepage.global.error.ErrorCode.MEMBER_CANNOT_FOLLOW_ME;
 import static com.keeper.homepage.global.error.ErrorCode.MEMBER_TYPE_NOT_FOUND;
 
+import com.keeper.homepage.domain.member.application.convenience.MemberDeleteService;
 import com.keeper.homepage.domain.member.application.convenience.MemberFindService;
 import com.keeper.homepage.domain.member.dao.MemberRepository;
 import com.keeper.homepage.domain.member.dao.type.MemberTypeRepository;
@@ -31,6 +32,8 @@ public class MemberService {
   private final MemberFindService memberFindService;
   private final MemberProfileService memberProfileService;
   private final MemberTypeRepository memberTypeRepository;
+  private final MemberDeleteService memberDeleteService;
+
 
   @Transactional
   public void changePassword(Member me, String newPassword) {
@@ -88,7 +91,8 @@ public class MemberService {
   public void deleteMember(Member member, String rawPassword) {
     memberProfileService.checkMemberPassword(member, rawPassword);
     checkBorrowedBook(member);
-    // TODO: 회원 delete
+
+    memberDeleteService.delete(member);
   }
 
   private void checkBorrowedBook(Member member) {

--- a/src/main/java/com/keeper/homepage/domain/member/application/convenience/MemberDeleteService.java
+++ b/src/main/java/com/keeper/homepage/domain/member/application/convenience/MemberDeleteService.java
@@ -48,14 +48,14 @@ public class MemberDeleteService {
 
   public void delete(Member member) {
     Member virtualMember = getVirtualMember();
-    postRepository.updateMember(member, virtualMember);
-    commentRepository.updateMember(member, virtualMember);
-    studyRepository.updateMember(member, virtualMember);
-    seminarRepository.updateStarter(member, virtualMember);
-    ctfChallengeRepository.updateCreator(member, virtualMember);
-    ctfTeamRepository.updateCreator(member, virtualMember);
-    ctfContestRepository.updateCreator(member, virtualMember);
-    electionRepository.updateMember(member, virtualMember);
+    postRepository.updateVirtualMember(member, virtualMember);
+    commentRepository.updateVirtualMember(member, virtualMember);
+    studyRepository.updateVirtualMember(member, virtualMember);
+    seminarRepository.updateVirtualMember(member, virtualMember);
+    ctfChallengeRepository.updateVirtualMember(member, virtualMember);
+    ctfTeamRepository.updateVirtualMember(member, virtualMember);
+    ctfContestRepository.updateVirtualMember(member, virtualMember);
+    electionRepository.updateVirtualMember(member, virtualMember);
 
     gameRepository.deleteAllByMember(member);
     postLikeRepository.deleteAllByMember(member);

--- a/src/main/java/com/keeper/homepage/domain/member/application/convenience/MemberDeleteService.java
+++ b/src/main/java/com/keeper/homepage/domain/member/application/convenience/MemberDeleteService.java
@@ -1,0 +1,74 @@
+package com.keeper.homepage.domain.member.application.convenience;
+
+import static com.keeper.homepage.global.error.ErrorCode.MEMBER_NOT_FOUND;
+
+import com.keeper.homepage.domain.comment.dao.CommentRepository;
+import com.keeper.homepage.domain.ctf.dao.CtfContestRepository;
+import com.keeper.homepage.domain.ctf.dao.challenge.CtfChallengeRepository;
+import com.keeper.homepage.domain.ctf.dao.team.CtfTeamRepository;
+import com.keeper.homepage.domain.election.dao.ElectionRepository;
+import com.keeper.homepage.domain.game.dao.GameRepository;
+import com.keeper.homepage.domain.member.dao.MemberRepository;
+import com.keeper.homepage.domain.member.dao.comment.MemberHasCommentDislikeRepository;
+import com.keeper.homepage.domain.member.dao.comment.MemberHasCommentLikeRepository;
+import com.keeper.homepage.domain.member.dao.post.MemberHasPostDislikeRepository;
+import com.keeper.homepage.domain.member.dao.post.MemberHasPostLikeRepository;
+import com.keeper.homepage.domain.member.dao.post.MemberReadPostRepository;
+import com.keeper.homepage.domain.member.entity.Member;
+import com.keeper.homepage.domain.post.dao.PostRepository;
+import com.keeper.homepage.domain.seminar.dao.SeminarRepository;
+import com.keeper.homepage.domain.study.dao.StudyRepository;
+import com.keeper.homepage.global.error.BusinessException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MemberDeleteService {
+
+  public static final long VIRTUAL_MEMBER_ID = 1;
+
+  private final MemberRepository memberRepository;
+  private final PostRepository postRepository;
+  private final CommentRepository commentRepository;
+  private final MemberHasCommentLikeRepository commentLikeRepository;
+  private final MemberHasCommentDislikeRepository commentDislikeRepository;
+  private final MemberHasPostLikeRepository postLikeRepository;
+  private final MemberHasPostDislikeRepository postDislikeRepository;
+  private final MemberReadPostRepository readPostRepository;
+  private final StudyRepository studyRepository;
+  private final SeminarRepository seminarRepository;
+  private final CtfChallengeRepository ctfChallengeRepository;
+  private final CtfTeamRepository ctfTeamRepository;
+  private final CtfContestRepository ctfContestRepository;
+  private final ElectionRepository electionRepository;
+  private final GameRepository gameRepository;
+
+  public void delete(Member member) {
+    Member virtualMember = getVirtualMember();
+    postRepository.updateMember(member, virtualMember);
+    commentRepository.updateMember(member, virtualMember);
+    studyRepository.updateMember(member, virtualMember);
+    seminarRepository.updateStarter(member, virtualMember);
+    ctfChallengeRepository.updateCreator(member, virtualMember);
+    ctfTeamRepository.updateCreator(member, virtualMember);
+    ctfContestRepository.updateCreator(member, virtualMember);
+    electionRepository.updateMember(member, virtualMember);
+
+    gameRepository.deleteAllByMember(member);
+    postLikeRepository.deleteAllByMember(member);
+    postDislikeRepository.deleteAllByMember(member);
+    commentLikeRepository.deleteAllByMember(member);
+    commentDislikeRepository.deleteAllByMember(member);
+    readPostRepository.deleteAllByMember(member);
+    postRepository.deleteAllByMemberAndIsTempTrue(member);
+    memberRepository.delete(member);
+  }
+
+  public Member getVirtualMember() {
+    return memberRepository.findById(VIRTUAL_MEMBER_ID)
+        .orElseThrow(() -> new BusinessException(VIRTUAL_MEMBER_ID, "memberId", MEMBER_NOT_FOUND));
+  }
+}

--- a/src/main/java/com/keeper/homepage/domain/member/application/convenience/MemberDeleteService.java
+++ b/src/main/java/com/keeper/homepage/domain/member/application/convenience/MemberDeleteService.java
@@ -11,6 +11,7 @@ import com.keeper.homepage.domain.game.dao.GameRepository;
 import com.keeper.homepage.domain.member.dao.MemberRepository;
 import com.keeper.homepage.domain.member.dao.comment.MemberHasCommentDislikeRepository;
 import com.keeper.homepage.domain.member.dao.comment.MemberHasCommentLikeRepository;
+import com.keeper.homepage.domain.member.dao.friend.FriendRepository;
 import com.keeper.homepage.domain.member.dao.post.MemberHasPostDislikeRepository;
 import com.keeper.homepage.domain.member.dao.post.MemberHasPostLikeRepository;
 import com.keeper.homepage.domain.member.dao.post.MemberReadPostRepository;
@@ -45,6 +46,7 @@ public class MemberDeleteService {
   private final CtfContestRepository ctfContestRepository;
   private final ElectionRepository electionRepository;
   private final GameRepository gameRepository;
+  private final FriendRepository friendRepository;
 
   public void delete(Member member) {
     Member virtualMember = getVirtualMember();
@@ -57,6 +59,8 @@ public class MemberDeleteService {
     ctfContestRepository.updateVirtualMember(member, virtualMember);
     electionRepository.updateVirtualMember(member, virtualMember);
 
+    friendRepository.deleteAllByFollowee(member);
+    friendRepository.deleteAllByFollower(member);
     gameRepository.deleteAllByMember(member);
     postLikeRepository.deleteAllByMember(member);
     postDislikeRepository.deleteAllByMember(member);

--- a/src/main/java/com/keeper/homepage/domain/member/dao/comment/MemberHasCommentDislikeRepository.java
+++ b/src/main/java/com/keeper/homepage/domain/member/dao/comment/MemberHasCommentDislikeRepository.java
@@ -1,6 +1,7 @@
 package com.keeper.homepage.domain.member.dao.comment;
 
 import com.keeper.homepage.domain.comment.entity.Comment;
+import com.keeper.homepage.domain.member.entity.Member;
 import com.keeper.homepage.domain.member.entity.comment.MemberHasCommentDislike;
 import com.keeper.homepage.domain.post.entity.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -11,5 +12,5 @@ public interface MemberHasCommentDislikeRepository extends JpaRepository<MemberH
 
   void deleteAllByComment_Post(Post post);
 
-  Long countByComment(Comment comment);
+  void deleteAllByMember(Member member);
 }

--- a/src/main/java/com/keeper/homepage/domain/member/dao/comment/MemberHasCommentLikeRepository.java
+++ b/src/main/java/com/keeper/homepage/domain/member/dao/comment/MemberHasCommentLikeRepository.java
@@ -1,6 +1,7 @@
 package com.keeper.homepage.domain.member.dao.comment;
 
 import com.keeper.homepage.domain.comment.entity.Comment;
+import com.keeper.homepage.domain.member.entity.Member;
 import com.keeper.homepage.domain.member.entity.comment.MemberHasCommentLike;
 import com.keeper.homepage.domain.post.entity.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -11,5 +12,5 @@ public interface MemberHasCommentLikeRepository extends JpaRepository<MemberHasC
 
   void deleteAllByComment_Post(Post post);
 
-  Long countByComment(Comment comment);
+  void deleteAllByMember(Member member);
 }

--- a/src/main/java/com/keeper/homepage/domain/member/dao/friend/FriendRepository.java
+++ b/src/main/java/com/keeper/homepage/domain/member/dao/friend/FriendRepository.java
@@ -1,7 +1,12 @@
 package com.keeper.homepage.domain.member.dao.friend;
 
+import com.keeper.homepage.domain.member.entity.Member;
 import com.keeper.homepage.domain.member.entity.friend.Friend;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface FriendRepository extends JpaRepository<Friend, Long> {
+
+  void deleteAllByFollower(Member member);
+
+  void deleteAllByFollowee(Member member);
 }

--- a/src/main/java/com/keeper/homepage/domain/member/dao/post/MemberHasPostDislikeRepository.java
+++ b/src/main/java/com/keeper/homepage/domain/member/dao/post/MemberHasPostDislikeRepository.java
@@ -1,5 +1,6 @@
 package com.keeper.homepage.domain.member.dao.post;
 
+import com.keeper.homepage.domain.member.entity.Member;
 import com.keeper.homepage.domain.member.entity.post.MemberHasPostDislike;
 import com.keeper.homepage.domain.post.entity.Post;
 import java.util.List;
@@ -11,5 +12,5 @@ public interface MemberHasPostDislikeRepository extends JpaRepository<MemberHasP
 
   void deleteAllByPost(Post post);
 
-  Long countByPost(Post post);
+  void deleteAllByMember(Member member);
 }

--- a/src/main/java/com/keeper/homepage/domain/member/dao/post/MemberHasPostLikeRepository.java
+++ b/src/main/java/com/keeper/homepage/domain/member/dao/post/MemberHasPostLikeRepository.java
@@ -1,5 +1,6 @@
 package com.keeper.homepage.domain.member.dao.post;
 
+import com.keeper.homepage.domain.member.entity.Member;
 import com.keeper.homepage.domain.member.entity.post.MemberHasPostLike;
 import com.keeper.homepage.domain.post.entity.Post;
 import java.util.List;
@@ -11,5 +12,5 @@ public interface MemberHasPostLikeRepository extends JpaRepository<MemberHasPost
 
   void deleteAllByPost(Post post);
 
-  Long countByPost(Post post);
+  void deleteAllByMember(Member member);
 }

--- a/src/main/java/com/keeper/homepage/domain/member/dao/post/MemberReadPostRepository.java
+++ b/src/main/java/com/keeper/homepage/domain/member/dao/post/MemberReadPostRepository.java
@@ -1,0 +1,11 @@
+package com.keeper.homepage.domain.member.dao.post;
+
+import com.keeper.homepage.domain.member.entity.Member;
+import com.keeper.homepage.domain.member.entity.post.MemberReadPost;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberReadPostRepository extends JpaRepository<MemberReadPost, Long> {
+
+  void deleteAllByMember(Member member);
+
+}

--- a/src/main/java/com/keeper/homepage/domain/member/dto/request/AdminDeleteMemberRequest.java
+++ b/src/main/java/com/keeper/homepage/domain/member/dto/request/AdminDeleteMemberRequest.java
@@ -1,0 +1,22 @@
+package com.keeper.homepage.domain.member.dto.request;
+
+import static lombok.AccessLevel.PRIVATE;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = PRIVATE)
+@AllArgsConstructor(access = PRIVATE)
+public class AdminDeleteMemberRequest {
+
+  @NotEmpty(message = "하나 이상의 회원 ID를 입력해주세요.")
+  private List<@NotNull Long> memberIds;
+
+}

--- a/src/main/java/com/keeper/homepage/domain/member/entity/Member.java
+++ b/src/main/java/com/keeper/homepage/domain/member/entity/Member.java
@@ -8,15 +8,19 @@ import static com.keeper.homepage.domain.member.entity.embedded.StudentId.MAX_ST
 import static com.keeper.homepage.domain.member.entity.rank.MemberRank.MemberRankType.일반회원;
 import static com.keeper.homepage.domain.member.entity.type.MemberType.MemberTypeEnum.정회원;
 import static jakarta.persistence.CascadeType.ALL;
-import static jakarta.persistence.CascadeType.PERSIST;
 import static jakarta.persistence.CascadeType.REMOVE;
+import static jakarta.persistence.FetchType.LAZY;
 import static java.time.LocalDate.now;
 
 import com.keeper.homepage.domain.attendance.entity.Attendance;
 import com.keeper.homepage.domain.comment.entity.Comment;
 import com.keeper.homepage.domain.ctf.entity.CtfContest;
+import com.keeper.homepage.domain.ctf.entity.challenge.CtfChallenge;
 import com.keeper.homepage.domain.ctf.entity.team.CtfTeam;
 import com.keeper.homepage.domain.ctf.entity.team.CtfTeamHasMember;
+import com.keeper.homepage.domain.election.entity.Election;
+import com.keeper.homepage.domain.election.entity.ElectionCandidate;
+import com.keeper.homepage.domain.election.entity.ElectionVoter;
 import com.keeper.homepage.domain.library.entity.Book;
 import com.keeper.homepage.domain.library.entity.BookBorrowInfo;
 import com.keeper.homepage.domain.library.entity.BookBorrowStatus;
@@ -35,16 +39,17 @@ import com.keeper.homepage.domain.member.entity.rank.MemberRank;
 import com.keeper.homepage.domain.member.entity.type.MemberType;
 import com.keeper.homepage.domain.point.entity.PointLog;
 import com.keeper.homepage.domain.post.entity.Post;
+import com.keeper.homepage.domain.seminar.entity.Seminar;
 import com.keeper.homepage.domain.seminar.entity.SeminarAttendance;
 import com.keeper.homepage.domain.study.entity.Study;
 import com.keeper.homepage.domain.study.entity.StudyHasMember;
+import com.keeper.homepage.domain.survey.entity.SurveyMemberReply;
 import com.keeper.homepage.domain.thumbnail.entity.Thumbnail;
 import jakarta.persistence.AttributeOverride;
 import jakarta.persistence.AttributeOverrides;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -65,13 +70,11 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
-import org.hibernate.annotations.Where;
 
 @DynamicInsert
 @DynamicUpdate
 @Getter
 @Entity
-@Where(clause = "is_deleted = false")
 @EqualsAndHashCode(of = {"id"})
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "member")
@@ -104,18 +107,18 @@ public class Member {
   @Column(name = "total_attendance", nullable = false)
   private Integer totalAttendance;
 
-  @ManyToOne(fetch = FetchType.LAZY)
+  @ManyToOne(fetch = LAZY)
   @JoinColumn(name = "member_type_id")
   private MemberType memberType;
 
-  @ManyToOne(fetch = FetchType.LAZY)
+  @ManyToOne(fetch = LAZY)
   @JoinColumn(name = "member_rank_id")
   private MemberRank memberRank;
 
   @OneToMany(mappedBy = "member", cascade = REMOVE)
   private final List<Attendance> memberAttendance = new ArrayList<>();
 
-  @OneToMany(mappedBy = "member", cascade = PERSIST)
+  @OneToMany(mappedBy = "member", cascade = ALL)
   private final List<BookBorrowInfo> bookBorrowInfos = new ArrayList<>();
 
   @OneToMany(mappedBy = "member", cascade = ALL, orphanRemoval = true)
@@ -124,7 +127,7 @@ public class Member {
   @OneToMany(mappedBy = "follower", cascade = ALL, orphanRemoval = true)
   private final Set<Friend> follower = new HashSet<>();
 
-  @OneToMany(mappedBy = "followee")
+  @OneToMany(mappedBy = "followee", cascade = REMOVE)
   private final Set<Friend> followee = new HashSet<>();
 
   @OneToMany(mappedBy = "member", cascade = ALL, orphanRemoval = true)
@@ -146,9 +149,30 @@ public class Member {
   private final Set<StudyHasMember> studyMembers = new HashSet<>();
 
   @OneToMany(mappedBy = "member")
+  private final List<Post> posts = new ArrayList<>();
+
+  @OneToMany(mappedBy = "member")
   private final List<Comment> comments = new ArrayList<>();
 
-  @OneToMany(mappedBy = "member", cascade = PERSIST)
+  @OneToMany(mappedBy = "headMember")
+  private final List<Study> studies = new ArrayList<>();
+
+  @OneToMany(mappedBy = "starter")
+  private final List<Seminar> seminars = new ArrayList<>();
+
+  @OneToMany(mappedBy = "creator")
+  private final List<CtfChallenge> ctfChallenges = new ArrayList<>();
+
+  @OneToMany(mappedBy = "creator")
+  private final List<CtfTeam> ctfTeams = new ArrayList<>();
+
+  @OneToMany(mappedBy = "creator")
+  private final List<CtfContest> ctfContests = new ArrayList<>();
+
+  @OneToMany(mappedBy = "member")
+  private final List<Election> elections = new ArrayList<>();
+
+  @OneToMany(mappedBy = "member", cascade = ALL)
   private final List<PointLog> pointLogs = new ArrayList<>();
 
   @OneToMany(mappedBy = "member", cascade = ALL, orphanRemoval = true)
@@ -156,6 +180,15 @@ public class Member {
 
   @OneToMany(mappedBy = "member", cascade = REMOVE)
   private final List<SeminarAttendance> seminarAttendances = new ArrayList<>();
+
+  @OneToMany(mappedBy = "member", cascade = REMOVE)
+  private final List<SurveyMemberReply> surveyMemberReplies = new ArrayList<>();
+
+  @OneToMany(mappedBy = "member", cascade = REMOVE)
+  private final List<ElectionCandidate> electionCandidates = new ArrayList<>();
+
+  @OneToMany(mappedBy = "member", cascade = REMOVE)
+  private final List<ElectionVoter> electionVoters = new ArrayList<>();
 
   @Builder
   private Member(Profile profile, Integer point, Integer level, Integer totalAttendance) {

--- a/src/main/java/com/keeper/homepage/domain/member/entity/Member.java
+++ b/src/main/java/com/keeper/homepage/domain/member/entity/Member.java
@@ -10,7 +10,7 @@ import static com.keeper.homepage.domain.member.entity.type.MemberType.MemberTyp
 import static jakarta.persistence.CascadeType.ALL;
 import static jakarta.persistence.CascadeType.PERSIST;
 import static jakarta.persistence.CascadeType.REMOVE;
-import static java.time.LocalDate.*;
+import static java.time.LocalDate.now;
 
 import com.keeper.homepage.domain.attendance.entity.Attendance;
 import com.keeper.homepage.domain.comment.entity.Comment;
@@ -52,7 +52,6 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -113,9 +112,6 @@ public class Member {
   @JoinColumn(name = "member_rank_id")
   private MemberRank memberRank;
 
-  @Column(name = "is_deleted", nullable = false)
-  private Boolean isDeleted;
-
   @OneToMany(mappedBy = "member", cascade = REMOVE)
   private final List<Attendance> memberAttendance = new ArrayList<>();
 
@@ -171,7 +167,6 @@ public class Member {
     this.memberType = MemberType.getMemberTypeBy(정회원);
     this.memberRank = MemberRank.getMemberRankBy(일반회원);
     this.assignJob(MemberJobType.ROLE_회원);
-    this.isDeleted = false;
   }
 
   public void assignJob(MemberJobType jobType) {
@@ -408,13 +403,5 @@ public class Member {
   public boolean hasAnyBorrowBooks() {
     return this.bookBorrowInfos.stream()
         .anyMatch(BookBorrowInfo::isInBorrowing);
-  }
-
-  public void deleteMember() {
-    this.getProfile().deleteMemberProfile();
-    this.generation = Generation.generateGeneration(now());
-    this.totalAttendance = 0;
-    this.level = 0;
-    this.isDeleted = true;
   }
 }

--- a/src/main/java/com/keeper/homepage/domain/member/entity/embedded/Profile.java
+++ b/src/main/java/com/keeper/homepage/domain/member/entity/embedded/Profile.java
@@ -1,6 +1,7 @@
 package com.keeper.homepage.domain.member.entity.embedded;
 
 import static java.time.LocalDate.*;
+import static java.util.UUID.*;
 
 import com.keeper.homepage.domain.thumbnail.entity.Thumbnail;
 import jakarta.persistence.CascadeType;
@@ -11,6 +12,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
 import java.time.LocalDate;
+import java.util.Random;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -74,13 +76,36 @@ public class Profile {
   }
 
   public void deleteMemberProfile() {
-    final String uuid = UUID.randomUUID().toString();
-    this.loginId = LoginId.from(uuid);
-    this.emailAddress = EmailAddress.from(uuid);
-    this.studentId = StudentId.from(uuid);
+    this.loginId = LoginId.from(generateRandomString(80));
+    this.emailAddress = EmailAddress.from(generateRandomString(5) + '@' + generateRandomString(5) + ".com");
+    this.studentId = StudentId.from(generateRandomDigitString(45));
     this.password = Password.from("delete");
     this.realName = RealName.from("탈퇴회원");
     this.birthday = null;
     this.thumbnail = null;
+  }
+
+  public static final Random RANDOM = new Random();
+
+  private String generateRandomString(int length) {
+    char leftLimit = '0';
+    char rightLimit = 'z';
+
+    return Profile.RANDOM.ints(leftLimit, rightLimit + 1)
+        .filter(i -> Character.isAlphabetic(i) || Character.isDigit(i))
+        .limit(length)
+        .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
+        .toString();
+  }
+
+  private String generateRandomDigitString(int length) {
+    final Random random = new Random();
+    char leftLimit = '0';
+    char rightLimit = '9';
+
+    return random.ints(leftLimit, rightLimit + 1)
+        .limit(length)
+        .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
+        .toString();
   }
 }

--- a/src/main/java/com/keeper/homepage/domain/member/entity/embedded/Profile.java
+++ b/src/main/java/com/keeper/homepage/domain/member/entity/embedded/Profile.java
@@ -11,6 +11,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
 import java.time.LocalDate;
+import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -73,12 +74,13 @@ public class Profile {
   }
 
   public void deleteMemberProfile() {
-    this.loginId = LoginId.from("delete");
-    this.emailAddress = EmailAddress.from("delete@delete.com");
+    final String uuid = UUID.randomUUID().toString();
+    this.loginId = LoginId.from(uuid);
+    this.emailAddress = EmailAddress.from(uuid);
+    this.studentId = StudentId.from(uuid);
     this.password = Password.from("delete");
     this.realName = RealName.from("탈퇴회원");
     this.birthday = null;
-    this.studentId = null;
     this.thumbnail = null;
   }
 }

--- a/src/main/java/com/keeper/homepage/domain/member/entity/embedded/Profile.java
+++ b/src/main/java/com/keeper/homepage/domain/member/entity/embedded/Profile.java
@@ -1,8 +1,5 @@
 package com.keeper.homepage.domain.member.entity.embedded;
 
-import static java.time.LocalDate.*;
-import static java.util.UUID.*;
-
 import com.keeper.homepage.domain.thumbnail.entity.Thumbnail;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -12,8 +9,6 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
 import java.time.LocalDate;
-import java.util.Random;
-import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -67,45 +62,12 @@ public class Profile {
     this.studentId = newProfile.studentId;
     this.birthday = newProfile.birthday;
   }
+
   public void updateThumbnail(Thumbnail thumbnail) {
     this.thumbnail = thumbnail;
   }
 
   public void updateEmailAddress(String newEmailAddress) {
     this.emailAddress = EmailAddress.from(newEmailAddress);
-  }
-
-  public void deleteMemberProfile() {
-    this.loginId = LoginId.from(generateRandomString(80));
-    this.emailAddress = EmailAddress.from(generateRandomString(5) + '@' + generateRandomString(5) + ".com");
-    this.studentId = StudentId.from(generateRandomDigitString(45));
-    this.password = Password.from("delete");
-    this.realName = RealName.from("탈퇴회원");
-    this.birthday = null;
-    this.thumbnail = null;
-  }
-
-  public static final Random RANDOM = new Random();
-
-  private String generateRandomString(int length) {
-    char leftLimit = '0';
-    char rightLimit = 'z';
-
-    return Profile.RANDOM.ints(leftLimit, rightLimit + 1)
-        .filter(i -> Character.isAlphabetic(i) || Character.isDigit(i))
-        .limit(length)
-        .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
-        .toString();
-  }
-
-  private String generateRandomDigitString(int length) {
-    final Random random = new Random();
-    char leftLimit = '0';
-    char rightLimit = '9';
-
-    return random.ints(leftLimit, rightLimit + 1)
-        .limit(length)
-        .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
-        .toString();
   }
 }

--- a/src/main/java/com/keeper/homepage/domain/member/entity/type/MemberType.java
+++ b/src/main/java/com/keeper/homepage/domain/member/entity/type/MemberType.java
@@ -12,8 +12,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
-import java.util.Arrays;
-import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -60,7 +58,6 @@ public class MemberType {
     정회원(2),
     휴면회원(3),
     졸업(4),
-    탈퇴(5),
     ;
 
     @Getter

--- a/src/main/java/com/keeper/homepage/domain/post/dao/PostRepository.java
+++ b/src/main/java/com/keeper/homepage/domain/post/dao/PostRepository.java
@@ -152,7 +152,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {
   @Query("UPDATE Post p "
       + "SET p.member = :virtualMember "
       + "WHERE p.member = :member AND p.isTemp = false ")
-  void updateMember(@Param("member") Member member, @Param("virtualMember") Member virtualMember);
+  void updateVirtualMember(@Param("member") Member member, @Param("virtualMember") Member virtualMember);
 
   void deleteAllByMemberAndIsTempTrue(Member member);
 }

--- a/src/main/java/com/keeper/homepage/domain/post/dao/PostRepository.java
+++ b/src/main/java/com/keeper/homepage/domain/post/dao/PostRepository.java
@@ -9,6 +9,7 @@ import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -146,4 +147,12 @@ public interface PostRepository extends JpaRepository<Post, Long> {
   Page<Post> findAllByMemberAndIsTempFalse(Member member, Pageable pageable);
 
   Page<Post> findAllByMemberAndIsTempTrue(Member member, Pageable pageable);
+
+  @Modifying
+  @Query("UPDATE Post p "
+      + "SET p.member = :virtualMember "
+      + "WHERE p.member = :member AND p.isTemp = false ")
+  void updateMember(@Param("member") Member member, @Param("virtualMember") Member virtualMember);
+
+  void deleteAllByMemberAndIsTempTrue(Member member);
 }

--- a/src/main/java/com/keeper/homepage/domain/post/entity/Post.java
+++ b/src/main/java/com/keeper/homepage/domain/post/entity/Post.java
@@ -202,4 +202,8 @@ public class Post extends BaseEntity {
   public CategoryType getCategoryType() {
     return this.category.getType();
   }
+
+  public void changeWriter(Member member) {
+    this.member = member;
+  }
 }

--- a/src/main/java/com/keeper/homepage/domain/seminar/dao/SeminarRepository.java
+++ b/src/main/java/com/keeper/homepage/domain/seminar/dao/SeminarRepository.java
@@ -1,11 +1,13 @@
 package com.keeper.homepage.domain.seminar.dao;
 
+import com.keeper.homepage.domain.member.entity.Member;
 import com.keeper.homepage.domain.seminar.entity.Seminar;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -42,4 +44,11 @@ public interface SeminarRepository extends JpaRepository<Seminar, Long> {
   @Query("SELECT COUNT(s) > 0 "
       + "FROM Seminar s WHERE DATE(s.openTime) = :localDate")
   boolean existsByOpenTime(@Param("localDate") LocalDate localDate);
+
+  @Modifying
+  @Query("UPDATE Seminar s "
+      + "SET s.starter = :virtualMember "
+      + "WHERE s.starter = :member")
+  void updateStarter(@Param("member") Member member, @Param("virtualMember") Member virtualMember);
+
 }

--- a/src/main/java/com/keeper/homepage/domain/seminar/dao/SeminarRepository.java
+++ b/src/main/java/com/keeper/homepage/domain/seminar/dao/SeminarRepository.java
@@ -49,6 +49,6 @@ public interface SeminarRepository extends JpaRepository<Seminar, Long> {
   @Query("UPDATE Seminar s "
       + "SET s.starter = :virtualMember "
       + "WHERE s.starter = :member")
-  void updateStarter(@Param("member") Member member, @Param("virtualMember") Member virtualMember);
+  void updateVirtualMember(@Param("member") Member member, @Param("virtualMember") Member virtualMember);
 
 }

--- a/src/main/java/com/keeper/homepage/domain/study/dao/StudyRepository.java
+++ b/src/main/java/com/keeper/homepage/domain/study/dao/StudyRepository.java
@@ -1,10 +1,21 @@
 package com.keeper.homepage.domain.study.dao;
 
+import com.keeper.homepage.domain.member.entity.Member;
 import com.keeper.homepage.domain.study.entity.Study;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface StudyRepository extends JpaRepository<Study, Long> {
 
   List<Study> findAllByYearAndSeason(int year, int season);
+
+  @Modifying
+  @Query("UPDATE Study s "
+      + "SET s.headMember = :virtualMember "
+      + "WHERE s.headMember = :member")
+  void updateMember(@Param("member") Member member, @Param("virtualMember") Member virtualMember);
+
 }

--- a/src/main/java/com/keeper/homepage/domain/study/dao/StudyRepository.java
+++ b/src/main/java/com/keeper/homepage/domain/study/dao/StudyRepository.java
@@ -16,6 +16,6 @@ public interface StudyRepository extends JpaRepository<Study, Long> {
   @Query("UPDATE Study s "
       + "SET s.headMember = :virtualMember "
       + "WHERE s.headMember = :member")
-  void updateMember(@Param("member") Member member, @Param("virtualMember") Member virtualMember);
+  void updateVirtualMember(@Param("member") Member member, @Param("virtualMember") Member virtualMember);
 
 }

--- a/src/main/java/com/keeper/homepage/domain/study/entity/Study.java
+++ b/src/main/java/com/keeper/homepage/domain/study/entity/Study.java
@@ -122,4 +122,8 @@ public class Study extends BaseEntity {
     this.season = newStudy.getSeason();
     this.link = newStudy.getLink();
   }
+
+  public void changeHeadMember(Member member) {
+    this.headMember = member;
+  }
 }

--- a/src/test/java/com/keeper/homepage/IntegrationTest.java
+++ b/src/test/java/com/keeper/homepage/IntegrationTest.java
@@ -26,6 +26,15 @@ import com.keeper.homepage.domain.comment.CommentTestHelper;
 import com.keeper.homepage.domain.comment.application.CommentService;
 import com.keeper.homepage.domain.comment.dao.CommentRepository;
 import com.keeper.homepage.domain.ctf.CtfChallengeTestHelper;
+import com.keeper.homepage.domain.ctf.CtfContestTestHelper;
+import com.keeper.homepage.domain.ctf.CtfFlagTestHelper;
+import com.keeper.homepage.domain.ctf.CtfTeamTestHelper;
+import com.keeper.homepage.domain.ctf.application.CtfTeamService;
+import com.keeper.homepage.domain.ctf.dao.CtfContestRepository;
+import com.keeper.homepage.domain.ctf.dao.challenge.CtfChallengeCategoryRepository;
+import com.keeper.homepage.domain.ctf.dao.challenge.CtfChallengeRepository;
+import com.keeper.homepage.domain.ctf.dao.challenge.CtfChallengeTypeRepository;
+import com.keeper.homepage.domain.ctf.dao.team.CtfTeamRepository;
 import com.keeper.homepage.domain.election.ElectionCandidateTestHelper;
 import com.keeper.homepage.domain.election.ElectionTestHelper;
 import com.keeper.homepage.domain.election.ElectionVoterTestHelper;
@@ -34,13 +43,6 @@ import com.keeper.homepage.domain.election.dao.ElectionCandidateRepository;
 import com.keeper.homepage.domain.election.dao.ElectionChartLogRepository;
 import com.keeper.homepage.domain.election.dao.ElectionRepository;
 import com.keeper.homepage.domain.election.dao.ElectionVoterRepository;
-import com.keeper.homepage.domain.ctf.CtfContestTestHelper;
-import com.keeper.homepage.domain.ctf.CtfFlagTestHelper;
-import com.keeper.homepage.domain.ctf.CtfTeamTestHelper;
-import com.keeper.homepage.domain.ctf.application.CtfTeamService;
-import com.keeper.homepage.domain.ctf.dao.challenge.CtfChallengeCategoryRepository;
-import com.keeper.homepage.domain.ctf.dao.challenge.CtfChallengeRepository;
-import com.keeper.homepage.domain.ctf.dao.challenge.CtfChallengeTypeRepository;
 import com.keeper.homepage.domain.file.dao.FileRepository;
 import com.keeper.homepage.domain.game.GameTestHelper;
 import com.keeper.homepage.domain.game.application.BaseballService;
@@ -117,12 +119,10 @@ import com.keeper.homepage.global.util.thumbnail.ThumbnailUtil;
 import com.ninjasquad.springmockk.SpykBean;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
-
 import java.io.File;
 import java.io.IOException;
 import java.time.LocalDate;
 import java.util.Random;
-
 import org.apache.tomcat.util.http.fileupload.FileUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -288,6 +288,12 @@ public class IntegrationTest {
   @Autowired
   protected CtfChallengeRepository ctfChallengeRepository;
 
+  @Autowired
+  protected CtfTeamRepository ctfTeamRepository;
+
+  @Autowired
+  protected CtfContestRepository ctfContestRepository;
+
   /******* Service *******/
   @SpyBean
   protected MemberService memberService;
@@ -357,7 +363,7 @@ public class IntegrationTest {
 
   @SpyBean
   protected CtfTeamService ctfTeamService;
-  
+
   @SpyBean
   protected MeritTypeService meritTypeService;
 

--- a/src/test/java/com/keeper/homepage/domain/member/api/MemberControllerTest.java
+++ b/src/test/java/com/keeper/homepage/domain/member/api/MemberControllerTest.java
@@ -520,7 +520,7 @@ class MemberControllerTest extends MemberApiTestHelper {
       String securedValue = getSecuredValue(MemberController.class, "deleteMember");
       DeleteMemberRequest request = DeleteMemberRequest.from("testPassword");
 
-      mockMvc.perform(patch("/members")
+      mockMvc.perform(delete("/members")
               .cookie(new Cookie(ACCESS_TOKEN.getTokenName(), memberToken))
               .content(asJsonString(request))
               .contentType(MediaType.APPLICATION_JSON))
@@ -540,7 +540,7 @@ class MemberControllerTest extends MemberApiTestHelper {
     public void 비밀번호가_틀릴_시_탈퇴에_실패한다() throws Exception {
       DeleteMemberRequest request = DeleteMemberRequest.from("falsePassword");
 
-      mockMvc.perform(patch("/members")
+      mockMvc.perform(delete("/members")
               .cookie(new Cookie(ACCESS_TOKEN.getTokenName(), memberToken))
               .content(asJsonString(request))
               .contentType(MediaType.APPLICATION_JSON))

--- a/src/test/java/com/keeper/homepage/domain/member/application/MemberServiceTest.java
+++ b/src/test/java/com/keeper/homepage/domain/member/application/MemberServiceTest.java
@@ -126,12 +126,12 @@ public class MemberServiceTest extends IntegrationTest {
           .setParameter("id", member.getId())
           .getSingleResult();
 
-      assertThat(findMember.getProfile().getLoginId().get().length()).isEqualTo(80);
-      assertThat(findMember.getProfile().getEmailAddress().get().length()).isEqualTo(15);
+      assertThat(findMember.getProfile().getLoginId().get()).hasSize(80);
+      assertThat(findMember.getProfile().getEmailAddress().get()).hasSize(15);
       assertThat(findMember.getProfile().getPassword().isWrongPassword("delete")).isFalse();
       assertThat(findMember.getProfile().getRealName().get()).isEqualTo("탈퇴회원");
       assertThat(findMember.getProfile().getBirthday()).isNull();
-      assertThat(findMember.getProfile().getStudentId().get().length()).isEqualTo(45);
+      assertThat(findMember.getProfile().getStudentId().get()).hasSize(45);
       assertThat(findMember.getProfile().getThumbnail()).isNull();
     }
 

--- a/src/test/java/com/keeper/homepage/domain/member/application/MemberServiceTest.java
+++ b/src/test/java/com/keeper/homepage/domain/member/application/MemberServiceTest.java
@@ -13,6 +13,8 @@ import static com.keeper.homepage.global.error.ErrorCode.MEMBER_WRONG_PASSWORD;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doNothing;
 
 import com.keeper.homepage.IntegrationTest;
 import com.keeper.homepage.domain.comment.entity.Comment;
@@ -22,10 +24,8 @@ import com.keeper.homepage.domain.ctf.entity.team.CtfTeam;
 import com.keeper.homepage.domain.election.entity.Election;
 import com.keeper.homepage.domain.election.entity.ElectionCandidate;
 import com.keeper.homepage.domain.election.entity.ElectionChartLog;
-import static org.mockito.Mockito.*;
-
-import com.keeper.homepage.domain.member.dto.request.UpdateMemberEmailAddressRequest;
 import com.keeper.homepage.domain.library.entity.Book;
+import com.keeper.homepage.domain.member.dto.request.UpdateMemberEmailAddressRequest;
 import com.keeper.homepage.domain.member.entity.Member;
 import com.keeper.homepage.domain.member.entity.embedded.EmailAddress;
 import com.keeper.homepage.domain.member.entity.embedded.Password;

--- a/src/test/java/com/keeper/homepage/domain/member/application/MemberServiceTest.java
+++ b/src/test/java/com/keeper/homepage/domain/member/application/MemberServiceTest.java
@@ -1,29 +1,22 @@
 package com.keeper.homepage.domain.member.application;
 
-import static com.keeper.homepage.domain.library.entity.BookBorrowStatus.*;
-import static com.keeper.homepage.domain.library.entity.BookBorrowStatus.BookBorrowStatusType.대출대기;
 import static com.keeper.homepage.domain.library.entity.BookBorrowStatus.BookBorrowStatusType.대출중;
-import static com.keeper.homepage.domain.member.entity.type.MemberType.MemberTypeEnum.*;
+import static com.keeper.homepage.domain.library.entity.BookBorrowStatus.getBookBorrowStatusBy;
+import static com.keeper.homepage.domain.member.entity.type.MemberType.MemberTypeEnum.휴면회원;
 import static com.keeper.homepage.global.error.ErrorCode.MEMBER_BOOK_NOT_EMPTY;
 import static com.keeper.homepage.global.error.ErrorCode.MEMBER_CANNOT_FOLLOW_ME;
 import static com.keeper.homepage.global.error.ErrorCode.MEMBER_WRONG_PASSWORD;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.keeper.homepage.IntegrationTest;
 import com.keeper.homepage.domain.library.entity.Book;
-import com.keeper.homepage.domain.library.entity.BookBorrowStatus;
 import com.keeper.homepage.domain.member.entity.Member;
 import com.keeper.homepage.domain.member.entity.embedded.Password;
 import com.keeper.homepage.domain.member.entity.friend.Friend;
-import com.keeper.homepage.domain.member.entity.type.MemberType.MemberTypeEnum;
-import com.keeper.homepage.global.config.password.PasswordFactory;
 import com.keeper.homepage.global.error.BusinessException;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -110,29 +103,6 @@ public class MemberServiceTest extends IntegrationTest {
       member = memberTestHelper.builder()
           .password(Password.from("TruePassword"))
           .build();
-    }
-
-    @Test
-    @DisplayName("회원 탈퇴 시 유저 정보는 마킹되어야 한다.")
-    public void 회원_탈퇴_시_유저_이름은_회원탈퇴로_마킹되어야_한다() {
-      memberService.deleteMember(member, "TruePassword");
-
-      em.flush();
-      em.clear();
-      System.out.println("member = " + member.getId());
-      System.out.println("member.getRealName() = " + member.getRealName());
-
-      Member findMember = (Member) em.createNativeQuery("SELECT * FROM member WHERE id = :id", Member.class)
-          .setParameter("id", member.getId())
-          .getSingleResult();
-
-      assertThat(findMember.getProfile().getLoginId().get()).hasSize(80);
-      assertThat(findMember.getProfile().getEmailAddress().get()).hasSize(15);
-      assertThat(findMember.getProfile().getPassword().isWrongPassword("delete")).isFalse();
-      assertThat(findMember.getProfile().getRealName().get()).isEqualTo("탈퇴회원");
-      assertThat(findMember.getProfile().getBirthday()).isNull();
-      assertThat(findMember.getProfile().getStudentId().get()).hasSize(45);
-      assertThat(findMember.getProfile().getThumbnail()).isNull();
     }
 
     @Test

--- a/src/test/java/com/keeper/homepage/domain/member/application/MemberServiceTest.java
+++ b/src/test/java/com/keeper/homepage/domain/member/application/MemberServiceTest.java
@@ -126,12 +126,12 @@ public class MemberServiceTest extends IntegrationTest {
           .setParameter("id", member.getId())
           .getSingleResult();
 
-      assertThat(findMember.getProfile().getLoginId().get()).isEqualTo("delete");
-      assertThat(findMember.getProfile().getEmailAddress().get()).isEqualTo("delete@delete.com");
+      assertThat(findMember.getProfile().getLoginId().get().length()).isEqualTo(80);
+      assertThat(findMember.getProfile().getEmailAddress().get().length()).isEqualTo(15);
       assertThat(findMember.getProfile().getPassword().isWrongPassword("delete")).isFalse();
       assertThat(findMember.getProfile().getRealName().get()).isEqualTo("탈퇴회원");
       assertThat(findMember.getProfile().getBirthday()).isNull();
-      assertThat(findMember.getProfile().getStudentId()).isNull();
+      assertThat(findMember.getProfile().getStudentId().get().length()).isEqualTo(45);
       assertThat(findMember.getProfile().getThumbnail()).isNull();
     }
 

--- a/src/test/java/com/keeper/homepage/domain/member/application/MemberServiceTest.java
+++ b/src/test/java/com/keeper/homepage/domain/member/application/MemberServiceTest.java
@@ -2,7 +2,11 @@ package com.keeper.homepage.domain.member.application;
 
 import static com.keeper.homepage.domain.library.entity.BookBorrowStatus.BookBorrowStatusType.대출중;
 import static com.keeper.homepage.domain.library.entity.BookBorrowStatus.getBookBorrowStatusBy;
+import static com.keeper.homepage.domain.member.entity.job.MemberJob.MemberJobType.ROLE_회장;
+import static com.keeper.homepage.domain.member.entity.job.MemberJob.getMemberJobBy;
 import static com.keeper.homepage.domain.member.entity.type.MemberType.MemberTypeEnum.휴면회원;
+import static com.keeper.homepage.domain.seminar.entity.SeminarAttendanceStatus.SeminarAttendanceStatusType.ATTENDANCE;
+import static com.keeper.homepage.domain.seminar.entity.SeminarAttendanceStatus.getSeminarAttendanceStatusBy;
 import static com.keeper.homepage.global.error.ErrorCode.MEMBER_BOOK_NOT_EMPTY;
 import static com.keeper.homepage.global.error.ErrorCode.MEMBER_CANNOT_FOLLOW_ME;
 import static com.keeper.homepage.global.error.ErrorCode.MEMBER_WRONG_PASSWORD;
@@ -11,11 +15,23 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.keeper.homepage.IntegrationTest;
+import com.keeper.homepage.domain.comment.entity.Comment;
+import com.keeper.homepage.domain.ctf.entity.CtfContest;
+import com.keeper.homepage.domain.ctf.entity.challenge.CtfChallenge;
+import com.keeper.homepage.domain.ctf.entity.team.CtfTeam;
+import com.keeper.homepage.domain.election.entity.Election;
+import com.keeper.homepage.domain.election.entity.ElectionCandidate;
+import com.keeper.homepage.domain.election.entity.ElectionChartLog;
 import com.keeper.homepage.domain.library.entity.Book;
 import com.keeper.homepage.domain.member.entity.Member;
 import com.keeper.homepage.domain.member.entity.embedded.Password;
 import com.keeper.homepage.domain.member.entity.friend.Friend;
+import com.keeper.homepage.domain.post.entity.Post;
+import com.keeper.homepage.domain.seminar.entity.Seminar;
+import com.keeper.homepage.domain.seminar.entity.SeminarAttendance;
+import com.keeper.homepage.domain.study.entity.Study;
 import com.keeper.homepage.global.error.BusinessException;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -95,7 +111,7 @@ public class MemberServiceTest extends IntegrationTest {
   @DisplayName("회원 탈퇴 기능 테스트")
   class DeleteMemberTest {
 
-    private Member member;
+    private Member member, other;
     private Book book;
 
     @BeforeEach
@@ -103,6 +119,7 @@ public class MemberServiceTest extends IntegrationTest {
       member = memberTestHelper.builder()
           .password(Password.from("TruePassword"))
           .build();
+      other = memberTestHelper.generate();
     }
 
     @Test
@@ -126,6 +143,101 @@ public class MemberServiceTest extends IntegrationTest {
           () -> memberService.deleteMember(member, "TruePassword"),
           MEMBER_BOOK_NOT_EMPTY.getMessage());
     }
-  }
 
+    @Test
+    @DisplayName("탈퇴 시 남겨야 하는 데이터는 남아야 하고, 더미 회원이 작성자로 남아야 한다.")
+    public void 탈퇴_시_남겨야_하는_데이터는_남아야_하고_더미_회원이_작성자로_남아야_한다() throws Exception {
+      //given
+      Post post = postTestHelper.builder().member(member).build();
+      Comment comment = commentTestHelper.builder().member(member).build();
+      Study study = studyTestHelper.builder().headMember(member).build();
+      Seminar seminar = seminarTestHelper.builder().build();
+      seminar.setStarter(member);
+      CtfChallenge challenge = ctfChallengeTestHelper.builder().creator(member).build();
+      CtfTeam team = ctfTeamTestHelper.builder().creator(member).build();
+      CtfContest contest = ctfContestTestHelper.builder().creator(member).build();
+      Election election = electionTestHelper.builder().member(member).build();
+      em.flush();
+      em.clear();
+
+      //when
+      member = memberRepository.findById(member.getId()).orElseThrow();
+      memberService.deleteMember(member, "TruePassword");
+      em.flush();
+      em.clear();
+
+      //then
+      post = postRepository.findById(post.getId()).orElseThrow();
+      comment = commentRepository.findById(comment.getId()).orElseThrow();
+      study = studyRepository.findById(study.getId()).orElseThrow();
+      seminar = seminarRepository.findById(seminar.getId()).orElseThrow();
+      challenge = ctfChallengeRepository.findById(challenge.getId()).orElseThrow();
+      team = ctfTeamRepository.findById(team.getId()).orElseThrow();
+      contest = ctfContestRepository.findById(contest.getId()).orElseThrow();
+      election = electionRepository.findById(election.getId()).orElseThrow();
+
+      Member virtualMember = memberFindService.getVirtualMember();
+      assertThat(post.getMember()).isEqualTo(virtualMember);
+      assertThat(comment.getMember()).isEqualTo(virtualMember);
+      assertThat(study.getHeadMember()).isEqualTo(virtualMember);
+      assertThat(seminar.getStarter()).isEqualTo(virtualMember);
+      assertThat(challenge.getCreator()).isEqualTo(virtualMember);
+      assertThat(team.getCreator()).isEqualTo(virtualMember);
+      assertThat(contest.getCreator()).isEqualTo(virtualMember);
+      assertThat(election.getMember()).isEqualTo(virtualMember);
+    }
+
+    @Test
+    @DisplayName("탈퇴 시 필요없는 데이터는 cascade REMOVE로 제거된다.")
+    public void 탈퇴_시_필요없는_데이터는_cascade_REMOVE로_제거된다() throws Exception {
+      //given
+      long memberId = member.getId();
+      Long attendanceId = attendanceTestHelper.builder().member(member).build().getId(); // O
+      Long borrowId = bookBorrowInfoTestHelper.builder().member(member).build().getId(); // O
+      Post post = postTestHelper.builder().member(member).isTemp(true).build(); // O
+      Long pointId = pointLogTestHelper.builder().member(member).build().getId(); // O
+      member.follow(other); // O
+      other.follow(member); // O
+      member.like(post); // O
+      member.dislike(post); // O
+      member.read(post); // O
+      Study study = studyTestHelper.generate();
+      member.join(study); // O
+      CtfTeam ctfTeam = ctfTeamTestHelper.generate();
+      member.join(ctfTeam); // O
+      Seminar seminar = seminarTestHelper.generate();
+      Long seminarAttendanceId = seminarAttendanceRepository.save(SeminarAttendance.builder()
+          .seminar(seminar)
+          .member(member)
+          .seminarAttendanceStatus(getSeminarAttendanceStatusBy(ATTENDANCE))
+          .attendTime(LocalDateTime.now())
+          .build()).getId();// O
+      Long replyId = surveyMemberReplyTestHelper.builder().member(member).build().getId();// O
+      ElectionCandidate electionCandidate = electionCandidateTestHelper.builder(getMemberJobBy(ROLE_회장)).member(member)
+          .build(); // O
+      electionVoterTestHelper.builder().member(member).build(); // O
+      electionChartLogRepository.save(ElectionChartLog.builder()
+          .electionCandidate(electionCandidate)
+          .voteTime(LocalDateTime.now())
+          .build()); // O
+      Long gameId = gameTestHelper.builder().member(member).build().getId();// O
+      em.flush();
+      em.clear();
+
+      //when
+      member = memberRepository.findById(member.getId()).orElseThrow();
+      memberService.deleteMember(member, "TruePassword");
+      em.flush();
+      em.clear();
+
+      //then
+      assertThat(memberRepository.findById(memberId)).isEmpty();
+      assertThat(attendanceRepository.findById(attendanceId)).isEmpty();
+      assertThat(bookBorrowInfoRepository.findById(borrowId)).isEmpty();
+      assertThat(pointLogRepository.findById(pointId)).isEmpty();
+      assertThat(seminarAttendanceRepository.findById(seminarAttendanceId)).isEmpty();
+      assertThat(surveyMemberReplyRepository.findById(replyId)).isEmpty();
+      assertThat(gameRepository.findById(gameId)).isEmpty();
+    }
+  }
 }


### PR DESCRIPTION
## 🔥 Related Issue

> close: #361
> close: #365

## 📝 Description

- 회원 삭제를 row를 삭제하는 hard delete 방식으로 변경하였습니다.
- 관리자용 회원 삭제 api를 구현하였습니다. 활동인원 관리 페이지에서 회원을 탈퇴 시킬 때 사용될 api 입니다.

## ⭐️ Review Request

- [회원 탈퇴 시 남겨야 할 정보](https://www.notion.so/5ff42404d696419c9c107792eddc5b11?pvs=4) 기획서를 참고하시면 될 것 같습니다.
- CTF, Election, Survey 관련해서는 예전 데이터들이 남아있어서 같이 구현해주었습니다.

