### PR TITLE
Feature/#396 도서 관리 기능을 사서의 요구사항에 맞게 변경

### DIFF
--- a/src/main/java/com/keeper/homepage/domain/library/application/BookService.java
+++ b/src/main/java/com/keeper/homepage/domain/library/application/BookService.java
@@ -47,7 +47,7 @@ public class BookService {
 
   private final BookBorrowInfoFindService bookBorrowInfoFindService;
 
-  public static final long MAX_BORROWING_COUNT = 5;
+  public static final long MAX_BORROWING_COUNT = 2;
 
   public Page<BookResponse> getBooks(Member member, @NotNull BookSearchType searchType, String search,
       PageRequest pageable) {

--- a/src/main/java/com/keeper/homepage/domain/library/dao/BookBorrowLogRepository.java
+++ b/src/main/java/com/keeper/homepage/domain/library/dao/BookBorrowLogRepository.java
@@ -1,7 +1,11 @@
 package com.keeper.homepage.domain.library.dao;
 
+import com.keeper.homepage.domain.library.entity.Book;
 import com.keeper.homepage.domain.library.entity.BookBorrowInfo;
 import com.keeper.homepage.domain.library.entity.BookBorrowLog;
+import com.keeper.homepage.domain.library.entity.BookBorrowStatus;
+import com.keeper.homepage.domain.member.entity.Member;
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -30,4 +34,12 @@ public interface BookBorrowLogRepository extends JpaRepository<BookBorrowLog, Lo
   Page<BookBorrowLog> findAllByStatus(@Param("borrowStatus") String borrowStatus,
       @Param("search") String search, Pageable pageable);
 
+  @Query(value = "select borrowLog "
+      + "from BookBorrowLog  borrowLog "
+      + "where borrowLog.bookId = :bookId "
+      + "AND borrowLog.memberId = :memberId "
+      + "AND borrowLog.returnDate is not null "
+      + "order by borrowLog.id desc")
+  Optional<BookBorrowLog> findByMemberAndBookAndReturned(@Param("memberId") Long memberId,
+      @Param("bookId") Long bookId);
 }

--- a/src/main/java/com/keeper/homepage/domain/library/dao/BookBorrowLogRepository.java
+++ b/src/main/java/com/keeper/homepage/domain/library/dao/BookBorrowLogRepository.java
@@ -31,7 +31,7 @@ public interface BookBorrowLogRepository extends JpaRepository<BookBorrowLog, Lo
       @Param("search") String search, Pageable pageable);
 
   @Query(value = "select borrowLog "
-      + "from BookBorrowLog  borrowLog "
+      + "from BookBorrowLog borrowLog "
       + "where borrowLog.bookId = :bookId "
       + "AND borrowLog.memberId = :memberId "
       + "AND borrowLog.returnDate is not null "

--- a/src/main/java/com/keeper/homepage/domain/library/dao/BookBorrowLogRepository.java
+++ b/src/main/java/com/keeper/homepage/domain/library/dao/BookBorrowLogRepository.java
@@ -1,10 +1,6 @@
 package com.keeper.homepage.domain.library.dao;
 
-import com.keeper.homepage.domain.library.entity.Book;
-import com.keeper.homepage.domain.library.entity.BookBorrowInfo;
 import com.keeper.homepage.domain.library.entity.BookBorrowLog;
-import com.keeper.homepage.domain.library.entity.BookBorrowStatus;
-import com.keeper.homepage.domain.member.entity.Member;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;

--- a/src/main/java/com/keeper/homepage/domain/library/dao/BookBorrowLogRepository.java
+++ b/src/main/java/com/keeper/homepage/domain/library/dao/BookBorrowLogRepository.java
@@ -35,6 +35,7 @@ public interface BookBorrowLogRepository extends JpaRepository<BookBorrowLog, Lo
       + "where borrowLog.bookId = :bookId "
       + "AND borrowLog.memberId = :memberId "
       + "AND borrowLog.returnDate is not null "
+      + "AND borrowLog.borrowStatus = '반납완료' "
       + "order by borrowLog.id desc")
   Optional<BookBorrowLog> findByMemberAndBookAndReturned(@Param("memberId") Long memberId,
       @Param("bookId") Long bookId);

--- a/src/main/java/com/keeper/homepage/global/error/ErrorCode.java
+++ b/src/main/java/com/keeper/homepage/global/error/ErrorCode.java
@@ -62,6 +62,7 @@ public enum ErrorCode {
   BOOK_BORROWING_COUNT_OVER("대출 신청 가능 수량을 초과했습니다.", HttpStatus.BAD_REQUEST),
   BOOK_CURRENT_QUANTITY_IS_ZERO("현재 수량이 없는 책은 대출 신청이 불가합니다.", HttpStatus.BAD_REQUEST),
   BORROW_REQUEST_ALREADY("이미 대출 신청을 한 책은 대출 신청이 불가합니다.", HttpStatus.BAD_REQUEST),
+  BORROW_RENEWAL_ELIGIBILITY_NOT_MET("아직 대출할 수 없습니다.", HttpStatus.BAD_REQUEST),
   BORROW_NOT_FOUND("존재하지 않는 대출 기록입니다.", HttpStatus.NOT_FOUND),
   BORROW_STATUS_IS_NOT_REQUESTS("대출 대기중이 아닙니다.", HttpStatus.BAD_REQUEST),
   BORROW_STATUS_IS_NOT_WAITING_RETURN("반납 대기중이 아닙니다.", HttpStatus.BAD_REQUEST),

--- a/src/main/java/com/keeper/homepage/global/error/ErrorCode.java
+++ b/src/main/java/com/keeper/homepage/global/error/ErrorCode.java
@@ -62,7 +62,7 @@ public enum ErrorCode {
   BOOK_BORROWING_COUNT_OVER("대출 신청 가능 수량을 초과했습니다.", HttpStatus.BAD_REQUEST),
   BOOK_CURRENT_QUANTITY_IS_ZERO("현재 수량이 없는 책은 대출 신청이 불가합니다.", HttpStatus.BAD_REQUEST),
   BORROW_REQUEST_ALREADY("이미 대출 신청을 한 책은 대출 신청이 불가합니다.", HttpStatus.BAD_REQUEST),
-  BORROW_RENEWAL_ELIGIBILITY_NOT_MET("아직 대출할 수 없습니다.", HttpStatus.BAD_REQUEST),
+  BORROW_RENEWAL_ELIGIBILITY_NOT_MET("대출 갱신 자격이 충족되지 않았습니다.", HttpStatus.BAD_REQUEST),
   BORROW_NOT_FOUND("존재하지 않는 대출 기록입니다.", HttpStatus.NOT_FOUND),
   BORROW_STATUS_IS_NOT_REQUESTS("대출 대기중이 아닙니다.", HttpStatus.BAD_REQUEST),
   BORROW_STATUS_IS_NOT_WAITING_RETURN("반납 대기중이 아닙니다.", HttpStatus.BAD_REQUEST),

--- a/src/test/java/com/keeper/homepage/domain/library/application/BookServiceTest.java
+++ b/src/test/java/com/keeper/homepage/domain/library/application/BookServiceTest.java
@@ -121,16 +121,16 @@ public class BookServiceTest extends IntegrationTest {
     }
 
     @Test
-    @DisplayName("도서 대출중인 권수가 5권 이하면 도서 대출은 성공해야 한다.")
-    public void 도서_대출중인_권수가_5권_이하면_도서_대출은_성공해야_한다() {
+    @DisplayName("도서 대출중인 권수가 2권 이하면 도서 대출은 성공해야 한다.")
+    public void 도서_대출중인_권수가_2권_이하면_도서_대출은_성공해야_한다() {
       assertDoesNotThrow(() -> bookService.requestBorrow(member, book.getId()));
       assertThat(bookBorrowInfoRepository.findByMemberAndBookAndInBorrowingOrWait(member, book)).isNotEmpty();
     }
 
     @Test
-    @DisplayName("도서 대출중인 권수가 5권 초과면 도서 대출은 실패해야 한다.")
-    public void 도서_대출중인_권수가_5권_초과면_도서_대출은_실패해야_한다() {
-      for (int i = 0; i < 4; i++) {
+    @DisplayName("도서 대출중인 권수가 2권 초과면 도서 대출은 실패해야 한다.")
+    public void 도서_대출중인_권수가_2권_초과면_도서_대출은_실패해야_한다() {
+      for (int i = 0; i < 1; i++) {
         bookBorrowInfoTestHelper.builder()
             .member(member)
             .book(book)


### PR DESCRIPTION
## 🔥 Related Issue
https://github.com/KEEPER31337/Homepage-Back-R2/issues/396


## 📝 Description
- 사서님 요구사항에 맞추어서 기본적인 부분들 반영하였습니다.
```
<대출규정 관련건>
최대 대출 권수는 2권으로 한다.
반납일 포함 3일이 경과된 후에 재대출이 가능하다.
```
였으며 규정 반영에 따라서 테스트코드도 요구사항에 맞추어 변경해주었습니다.

이 외에 사서님이 요구하신 기존에 없는 새롭게 추가되는 기능들은 새로운 이슈로 파서 프론트엔드 한 분과 디자이너와 함께 논의하며 개발하면 좋을 것 같습니다.

## ⭐️ Review Request
- 더 좋은 네이밍 있으면 추천해주셨으면 좋겠습니다.
- `book_borrow_info`테이블에 반납 완료 날짜가 없어서 `book_borrow_log`에서 가져오는 로직을 수행했습니다.
- 해당 쿼리는 `BookBorrowLogRepository`안에 있는데 페이지네이션한 쿼리들 안에 있어서 그런지 뭔가 있으면 안될 자리에 있다는 느낌이 드네요. 그러나 마땅히 괜찮은 위치를 찾지 못해서 일단 여기 뒀습니다.
