### PR TITLE
fix: status 401이 내려갈 때 쿠키 모두 삭제

### DIFF
--- a/src/main/java/com/keeper/homepage/domain/auth/application/AuthCookieService.java
+++ b/src/main/java/com/keeper/homepage/domain/auth/application/AuthCookieService.java
@@ -39,9 +39,13 @@ public class AuthCookieService {
     httpResponse.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
   }
 
-  public void setCookieExpired(String authId, HttpServletResponse response) {
+  public void setCookieExpiredWithRedis(String authId, HttpServletResponse response) {
+    setCookieExpired(response);
+    redisUtil.deleteData(authId);
+  }
+
+  public void setCookieExpired(HttpServletResponse response) {
     setTokenInCookie(response, "", 0, REFRESH_TOKEN.getTokenName());
     setTokenInCookie(response, "", 0, ACCESS_TOKEN.getTokenName());
-    redisUtil.deleteData(authId);
   }
 }

--- a/src/main/java/com/keeper/homepage/domain/auth/application/SignOutService.java
+++ b/src/main/java/com/keeper/homepage/domain/auth/application/SignOutService.java
@@ -12,6 +12,6 @@ public class SignOutService {
   private final AuthCookieService authCookieService;
 
   public void signOut(Member me, HttpServletResponse response) {
-    authCookieService.setCookieExpired(String.valueOf(me.getId()), response);
+    authCookieService.setCookieExpiredWithRedis(String.valueOf(me.getId()), response);
   }
 }

--- a/src/main/java/com/keeper/homepage/global/config/security/filter/RefreshTokenFilter.java
+++ b/src/main/java/com/keeper/homepage/global/config/security/filter/RefreshTokenFilter.java
@@ -53,6 +53,8 @@ public class RefreshTokenFilter extends GenericFilterBean {
       HttpServletResponse httpResponse = (HttpServletResponse) response;
 
       authCookieService.setNewCookieInResponse(authId, roles, httpRequest.getHeader(USER_AGENT), httpResponse);
+    } else {
+      authCookieService.setCookieExpired((HttpServletResponse) response);
     }
 
     filterChain.doFilter(request, response);

--- a/src/test/java/com/keeper/homepage/domain/auth/api/SignOutControllerTest.java
+++ b/src/test/java/com/keeper/homepage/domain/auth/api/SignOutControllerTest.java
@@ -15,10 +15,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.keeper.homepage.IntegrationTest;
 import com.keeper.homepage.domain.member.entity.Member;
 import jakarta.servlet.http.Cookie;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.ResultActions;
 
 class SignOutControllerTest extends IntegrationTest {
 
@@ -40,8 +42,7 @@ class SignOutControllerTest extends IntegrationTest {
           jwtTokenProvider.createAccessToken(ACCESS_TOKEN, member.getId(), ROLE_회원));
       Cookie refreshTokenCookie = new Cookie(REFRESH_TOKEN.getTokenName(),
           jwtTokenProvider.createAccessToken(REFRESH_TOKEN, member.getId(), ROLE_회원));
-      mockMvc.perform(post("/sign-out")
-              .cookie(accessTokenCookie, refreshTokenCookie))
+      callSignOutApi(accessTokenCookie, refreshTokenCookie)
           .andExpect(status().isNoContent())
           .andExpect(cookie().maxAge(ACCESS_TOKEN.getTokenName(), 0))
           .andExpect(cookie().maxAge(REFRESH_TOKEN.getTokenName(), 0))
@@ -52,6 +53,29 @@ class SignOutControllerTest extends IntegrationTest {
               )));
 
       assertThat(redisUtil.getData(String.valueOf(member.getId()), String.class)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("RT도 AT도 만료되었으면 로그아웃시에 쿠키는 지워져야 한다")
+    void should_tokenDeleted_when_expiredTokens() throws Exception {
+      // PK: 0
+      // ROLE: 회원
+      // expired: 2023년 1월 25일
+      String expiredRefreshToken = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIwIiwicm9sZXMiOiJST0xFX-2ajOybkCIsImlhdCI6MTY3NDYzMDk2MCwiZXhwIjoxNjc0NjMwOTYwfQ.qcAfEzhDulqsl6HCg8dziVlJoTPORpSUi5sjbCqTg_E";
+      Cookie expiredRefreshCookie = new Cookie(REFRESH_TOKEN.getTokenName(), expiredRefreshToken);
+      String expiredToken = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwicm9sZXMiOiJST0xFX-2ajOybkCIsImlhdCI6MTY3NDQ1MjM1NSwiZXhwIjoxNjc0NDUyMzU1fQ.FoRbgOGlzLwizp9jQNmM6pET4zA8TPXa56zZlsl6Al8";
+      Cookie expiredCookie = new Cookie(ACCESS_TOKEN.getTokenName(), expiredToken);
+
+      callSignOutApi(expiredCookie, expiredRefreshCookie)
+              .andExpect(status().isUnauthorized())
+              .andExpect(cookie().maxAge(ACCESS_TOKEN.getTokenName(), 0))
+              .andExpect(cookie().maxAge(REFRESH_TOKEN.getTokenName(), 0));
+    }
+
+    @NotNull
+    private ResultActions callSignOutApi(Cookie accessTokenCookie, Cookie refreshTokenCookie) throws Exception {
+      return mockMvc.perform(post("/sign-out")
+              .cookie(accessTokenCookie, refreshTokenCookie));
     }
   }
 }


### PR DESCRIPTION
## 🔥 Related Issue

> close: 없음

## 📝 Description

로그아웃 시에 정상적이라면 Response는 없이 204가 내려가야 함.
그런데 로그아웃을 누를 당시에 accessToken과 refreshToken 모두 만료됐을 경우 204 대신 401이 내려가게 됨.
지금은 401이 내려가도 쿠키가 지워지지 않아서 로그아웃이 안되고 있었어서 401이 내려가는 상황이면 항상 쿠키를 지우게끔 수정

## ⭐️ Review Request

오랜만에 코딩하니까 재밌네요~
@02ggang9 인증 부분 인수인계 해드릴까요...? ㅎㅎ 바빠서 유지보수 대응할 시간이 부족하네용