### PR TITLE
feat: 게시글 본문 이미지 업로드/다운로드 기능 추가

### DIFF
--- a/src/docs/asciidoc/post/post.adoc
+++ b/src/docs/asciidoc/post/post.adoc
@@ -472,3 +472,52 @@ include::{snippets}/download-post-file/path-parameters.adoc[]
 
 include::{snippets}/download-post-file/http-response.adoc[]
 
+== *게시글 본문용 파일 업로드*
+
+NOTE: 게시글의 본문 파일 업로드 기능입니다.
+
+=== 요청
+
+==== Request
+
+include::{snippets}/upload-file-for-content/http-request.adoc[]
+
+==== Request Cookies
+
+include::{snippets}/upload-file-for-content/request-cookies.adoc[]
+
+=== 응답
+
+==== Response
+
+include::{snippets}/upload-file-for-content/http-response.adoc[]
+
+==== Response Fields
+
+include::{snippets}/upload-file-for-content/response-fields.adoc[]
+
+== *게시글 본문 파일 다운로드*
+
+=== 요청
+
+==== Request
+
+include::{snippets}/get-file-for-content/http-request.adoc[]
+
+==== Request Cookies
+
+include::{snippets}/get-file-for-content/request-cookies.adoc[]
+
+==== Path Parameters
+
+include::{snippets}/get-file-for-content/path-parameters.adoc[]
+
+=== 응답
+
+==== Response
+
+include::{snippets}/get-file-for-content/http-response.adoc[]
+
+==== Response Headers
+
+include::{snippets}/get-file-for-content/response-headers.adoc[]

--- a/src/main/java/com/keeper/homepage/domain/file/application/FileService.java
+++ b/src/main/java/com/keeper/homepage/domain/file/application/FileService.java
@@ -10,13 +10,16 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.io.InputStreamResource;
 import org.springframework.core.io.Resource;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.util.UriUtils;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -27,6 +30,10 @@ public class FileService {
   public FileEntity findById(long fileId) {
     return fileRepository.findById(fileId)
         .orElseThrow(() -> new BusinessException(fileId, "fileId", FILE_NOT_FOUND));
+  }
+
+  public Optional<FileEntity> findByFileHash(String fileHash) {
+    return fileRepository.findByFileHash(fileHash);
   }
 
   public Resource getFileResource(FileEntity file) throws IOException {

--- a/src/main/java/com/keeper/homepage/domain/file/application/FileService.java
+++ b/src/main/java/com/keeper/homepage/domain/file/application/FileService.java
@@ -32,8 +32,8 @@ public class FileService {
         .orElseThrow(() -> new BusinessException(fileId, "fileId", FILE_NOT_FOUND));
   }
 
-  public Optional<FileEntity> findByFileHash(String fileHash) {
-    return fileRepository.findByFileHash(fileHash);
+  public Optional<FileEntity> findByFileUUID(String fileUUID) {
+    return fileRepository.findByFileUUID(fileUUID);
   }
 
   public Resource getFileResource(FileEntity file) throws IOException {

--- a/src/main/java/com/keeper/homepage/domain/file/dao/FileRepository.java
+++ b/src/main/java/com/keeper/homepage/domain/file/dao/FileRepository.java
@@ -1,8 +1,10 @@
 package com.keeper.homepage.domain.file.dao;
 
 import com.keeper.homepage.domain.file.entity.FileEntity;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface FileRepository extends JpaRepository<FileEntity, Long> {
 
+    Optional<FileEntity> findByFileHash(String fileHash);
 }

--- a/src/main/java/com/keeper/homepage/domain/file/dao/FileRepository.java
+++ b/src/main/java/com/keeper/homepage/domain/file/dao/FileRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface FileRepository extends JpaRepository<FileEntity, Long> {
 
-    Optional<FileEntity> findByFileHash(String fileHash);
+    Optional<FileEntity> findByFileUUID(String fileUUID);
 }

--- a/src/main/java/com/keeper/homepage/domain/file/entity/FileEntity.java
+++ b/src/main/java/com/keeper/homepage/domain/file/entity/FileEntity.java
@@ -12,6 +12,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -23,9 +24,10 @@ import lombok.NoArgsConstructor;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EqualsAndHashCode(of = "id")
-@Table(name = "file")
+@Table(name = "file", uniqueConstraints = {@UniqueConstraint(columnNames = {"file_hash"})})
 public class FileEntity {
 
+  private static final int MAX_FILE_HASH_LENGTH = 50;
   private static final int MAX_FILE_NAME_LENGTH = 256;
   private static final int MAX_FILE_PATH_LENGTH = 512;
 
@@ -49,17 +51,21 @@ public class FileEntity {
   @Column(name = "ip_address", nullable = false)
   private String ipAddress;
 
+  @Column(name = "file_hash", length = MAX_FILE_HASH_LENGTH)
+  private String fileHash;
+
   @OneToOne(mappedBy = "file", cascade = REMOVE, fetch = LAZY)
   private PostHasFile postHasFile;
 
   @Builder
   private FileEntity(String fileName, String filePath, Long fileSize, LocalDateTime uploadTime,
-      String ipAddress) {
+          String ipAddress, String fileHash) {
     this.fileName = fileName;
     this.filePath = filePath;
     this.fileSize = fileSize;
     this.uploadTime = uploadTime;
     this.ipAddress = ipAddress;
+    this.fileHash = fileHash;
   }
 
   public boolean isPost(Post post) {

--- a/src/main/java/com/keeper/homepage/domain/file/entity/FileEntity.java
+++ b/src/main/java/com/keeper/homepage/domain/file/entity/FileEntity.java
@@ -24,10 +24,10 @@ import lombok.NoArgsConstructor;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EqualsAndHashCode(of = "id")
-@Table(name = "file", uniqueConstraints = {@UniqueConstraint(columnNames = {"file_hash"})})
+@Table(name = "file", uniqueConstraints = {@UniqueConstraint(columnNames = {"file_uuid"})})
 public class FileEntity {
 
-  private static final int MAX_FILE_HASH_LENGTH = 50;
+  private static final int MAX_FILE_UUID_LENGTH = 50;
   private static final int MAX_FILE_NAME_LENGTH = 256;
   private static final int MAX_FILE_PATH_LENGTH = 512;
 
@@ -51,21 +51,21 @@ public class FileEntity {
   @Column(name = "ip_address", nullable = false)
   private String ipAddress;
 
-  @Column(name = "file_hash", length = MAX_FILE_HASH_LENGTH)
-  private String fileHash;
+  @Column(name = "file_uuid", length = MAX_FILE_UUID_LENGTH)
+  private String fileUUID;
 
   @OneToOne(mappedBy = "file", cascade = REMOVE, fetch = LAZY)
   private PostHasFile postHasFile;
 
   @Builder
   private FileEntity(String fileName, String filePath, Long fileSize, LocalDateTime uploadTime,
-          String ipAddress, String fileHash) {
+          String ipAddress, String fileUUID) {
     this.fileName = fileName;
     this.filePath = filePath;
     this.fileSize = fileSize;
     this.uploadTime = uploadTime;
     this.ipAddress = ipAddress;
-    this.fileHash = fileHash;
+    this.fileUUID = fileUUID;
   }
 
   public boolean isPost(Post post) {

--- a/src/main/java/com/keeper/homepage/domain/post/api/PostController.java
+++ b/src/main/java/com/keeper/homepage/domain/post/api/PostController.java
@@ -258,15 +258,15 @@ public class PostController {
     log.info("member \"{}\" uploaded file. memberId: {}, fileId: {}", member.getRealName(), member.getId(),
             fileEntity.getId());
     return ResponseEntity.status(HttpStatus.CREATED)
-            .body(FileForContentResponse.from("posts/files/" + fileEntity.getFileHash()));
+            .body(FileForContentResponse.from("posts/files/" + fileEntity.getFileUUID()));
   }
 
-  @GetMapping("/files/{fileHash}")
+  @GetMapping("/files/{fileUUID}")
   public ResponseEntity<Resource> getFileForContent(
           @LoginMember Member member,
-          @PathVariable String fileHash
+          @PathVariable String fileUUID
   ) throws IOException {
-    FileEntity file = postService.getFileForContent(fileHash, member);
+    FileEntity file = postService.getFileForContent(fileUUID, member);
     Resource resource = fileService.getFileResource(file);
     String fileName = fileService.getFileName(file);
     return ResponseEntity.ok()

--- a/src/main/java/com/keeper/homepage/domain/post/api/PostController.java
+++ b/src/main/java/com/keeper/homepage/domain/post/api/PostController.java
@@ -258,7 +258,7 @@ public class PostController {
     log.info("member \"{}\" uploaded file. memberId: {}, fileId: {}", member.getRealName(), member.getId(),
             fileEntity.getId());
     return ResponseEntity.status(HttpStatus.CREATED)
-            .body(FileForContentResponse.from("/posts/files/" + fileEntity.getFileHash()));
+            .body(FileForContentResponse.from("posts/files/" + fileEntity.getFileHash()));
   }
 
   @GetMapping("/files/{fileHash}")

--- a/src/main/java/com/keeper/homepage/domain/post/application/PostService.java
+++ b/src/main/java/com/keeper/homepage/domain/post/application/PostService.java
@@ -387,12 +387,12 @@ public class PostService {
     return fileUtil.saveFile(file).orElseThrow();
   }
 
-  public FileEntity getFileForContent(String fileHash, Member member) {
-    return fileService.findByFileHash(fileHash)
+  public FileEntity getFileForContent(String fileUUID, Member member) {
+    return fileService.findByFileUUID(fileUUID)
             .orElseThrow(() -> {
-              log.error("fileHash not found!! member \"{}\" request invalid fileHash. " +
-                      "fileHash: {}, memberId: {}", member.getRealName(), fileHash, member.getId());
-              return new BusinessException(fileHash, "fileHash", FILE_NOT_FOUND);
+              log.error("fileUUID not found!! member \"{}\" request invalid fileUUID. " +
+                      "fileUUID: {}, memberId: {}", member.getRealName(), fileUUID, member.getId());
+              return new BusinessException(fileUUID, "fileUUID", FILE_NOT_FOUND);
             });
   }
 }

--- a/src/main/java/com/keeper/homepage/domain/post/application/PostService.java
+++ b/src/main/java/com/keeper/homepage/domain/post/application/PostService.java
@@ -382,6 +382,7 @@ public class PostService {
     return file;
   }
 
+  @Transactional
   public FileEntity uploadFileForContent(MultipartFile file) {
     return fileUtil.saveFile(file).orElseThrow();
   }

--- a/src/main/java/com/keeper/homepage/domain/post/dto/response/FileForContentResponse.java
+++ b/src/main/java/com/keeper/homepage/domain/post/dto/response/FileForContentResponse.java
@@ -1,0 +1,21 @@
+package com.keeper.homepage.domain.post.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import static lombok.AccessLevel.PRIVATE;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = PRIVATE)
+public class FileForContentResponse {
+
+    private String filePath;
+
+    public static FileForContentResponse from(String filePath) {
+        return FileForContentResponse.builder()
+                .filePath(filePath)
+                .build();
+    }
+}

--- a/src/main/java/com/keeper/homepage/global/util/file/server/FileServerUtil.java
+++ b/src/main/java/com/keeper/homepage/global/util/file/server/FileServerUtil.java
@@ -87,7 +87,7 @@ class FileServerUtil extends FileUtil {
                         .fileSize(file.getSize())
                         .uploadTime(now)
                         .ipAddress(ipAddress)
-                        .fileHash(getRandomUUID())
+                        .fileUUID(getRandomUUID())
                         .build());
       } catch (DataIntegrityViolationException e) {
         if (retryCount == 0) {

--- a/src/main/java/com/keeper/homepage/global/util/file/server/FileServerUtil.java
+++ b/src/main/java/com/keeper/homepage/global/util/file/server/FileServerUtil.java
@@ -19,6 +19,7 @@ import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -76,14 +77,30 @@ class FileServerUtil extends FileUtil {
 
   private FileEntity saveFileEntity(MultipartFile file, File newFile, LocalDateTime now) {
     String ipAddress = WebUtil.getUserIP();
-    return fileRepository.save(
-        FileEntity.builder()
-            .fileName(file.getOriginalFilename())
-            .filePath(getFileUrl(newFile))
-            .fileSize(file.getSize())
-            .uploadTime(now)
-            .ipAddress(ipAddress)
-            .build());
+    int retryCount = 3;
+    while (retryCount >= 0) {
+      try {
+        return fileRepository.save(
+                FileEntity.builder()
+                        .fileName(file.getOriginalFilename())
+                        .filePath(getFileUrl(newFile))
+                        .fileSize(file.getSize())
+                        .uploadTime(now)
+                        .ipAddress(ipAddress)
+                        .fileHash(getRandomUUID())
+                        .build());
+      } catch (DataIntegrityViolationException e) {
+        if (retryCount == 0) {
+          throw e;
+        }
+        retryCount--;
+      }
+    }
+    throw new RuntimeException("save file entity failed.");
+  }
+
+  protected String getRandomUUID() {
+    return UUID.randomUUID().toString();
   }
 
   private static String getFileUrl(File newFile) {

--- a/src/test/java/com/keeper/homepage/domain/post/api/PostApiTestHelper.java
+++ b/src/test/java/com/keeper/homepage/domain/post/api/PostApiTestHelper.java
@@ -144,6 +144,18 @@ public class PostApiTestHelper extends IntegrationTest {
         .cookie(new Cookie(ACCESS_TOKEN.getTokenName(), memberToken)));
   }
 
+  ResultActions callUploadFileForContent(String accessToken, MockMultipartFile file) throws Exception {
+    return mockMvc.perform(multipart("/posts/files")
+            .file(file)
+            .cookie(new Cookie(ACCESS_TOKEN.getTokenName(), accessToken))
+            .contentType(MediaType.MULTIPART_FORM_DATA));
+  }
+
+  ResultActions callGetFileForContent(String accessToken, String fileHash) throws Exception {
+    return mockMvc.perform(get("/posts/files/{fileHash}", fileHash)
+            .cookie(new Cookie(ACCESS_TOKEN.getTokenName(), accessToken)));
+  }
+
   FieldDescriptor[] getPostsResponse() {
     return new FieldDescriptor[]{
         fieldWithPath("id").description("게시글 ID"),

--- a/src/test/java/com/keeper/homepage/domain/post/api/PostApiTestHelper.java
+++ b/src/test/java/com/keeper/homepage/domain/post/api/PostApiTestHelper.java
@@ -151,8 +151,8 @@ public class PostApiTestHelper extends IntegrationTest {
             .contentType(MediaType.MULTIPART_FORM_DATA));
   }
 
-  ResultActions callGetFileForContent(String accessToken, String fileHash) throws Exception {
-    return mockMvc.perform(get("/posts/files/{fileHash}", fileHash)
+  ResultActions callGetFileForContent(String accessToken, String fileUUID) throws Exception {
+    return mockMvc.perform(get("/posts/files/{fileUUID}", fileUUID)
             .cookie(new Cookie(ACCESS_TOKEN.getTokenName(), accessToken)));
   }
 

--- a/src/test/java/com/keeper/homepage/domain/post/api/PostControllerTest.java
+++ b/src/test/java/com/keeper/homepage/domain/post/api/PostControllerTest.java
@@ -1074,7 +1074,7 @@ public class PostControllerTest extends PostApiTestHelper {
 
       FileEntity fileEntity = postService.uploadFileForContent(file);
 
-      callGetFileForContent(memberToken, fileEntity.getFileHash())
+      callGetFileForContent(memberToken, fileEntity.getFileUUID())
               .andExpect(status().isOk())
               .andExpect(
                       header().string(CONTENT_DISPOSITION, "attachment; filename=\"" + fileEntity.getFileName() + "\""))
@@ -1084,7 +1084,7 @@ public class PostControllerTest extends PostApiTestHelper {
                                       .description("ACCESS TOKEN %s".formatted(securedValue))
                       ),
                       pathParameters(
-                              parameterWithName("fileHash").description("업로드한 파일의 hash")
+                              parameterWithName("fileUUID").description("업로드한 파일의 uuid")
                       ),
                       responseHeaders(
                               headerWithName(CONTENT_DISPOSITION).description("파일 이름을 포함한 응답 헤더입니다.")
@@ -1094,7 +1094,7 @@ public class PostControllerTest extends PostApiTestHelper {
     @Test
     @DisplayName("존재하지 않는 파일 해시일 경우 게시글 본문 파일 다운로드는 실패한다.")
     public void 존재하지_않는_파일_해시일_경우_게시글_본문_파일_다운로드는_실패한다() throws Exception {
-      callGetFileForContent(memberToken, "invalidFileHash")
+      callGetFileForContent(memberToken, "invalidFileUUID")
               .andExpect(status().isBadRequest());
     }
   }


### PR DESCRIPTION
## 🔥 Related Issue

> close: #109

## 📝 Description

게시글 본문용 이미지 업로드/다운로드 기능 추가

이미지 다운로드는 file hash를 이용하도록 했습니다.

- mysql에 추가한 컬럼과 sql 쿼리는 아래와 같습니다

```sql
ALTER TABLE file ADD file_uuid VARCHAR(50) NULL;
ALTER TABLE file ADD UNIQUE INDEX file_uuid_index (file_uuid);
```

## ⭐️ Review Request
