### PR TITLE
Feature/#398 하드코딩된 테스트 코드 수정

### DIFF
--- a/src/test/java/com/keeper/homepage/domain/auth/api/test/AuthTestControllerTest.java
+++ b/src/test/java/com/keeper/homepage/domain/auth/api/test/AuthTestControllerTest.java
@@ -183,34 +183,34 @@ class AuthTestControllerTest extends IntegrationTest {
         redisUtil.setDataExpire(JwtTokenProvider.getRefreshTokenKeyForRedis("0", null), refreshToken, REFRESH_TOKEN.getExpiredMillis());
       }
 
-//      @Test
-//      @DisplayName("AT가 만료되었으면 200 OK를 응답한다.")
-//      void should_200OK_when_accessTokenExpired() throws Exception {
-//        JwtType MOCKED_ACCESS_TOKEN = Mockito.spy(ACCESS_TOKEN);
-//        Mockito.doReturn(0L).when(MOCKED_ACCESS_TOKEN).getExpiredMillis();
-//
-//        String expiredAccessToken = jwtTokenProvider.createAccessToken(MOCKED_ACCESS_TOKEN, 0L, ROLE_회원);
-//
-//        Cookie expiredCookie = new Cookie(ACCESS_TOKEN.getTokenName(), expiredAccessToken);
-//        expiredCookie.setHttpOnly(true);
-//        assertThatThrownBy(() -> jwtTokenProvider.getAuthId(expiredAccessToken))
-//            .isInstanceOf(ExpiredJwtException.class);
-//
-//        MvcResult result = callRefreshApi(refreshCookie, expiredCookie)
-//            .andExpect(status().isOk())
-//            .andReturn();
-//
-//        String newAccessToken = Objects.requireNonNull(
-//                result.getResponse().getCookie(ACCESS_TOKEN.getTokenName()))
-//            .getValue();
-//        String newRefreshToken = Objects.requireNonNull(
-//                result.getResponse().getCookie(REFRESH_TOKEN.getTokenName()))
-//            .getValue();
-//
-//        jwtTokenProvider.getAuthId(newAccessToken);
-//        assertThat(newRefreshToken).isNotEqualTo(refreshCookie.getValue());
-//        assertThat(redisUtil.getData(JwtTokenProvider.getRefreshTokenKeyForRedis("0", null), String.class)).isNotEmpty();
-//      }
+      @Test
+      @DisplayName("AT가 만료되었으면 200 OK를 응답한다.")
+      void should_200OK_when_accessTokenExpired() throws Exception {
+        JwtType MOCKED_ACCESS_TOKEN = Mockito.spy(ACCESS_TOKEN);
+        Mockito.doReturn(0L).when(MOCKED_ACCESS_TOKEN).getExpiredMillis();
+
+        String expiredAccessToken = jwtTokenProvider.createAccessToken(MOCKED_ACCESS_TOKEN, 0L, ROLE_회원);
+        Cookie expiredCookie = new Cookie(ACCESS_TOKEN.getTokenName(), expiredAccessToken);
+        expiredCookie.setHttpOnly(true);
+
+        assertThatThrownBy(() -> jwtTokenProvider.getAuthId(expiredAccessToken))
+            .isInstanceOf(ExpiredJwtException.class);
+
+        MvcResult result = callRefreshApi(refreshCookie, expiredCookie)
+            .andExpect(status().isOk())
+            .andReturn();
+
+        String newAccessToken = Objects.requireNonNull(
+                result.getResponse().getCookie(ACCESS_TOKEN.getTokenName()))
+            .getValue();
+        String newRefreshToken = Objects.requireNonNull(
+                result.getResponse().getCookie(REFRESH_TOKEN.getTokenName()))
+            .getValue();
+
+        jwtTokenProvider.getAuthId(newAccessToken);
+        assertThat(newRefreshToken).isNotEqualTo(refreshCookie.getValue());
+        assertThat(redisUtil.getData(JwtTokenProvider.getRefreshTokenKeyForRedis("0", null), String.class)).isNotEmpty();
+      }
 
       @Test
       @DisplayName("AT도 있으면 200 OK를 응답한다.")


### PR DESCRIPTION
## 🔥 Related Issue

https://github.com/KEEPER31337/Homepage-Back-R2/issues/398

https://github.com/KEEPER31337/Homepage-Back-R2/pull/402

## 📝 Description

동적으로 application.yml에 있는 key 값을 토대로 만료된 accessToken을 만들도록 했습니다.

## ⭐️ Review Request

> 리뷰어에게 전달하고 싶은 내용을 적어주세요.
