### PR TITLE
#412 스프링 스케줄러 & AOP 충돌 해결

### DIFF
--- a/src/main/java/com/keeper/homepage/global/util/aop/ApiStatisticAop.java
+++ b/src/main/java/com/keeper/homepage/global/util/aop/ApiStatisticAop.java
@@ -1,5 +1,6 @@
 package com.keeper.homepage.global.util.aop;
 
+import java.lang.reflect.Proxy;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,16 +19,21 @@ public class ApiStatisticAop {
 
   private final ApiStatistic apiStatistic;
 
-  /* TODO: Spring 스케줄러 메서드 실행이 안되서 주석 처리.
+//   TODO: Spring 스케줄러 메서드 실행이 안되서 주석 처리.
   @Around("execution(* javax.sql.DataSource.getConnection())")
   public Object getConnection(ProceedingJoinPoint joinPoint) throws Throwable {
     Object connection = joinPoint.proceed();
+    // request scope가 아닌 경우 proxy를 타지 않고 바로 connection을 반환한다.
+    // ex) 스케쥴러
+    if (RequestContextHolder.getRequestAttributes() == null) {
+      return connection;
+    }
     return Proxy.newProxyInstance(
         connection.getClass().getClassLoader(),
         connection.getClass().getInterfaces(),
         new ConnectionProxyHandler(connection, apiStatistic)
     );
-  }*/
+  }
 
   @Around("within(@org.springframework.web.bind.annotation.RestController *)")
   public Object calculateExecutionTime(final ProceedingJoinPoint joinPoint) throws Throwable {


### PR DESCRIPTION
## 🔥 Related Issue

> close: #412

## 📝 Description

스케줄러와 AOP를 함께 사용했을 때 스케줄러가 도는 시점에 아래 에러가 뜸.

<details>
<summary>error 문구</summary>
<div markdown="1">

```
2024-05-03T15:01:11.019+09:00 ERROR 64836 --- [   scheduling-1] o.s.s.s.TaskUtils$LoggingErrorHandler    : Unexpected error occurred in scheduled task

org.springframework.beans.factory.support.ScopeNotActiveException: Error creating bean with name 'scopedTarget.apiStatistic': Scope 'request' is not active for the current thread; consider defining a scoped proxy for this bean if you intend to refer to it from a singleton
	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:374) ~[spring-beans-6.0.4.jar:6.0.4]
	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:200) ~[spring-beans-6.0.4.jar:6.0.4]
	at org.springframework.aop.target.SimpleBeanTargetSource.getTarget(SimpleBeanTargetSource.java:35) ~[spring-aop-6.0.4.jar:6.0.4]
	at org.springframework.aop.framework.CglibAopProxy$DynamicAdvisedInterceptor.intercept(CglibAopProxy.java:687) ~[spring-aop-6.0.4.jar:6.0.4]
	at com.keeper.homepage.global.util.aop.ApiStatistic$$SpringCGLIB$$0.queryCountUp(<generated>) ~[classes/:na]
	at com.keeper.homepage.global.util.aop.PreparedStatementProxyHandler.invoke(PreparedStatementProxyHandler.java:27) ~[classes/:na]
	at jdk.proxy2/jdk.proxy2.$Proxy232.executeUpdate(Unknown Source) ~[na:na]
	at org.hibernate.sql.exec.internal.StandardJdbcMutationExecutor.execute(StandardJdbcMutationExecutor.java:83) ~[hibernate-core-6.2.0.Final.jar:6.2.0.Final]
	at org.hibernate.query.sqm.internal.SimpleUpdateQueryPlan.executeUpdate(SimpleUpdateQueryPlan.java:90) ~[hibernate-core-6.2.0.Final.jar:6.2.0.Final]
	at org.hibernate.query.sqm.internal.QuerySqmImpl.doExecuteUpdate(QuerySqmImpl.java:739) ~[hibernate-core-6.2.0.Final.jar:6.2.0.Final]
	at org.hibernate.query.sqm.internal.QuerySqmImpl.executeUpdate(QuerySqmImpl.java:709) ~[hibernate-core-6.2.0.Final.jar:6.2.0.Final]
	at org.springframework.data.jpa.repository.query.JpaQueryExecution$ModifyingExecution.doExecute(JpaQueryExecution.java:236) ~[spring-data-jpa-3.0.1.jar:3.0.1]
	at org.springframework.data.jpa.repository.query.JpaQueryExecution.execute(JpaQueryExecution.java:90) ~[spring-data-jpa-3.0.1.jar:3.0.1]
	at org.springframework.data.jpa.repository.query.AbstractJpaQuery.doExecute(AbstractJpaQuery.java:148) ~[spring-data-jpa-3.0.1.jar:3.0.1]
	at org.springframework.data.jpa.repository.query.AbstractJpaQuery.execute(AbstractJpaQuery.java:136) ~[spring-data-jpa-3.0.1.jar:3.0.1]
	at org.springframework.data.repository.core.support.RepositoryMethodInvoker.doInvoke(RepositoryMethodInvoker.java:136) ~[spring-data-commons-3.0.1.jar:3.0.1]
	at org.springframework.data.repository.core.support.RepositoryMethodInvoker.invoke(RepositoryMethodInvoker.java:120) ~[spring-data-commons-3.0.1.jar:3.0.1]
	at org.springframework.data.repository.core.support.QueryExecutorMethodInterceptor.doInvoke(QueryExecutorMethodInterceptor.java:164) ~[spring-data-commons-3.0.1.jar:3.0.1]
	at org.springframework.data.repository.core.support.QueryExecutorMethodInterceptor.invoke(QueryExecutorMethodInterceptor.java:143) ~[spring-data-commons-3.0.1.jar:3.0.1]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:184) ~[spring-aop-6.0.4.jar:6.0.4]
	at org.springframework.data.projection.DefaultMethodInvokingMethodInterceptor.invoke(DefaultMethodInvokingMethodInterceptor.java:77) ~[spring-data-commons-3.0.1.jar:3.0.1]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:184) ~[spring-aop-6.0.4.jar:6.0.4]
	at org.springframework.transaction.interceptor.TransactionInterceptor$1.proceedWithInvocation(TransactionInterceptor.java:123) ~[spring-tx-6.0.4.jar:6.0.4]
	at org.springframework.transaction.interceptor.TransactionAspectSupport.invokeWithinTransaction(TransactionAspectSupport.java:388) ~[spring-tx-6.0.4.jar:6.0.4]
	at org.springframework.transaction.interceptor.TransactionInterceptor.invoke(TransactionInterceptor.java:119) ~[spring-tx-6.0.4.jar:6.0.4]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:184) ~[spring-aop-6.0.4.jar:6.0.4]
	at org.springframework.dao.support.PersistenceExceptionTranslationInterceptor.invoke(PersistenceExceptionTranslationInterceptor.java:137) ~[spring-tx-6.0.4.jar:6.0.4]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:184) ~[spring-aop-6.0.4.jar:6.0.4]
	at org.springframework.data.jpa.repository.support.CrudMethodMetadataPostProcessor$CrudMethodMetadataPopulatingMethodInterceptor.invoke(CrudMethodMetadataPostProcessor.java:134) ~[spring-data-jpa-3.0.1.jar:3.0.1]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:184) ~[spring-aop-6.0.4.jar:6.0.4]
	at org.springframework.aop.interceptor.ExposeInvocationInterceptor.invoke(ExposeInvocationInterceptor.java:97) ~[spring-aop-6.0.4.jar:6.0.4]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:184) ~[spring-aop-6.0.4.jar:6.0.4]
	at org.springframework.aop.framework.JdkDynamicAopProxy.invoke(JdkDynamicAopProxy.java:218) ~[spring-aop-6.0.4.jar:6.0.4]
	at jdk.proxy4/jdk.proxy4.$Proxy213.updateAllBeforeAttendanceToAbsence(Unknown Source) ~[na:na]
	at com.keeper.homepage.domain.seminar.application.SeminarAttendanceService.changeAllBeforeAttendanceToAbsence(SeminarAttendanceService.java:115) ~[classes/:na]
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[na:na]
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77) ~[na:na]
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:na]
	at java.base/java.lang.reflect.Method.invoke(Method.java:568) ~[na:na]
	at org.springframework.aop.support.AopUtils.invokeJoinpointUsingReflection(AopUtils.java:343) ~[spring-aop-6.0.4.jar:6.0.4]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.invokeJoinpoint(ReflectiveMethodInvocation.java:196) ~[spring-aop-6.0.4.jar:6.0.4]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:163) ~[spring-aop-6.0.4.jar:6.0.4]
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:752) ~[spring-aop-6.0.4.jar:6.0.4]
	at org.springframework.transaction.interceptor.TransactionInterceptor$1.proceedWithInvocation(TransactionInterceptor.java:123) ~[spring-tx-6.0.4.jar:6.0.4]
	at org.springframework.transaction.interceptor.TransactionAspectSupport.invokeWithinTransaction(TransactionAspectSupport.java:388) ~[spring-tx-6.0.4.jar:6.0.4]
	at org.springframework.transaction.interceptor.TransactionInterceptor.invoke(TransactionInterceptor.java:119) ~[spring-tx-6.0.4.jar:6.0.4]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:184) ~[spring-aop-6.0.4.jar:6.0.4]
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:752) ~[spring-aop-6.0.4.jar:6.0.4]
	at org.springframework.aop.framework.CglibAopProxy$DynamicAdvisedInterceptor.intercept(CglibAopProxy.java:703) ~[spring-aop-6.0.4.jar:6.0.4]
	at com.keeper.homepage.domain.seminar.application.SeminarAttendanceService$$SpringCGLIB$$0.changeAllBeforeAttendanceToAbsence(<generated>) ~[classes/:na]
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[na:na]
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77) ~[na:na]
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:na]
	at java.base/java.lang.reflect.Method.invoke(Method.java:568) ~[na:na]
	at org.springframework.scheduling.support.ScheduledMethodRunnable.run(ScheduledMethodRunnable.java:84) ~[spring-context-6.0.4.jar:6.0.4]
	at org.springframework.scheduling.support.DelegatingErrorHandlingRunnable.run(DelegatingErrorHandlingRunnable.java:54) ~[spring-context-6.0.4.jar:6.0.4]
	at org.springframework.scheduling.concurrent.ReschedulingRunnable.run(ReschedulingRunnable.java:96) ~[spring-context-6.0.4.jar:6.0.4]
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539) ~[na:na]
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264) ~[na:na]
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304) ~[na:na]
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) ~[na:na]
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) ~[na:na]
	at java.base/java.lang.Thread.run(Thread.java:840) ~[na:na]
Caused by: java.lang.IllegalStateException: No thread-bound request found: Are you referring to request attributes outside of an actual web request, or processing a request outside of the originally receiving thread? If you are actually operating within a web request and still receive this message, your code is probably running outside of DispatcherServlet: In this case, use RequestContextListener or RequestContextFilter to expose the current request.
	at org.springframework.web.context.request.RequestContextHolder.currentRequestAttributes(RequestContextHolder.java:131) ~[spring-web-6.0.4.jar:6.0.4]
	at org.springframework.web.context.request.AbstractRequestAttributesScope.get(AbstractRequestAttributesScope.java:42) ~[spring-web-6.0.4.jar:6.0.4]
	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:362) ~[spring-beans-6.0.4.jar:6.0.4]
	... 62 common frames omitted
```
</div>
</details>

에러 문구 중 아래 내용을 보면 `request` Scope 스레드가 활성화 된 게 없다고 함.
스케줄러는 request scope 스레드가 아니기 때문에 당연함.
```
Scope 'request' is not active for the current thread;
```

문제가 생긴 곳은 27번째 라인인데, `apiStatistic` 객체를 가져오지 못하고 있음.

<img width="779" alt="image" src="https://github.com/KEEPER31337/Homepage-Back-R2/assets/26597702/7c133aec-9c03-46b7-a6a8-6f3d3933d1e5">

`ApiStatistic` 클래스를 보면 `@RequestScope`를 가지고 있음을 볼 수 있음. 흔한 싱글톤이 아님.

<img width="250" alt="image" src="https://github.com/KEEPER31337/Homepage-Back-R2/assets/26597702/b25f26c0-a2eb-4e46-9d97-9ddcca783415">

이렇게 한 이유는, request마다 이 객체가 시간을 재고 사라지기 때문인 것으로 보임.

https://stackoverflow.com/questions/24166052/spring-get-current-scope

위 링크를 보면 `RequestContextHolder.getRequestAttributes()` 메서드로 현재 scope가 `RequestScope`인지 확인이 가능함.

api 쿼리 시간 계산은 `RequestScope`만 하면 되므로 `RequestScope`가 아닌 경우 패스하도록 설정

## ⭐️ Review Request

> 리뷰어에게 전달하고 싶은 내용을 적어주세요.
