### PR TITLE
Feature/세미나 출석 정보 조회시 기수와 이름 정렬을 추가한다.

### DIFF
--- a/src/main/java/com/keeper/homepage/domain/seminar/api/SeminarAttendanceController.java
+++ b/src/main/java/com/keeper/homepage/domain/seminar/api/SeminarAttendanceController.java
@@ -12,6 +12,7 @@ import jakarta.validation.constraints.PositiveOrZero;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;
@@ -49,7 +50,7 @@ public class SeminarAttendanceController {
       @RequestParam(defaultValue = "10") @PositiveOrZero int size
   ) {
     Page<SeminarAttendanceManageResponse> responses = seminarAttendanceService.getAttendances(
-        PageRequest.of(page, size));
+        PageRequest.of(page, size, Sort.by(Sort.DEFAULT_DIRECTION, "generation.generation").and(Sort.by(Sort.DEFAULT_DIRECTION,"profile.realName"))));
     return ResponseEntity.ok(responses);
   }
 

--- a/src/test/java/com/keeper/homepage/domain/seminar/api/SeminarAttendanceControllerTest.java
+++ b/src/test/java/com/keeper/homepage/domain/seminar/api/SeminarAttendanceControllerTest.java
@@ -24,6 +24,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.keeper.homepage.domain.member.entity.Member;
+import com.keeper.homepage.domain.member.entity.embedded.RealName;
 import com.keeper.homepage.domain.seminar.dto.request.SeminarAttendanceCodeRequest;
 import com.keeper.homepage.domain.seminar.dto.request.SeminarAttendanceStatusRequest;
 import com.keeper.homepage.domain.seminar.dto.request.SeminarStartRequest;
@@ -56,8 +57,8 @@ public class SeminarAttendanceControllerTest extends SeminarApiTestHelper {
 
   @BeforeEach
   void setUp() {
-    adminId = memberTestHelper.builder().build().getId();
-    userId = memberTestHelper.builder().build().getId();
+    adminId = memberTestHelper.builder().realName(RealName.from("김영환")).build().getId();
+    userId = memberTestHelper.builder().realName(RealName.from("김기철")).build().getId();
     adminToken = jwtTokenProvider.createAccessToken(ACCESS_TOKEN, adminId, ROLE_회원, ROLE_회장);
     userToken = jwtTokenProvider.createAccessToken(ACCESS_TOKEN, userId, ROLE_회원);
 
@@ -268,17 +269,17 @@ public class SeminarAttendanceControllerTest extends SeminarApiTestHelper {
       mockMvc.perform(get("/seminars/attendances")
               .cookie(new Cookie(ACCESS_TOKEN.getTokenName(), adminToken)))
           .andExpect(status().isOk())
-          .andExpect(jsonPath("$.content[0].memberId").value(adminId))
-          .andExpect(jsonPath("$.content[0].memberName").value(admin.getRealName()))
-          .andExpect(jsonPath("$.content[0].generation").value(admin.getGeneration()))
-          .andExpect(jsonPath("$.content[0].attendances[0].attendanceStatus").value(ATTENDANCE.toString()))
+          .andExpect(jsonPath("$.content[0].memberId").value(userId))
+          .andExpect(jsonPath("$.content[0].memberName").value(user.getRealName()))
+          .andExpect(jsonPath("$.content[0].generation").value(user.getGeneration()))
+          .andExpect(jsonPath("$.content[0].attendances[0].attendanceId").value(attendanceId))
+          .andExpect(jsonPath("$.content[0].attendances[0].attendanceStatus").value(LATENESS.toString()))
           .andExpect(jsonPath("$.content[0].attendances[0].excuse").isEmpty())
           .andExpect(jsonPath("$.content[0].attendances[0].attendDate").value(LocalDate.now().toString()))
-          .andExpect(jsonPath("$.content[1].memberId").value(userId))
-          .andExpect(jsonPath("$.content[1].memberName").value(user.getRealName()))
-          .andExpect(jsonPath("$.content[1].generation").value(user.getGeneration()))
-          .andExpect(jsonPath("$.content[1].attendances[0].attendanceId").value(attendanceId))
-          .andExpect(jsonPath("$.content[1].attendances[0].attendanceStatus").value(LATENESS.toString()))
+          .andExpect(jsonPath("$.content[1].memberId").value(adminId))
+          .andExpect(jsonPath("$.content[1].memberName").value(admin.getRealName()))
+          .andExpect(jsonPath("$.content[1].generation").value(admin.getGeneration()))
+          .andExpect(jsonPath("$.content[1].attendances[0].attendanceStatus").value(ATTENDANCE.toString()))
           .andExpect(jsonPath("$.content[1].attendances[0].excuse").isEmpty())
           .andExpect(jsonPath("$.content[1].attendances[0].attendDate").value(LocalDate.now().toString()))
           .andDo(document("get-seminar-attendances",


### PR DESCRIPTION
## 🔥 Related Issue

close: #394

## 📝 Description

기존의 세미나 출석 정보 조회는 생성된 회원 순으로 정렬됩니다.
세미나 출석 정보 조회를 기수 순으로 정렬하고, 동일 기수 내라면 이름 순으로 정렬하는 코드를 추가했습니다.

## ⭐️ Review Request

정렬 Controller 코드 단에서 하는 걸로 괜찮을까요?
테스트 코드를 따로 작성 안하고 기존 테스트 코드만 살짝 수정했습니다. 기수 순으로도 잘 정렬 되는지 테스트 추가하고 싶었는데 Generation을 설정하려면 엔티티 코드를 건드려야 할거 같아서 일단 뺐습니다... (기수순으로도 정렬 되는거 확인은 했습니다!)
추가적인 테스트 코드 필요할 거 같으면 말씀해주세요~! 
