### PR TITLE
feat: 야구게임 베팅가능 금액 변경

### DIFF
--- a/src/main/java/com/keeper/homepage/domain/game/application/BaseballService.kt
+++ b/src/main/java/com/keeper/homepage/domain/game/application/BaseballService.kt
@@ -134,8 +134,9 @@ class BaseballService(
         val earnablePoint = baseballResultEntity.earnablePoint
 
         if (baseballResultEntity.isEnd()) {
-            requestMember.addPoint(earnablePoint*2, EARN_POINT_MESSAGE)
-            gameEntity.baseball.baseballDayPoint = earnablePoint*2
+            earnablePoint * 2
+            requestMember.addPoint(earnablePoint, EARN_POINT_MESSAGE)
+            gameEntity.baseball.baseballDayPoint = earnablePoint
         }
 
         return BaseballResponse(

--- a/src/main/java/com/keeper/homepage/domain/game/application/BaseballService.kt
+++ b/src/main/java/com/keeper/homepage/domain/game/application/BaseballService.kt
@@ -19,7 +19,7 @@ import org.springframework.transaction.annotation.Transactional
 const val REDIS_KEY_PREFIX = "baseball_"
 const val GUESS_NUMBER_LENGTH = 4
 const val TRY_COUNT = 9
-const val MAX_BETTING_POINT = 5000L
+const val MAX_BETTING_POINT = 3000L
 const val MIN_BETTING_POINT = 1000L
 const val BETTING_POINT_MESSAGE = "야구 게임 베팅"
 const val EARN_POINT_MESSAGE = "야구 게임 획득"
@@ -66,6 +66,10 @@ class BaseballService(
         if (bettingPoint <= 0) {
             throw BusinessException(requestMember.id, "memberId", ErrorCode.POINT_MUST_BE_POSITIVE)
         }
+        if (bettingPoint !in 1000..3000) {
+            throw BusinessException(requestMember.id, "memberId", ErrorCode.INVALID_BETTING_POINT)
+        }
+
         if (requestMember.point < bettingPoint) {
             throw BusinessException(requestMember.id, "memberId", ErrorCode.NOT_ENOUGH_POINT)
         }
@@ -130,8 +134,8 @@ class BaseballService(
         val earnablePoint = baseballResultEntity.earnablePoint
 
         if (baseballResultEntity.isEnd()) {
-            requestMember.addPoint(earnablePoint, EARN_POINT_MESSAGE)
-            gameEntity.baseball.baseballDayPoint = earnablePoint
+            requestMember.addPoint(earnablePoint*2, EARN_POINT_MESSAGE)
+            gameEntity.baseball.baseballDayPoint = earnablePoint*2
         }
 
         return BaseballResponse(

--- a/src/main/java/com/keeper/homepage/domain/game/application/BaseballService.kt
+++ b/src/main/java/com/keeper/homepage/domain/game/application/BaseballService.kt
@@ -66,7 +66,7 @@ class BaseballService(
         if (bettingPoint <= 0) {
             throw BusinessException(requestMember.id, "memberId", ErrorCode.POINT_MUST_BE_POSITIVE)
         }
-        if (bettingPoint !in 1000..3000) {
+        if (bettingPoint !in MIN_BETTING_POINT.. MAX_BETTING_POINT) {
             throw BusinessException(requestMember.id, "memberId", ErrorCode.INVALID_BETTING_POINT)
         }
 

--- a/src/main/java/com/keeper/homepage/global/error/ErrorCode.java
+++ b/src/main/java/com/keeper/homepage/global/error/ErrorCode.java
@@ -82,6 +82,7 @@ public enum ErrorCode {
   NOT_ENOUGH_POINT("베팅 포인트는 보유한 포인트보다 많을 수 없습니다.", HttpStatus.BAD_REQUEST),
   POINT_MUST_BE_POSITIVE("베팅 포인트는 양수여야 합니다.", HttpStatus.BAD_REQUEST),
   NOT_PLAYED_YET("아직 게임을 시작하지 않았습니다.", HttpStatus.BAD_REQUEST),
+  INVALID_BETTING_POINT("베팅포인트는 1000이상 3000이하의 숫자여야합니다",HttpStatus.BAD_REQUEST),
   // FILE
   FILE_NOT_FOUND("해당 파일은 존재하지 않습니다.", HttpStatus.BAD_REQUEST),
   // ATTENDANCE

--- a/src/main/java/com/keeper/homepage/global/error/ErrorCode.java
+++ b/src/main/java/com/keeper/homepage/global/error/ErrorCode.java
@@ -82,7 +82,7 @@ public enum ErrorCode {
   NOT_ENOUGH_POINT("베팅 포인트는 보유한 포인트보다 많을 수 없습니다.", HttpStatus.BAD_REQUEST),
   POINT_MUST_BE_POSITIVE("베팅 포인트는 양수여야 합니다.", HttpStatus.BAD_REQUEST),
   NOT_PLAYED_YET("아직 게임을 시작하지 않았습니다.", HttpStatus.BAD_REQUEST),
-  INVALID_BETTING_POINT("베팅포인트는 1000이상 3000이하의 숫자여야합니다",HttpStatus.BAD_REQUEST),
+  INVALID_BETTING_POINT("베팅포인트는 " + MIN_BETTING_POINT + "이상 " + MAX_BETTING_POINT + "이하의 숫자여야합니다",HttpStatus.BAD_REQUEST),
   // FILE
   FILE_NOT_FOUND("해당 파일은 존재하지 않습니다.", HttpStatus.BAD_REQUEST),
   // ATTENDANCE

--- a/src/test/java/com/keeper/homepage/domain/game/api/GameControllerTest.kt
+++ b/src/test/java/com/keeper/homepage/domain/game/api/GameControllerTest.kt
@@ -78,7 +78,7 @@ class GameControllerTest : GameApiTestHelper() {
                 .andExpect(status().isOk)
                 .andExpect(jsonPath("$.guessNumberLength").value(4))
                 .andExpect(jsonPath("$.tryCount").value(9))
-                .andExpect(jsonPath("$.maxBettingPoint").value(5000L))
+                .andExpect(jsonPath("$.maxBettingPoint").value(3000L))
                 .andExpect(jsonPath("$.minBettingPoint").value(1000L))
                 .andDo(
                     document(


### PR DESCRIPTION
## 🔥 Related Issue

> close: #

## 📝 Description

- 야구 게임 최대 베팅 금액을 5000에서 3000으로 수정했습니다 .
- 1000과 3000사이 베팅 포인트를 벗어나는 경우에 대한 에러 코드를 추가했습니다.
- earnable point 를 기존의 *2배로 변경하였습니다 .

## ⭐️ Review Request

- 테스트를 돌리면 한 군데에서 아래 사진과 같은 test failed가 뜨는데 제가 야구 게임 코드를 다 파악하지 못해서 보시고 알려주시면 감사하겠습니다! 
![image](https://github.com/KEEPER31337/Homepage-Back-R2/assets/129289883/18677417-6507-49fa-9448-d3fd4688957a)


