### PR TITLE
In 절에 BatchSize 만큼의 중복된 ID가 바인딩되는 문제 해결

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,9 +2,10 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     id("java")
-    id("org.springframework.boot") version "3.0.1"
+    id("org.springframework.boot") version "3.0.2"
     id("io.spring.dependency-management") version "1.1.0"
     id("org.asciidoctor.jvm.convert") version "3.3.2"
+    id("org.hibernate.orm") version "6.2.0.Final"
 
     val kotlinVersion = "1.8.0"
     kotlin("jvm") version kotlinVersion


### PR DESCRIPTION
## 🔥 Related Issue

> close: #363

## 📝 Description

In 절에 BatchSize 만큼의 중복된 ID가 바인딩되는 문제를 해결했습니다.

![image](https://github.com/KEEPER31337/Homepage-Back-R2/assets/92802207/792b55d0-550e-4d65-8036-02ff67330406)

![image](https://github.com/KEEPER31337/Homepage-Back-R2/assets/92802207/7fa16b85-fe17-4dff-adf1-93adad183042)

In 절에 BatchSize 만큼의 중복된 ID가 바인딩되는 문제는 하이버네이트 6.1.x 버전에서 있었던 버그였습니다. ([참고링크](https://ttl-blog.tistory.com/1202)) 이 버그는 하이버네이트 6.2.x 버전에서 수정되었는데, 현재 사용하고 있는 스프링 부트 3.0.1 버전에서는 default로 하이버네이트 버전 6.1.x 버전을 사용하고 있습니다.

처음에는 하이버네이트 6.2.0 버전으로 업데이트 하면 해결되겠거니 했는데, 의존성 관련 문제인지 어플리케이션이 실행되지 않았습니다. 그래서 스프링 부트 3.0.2 버전으로 업데이트를 해보았더니 문제가 해결되었습니다! (스프링 부트 3.0.2 버전도 하이버네이트 버전을 명시해주지 않으면 6.1.x 버전을 default로 사용하기에 하이버네이트 버전도 명시해주었습니다.)

## ⭐️ Review Request

버전 업데이트 문제 없을 지 확인해주시면 감사하겠습니다! 🙇

해결에 있어 문제 원인 파악에 도움 주신 @02ggang9 님 감사합니다~~👍

