### PR TITLE
fix: security filter에서 allow origin *로 내려가는 문제 수정

### DIFF
--- a/src/main/java/com/keeper/homepage/global/config/security/SecurityConfiguration.java
+++ b/src/main/java/com/keeper/homepage/global/config/security/SecurityConfiguration.java
@@ -3,6 +3,7 @@ package com.keeper.homepage.global.config.security;
 import com.keeper.homepage.global.config.security.filter.RefreshTokenFilter;
 import com.keeper.homepage.global.config.security.handler.CustomAccessDeniedHandler;
 import com.keeper.homepage.global.config.security.handler.CustomAuthenticationEntryPoint;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -54,9 +55,9 @@ public class SecurityConfiguration {
   public CorsConfigurationSource corsConfigurationSource() {
     CorsConfiguration configuration = new CorsConfiguration();
 
-    configuration.addAllowedOriginPattern("*");
-    configuration.addAllowedHeader("*");
-    configuration.addAllowedMethod("*");
+    configuration.setAllowedOrigins(List.of("https://keeper.or.kr", "https://localhost:3000"));
+    configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+    configuration.addAllowedHeader("headers");
     configuration.setAllowCredentials(true);
 
     UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();


### PR DESCRIPTION
## 🔥 Related Issue

https://github.com/KEEPER31337/Homepage-Front-R2/issues/897

## 📝 Description

문제 상황은 아래와 같았습니다.

> api 호출 시 CORS 에러 발생합니다.
> 쿠키 비우고 재시도 시 CORS 에러 발생하지 않고 정상 동작합니다.

쿠키를 비우고 재시도시 CORS 에러가 발생하지 않는 것으로 보아, 쿠키에 사용되는 JWT에 문제가 있으면 CORS가 이상하게 내려간다고 판단했고, SecurityConfig를 살펴봤습니다.

확인해보니 SecurityConfig와 WebConfig에서 Origin 설정이 달랐고, 이를 맞춰주었습니다.

양쪽에서 CORS를 설정하는 것과 그 차이는 [이 사이트](https://stackoverflow.com/questions/63426010/cors-filter-vs-webmvcconfigurer-addcorsmappings)를 참고하시면 됩니다.

## ⭐️ Review Request

https://docs.spring.io/spring-security/site/docs/5.3.4.RELEASE/reference/html5/#cors

위 사이트를 참고하면 `WebSecurityConfigurerAdapter`를 이용해서 양 쪽 설정을 하나로 모을 수도 있는 것 같아요.

나중에 도전해봐도 좋을 것 같습니다.