### PR TITLE
feat: 대출 반려시 대출 정보 row 제거

### DIFF
--- a/src/main/java/com/keeper/homepage/domain/library/application/BorrowManageService.kt
+++ b/src/main/java/com/keeper/homepage/domain/library/application/BorrowManageService.kt
@@ -58,7 +58,7 @@ class BorrowManageService(
             throw BusinessException(borrowId, "borrowId", ErrorCode.BORROW_STATUS_IS_NOT_REQUESTS)
         }
 
-        borrowInfo.changeBorrowStatus(대출반려)
+        borrowInfoRepository.delete(borrowInfo)
         borrowLogRepository.save(BookBorrowLog.of(borrowInfo, LogType.대출반려))
     }
 

--- a/src/test/java/com/keeper/homepage/domain/library/api/BorrowManageControllerTest.kt
+++ b/src/test/java/com/keeper/homepage/domain/library/api/BorrowManageControllerTest.kt
@@ -424,7 +424,6 @@ class BorrowManageControllerTest : BorrowManageApiTestHelper() {
                         )
                     )
                 )
-            borrowInfo.borrowStatus.type shouldBe 대출반려
         }
 
         @Test


### PR DESCRIPTION
## 🔥 Related Issue

없음.

## 📝 Description

https://keepernewhome-5o41027.slack.com/archives/C04MA6U2K96/p1697026769781889

대출 신청 취소시엔 `borrowInfo`가 삭제되고 있었는데, 관리자 페이지에서 대출 신청을 반려했을 땐 `borrowInfo`가 삭제되지 않아 생기는 문제를 해결했습니다.

원래 `대출반려`로 하기로 했던 것 같은데 `borrowLog`가 생기면서 굳이 `대출반려`로 남겨놓을 필요 없을 것 같아서 제거합니다. 나중에 시간날때 `대출반려` enum도 제거하면 좋을 것 같아요.

## ⭐️ Review Request
 
오랜만입니당 😄
