### PR TITLE
fix: 출석 순위 버그 수정

### DIFF
--- a/src/main/java/com/keeper/homepage/global/config/interceptor/AttendanceInterceptor.java
+++ b/src/main/java/com/keeper/homepage/global/config/interceptor/AttendanceInterceptor.java
@@ -4,6 +4,7 @@ import com.keeper.homepage.domain.attendance.application.AttendanceService;
 import com.keeper.homepage.global.util.redis.RedisUtil;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.lang.reflect.UndeclaredThrowableException;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.AnonymousAuthenticationToken;
@@ -29,7 +30,11 @@ public class AttendanceInterceptor implements HandlerInterceptor {
       String key = "attendance:member:" + memberId;
       Optional<String> data = redisUtil.getData(key, String.class);
       if (data.isEmpty()) {
-        attendanceService.create(memberId);
+        try {
+          attendanceService.create(memberId);
+        } catch (UndeclaredThrowableException e) {
+          // 출석 중복 저장 발생
+        }
       }
     }
     return true;


### PR DESCRIPTION
## 🔥 Related Issue

> close: #359

## 📝 Description

- 53ddcda55e4ae3ffb0989975a2b1db51fb5b7ea8 에서 redis 값 만료시간 설정이 잘못되어 있었던 문제를 수정했습니다.
- eeaf5bddfb0f0108c98ce83730e4b281353b1952 에서 SessionCallback 인터페이스를 활용하여 문제 발생 시 Redis에서도 Transaction이 동작하도록 수정하였습니다. #359 문제는 프론트 페이지(ex. 메인페이지)에서 여러개의 api를 동시에 호출하여, 요청이 스레드에서 병렬로 돌아서 db 단에서 trigger 걸어둔 출석 중복 저장 에러가 발생했는데, redis의 값은 롤백이 되지 않아 발생한 문제로 추측합니다.
- ce11237183a9bad6b3615fcc94034e6aa7e5601d 에서 클라이언트에게 출석 중복 저장 에러(500)을 던져주지 않게 catch 하였습니다.

## ⭐️ Review Request

> 리뷰어에게 전달하고 싶은 내용을 적어주세요.

추석때 작업 힘들 것 같아 바로 머지하겠습니다! 추후 피드백 환영입니다!
