### PR TITLE
fix: 토큰에 권한이 비어있을 경우 role 추가하지 않도록 변경

### DIFF
--- a/src/main/java/com/keeper/homepage/global/config/security/data/JwtUserDetails.java
+++ b/src/main/java/com/keeper/homepage/global/config/security/data/JwtUserDetails.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.util.StringUtils;
 
 @RequiredArgsConstructor
 public class JwtUserDetails implements UserDetails {
@@ -18,7 +19,9 @@ public class JwtUserDetails implements UserDetails {
   public Collection<? extends GrantedAuthority> getAuthorities() {
     List<SimpleGrantedAuthority> roles = new ArrayList<>();
     for (String memberJob : memberJobs) {
-      roles.add(new SimpleGrantedAuthority(memberJob));
+      if (StringUtils.hasText(memberJob)) {
+        roles.add(new SimpleGrantedAuthority(memberJob));
+      }
     }
     return roles;
   }


### PR DESCRIPTION
## 🔥 Related Issue

> close: #447 

## 📝 Description

`JwtUtils`에서 `role`을 반환할 때 `SimpleGrantedAuthority` 객체에 담아서 반환해주고 있었는데,

<img width="549" alt="image" src="https://github.com/KEEPER31337/Homepage-Back-R2/assets/26597702/e6109eb0-c971-477a-952a-1c7b96a88c40">

`SimpleGrantedAuthority` 구현을 살펴보면 `hasText`가 아니면 exception을 반환하도록 되어 있습니다.

<img width="745" alt="image" src="https://github.com/KEEPER31337/Homepage-Back-R2/assets/26597702/486fd92c-4f0e-4105-80b1-084a7bff7401">

그런데 이 `SimpleGrantedAuthority` 객체의 exception을 반환하는 위치가 security의 filter단이라 WebMVC의 ControllerAdvice를 타지 못하는 것으로 보입니다. 그래서 아래와 같이 이상한 응답이 나가는 것으로 보여요.

![image](https://github.com/KEEPER31337/Homepage-Back-R2/assets/26597702/1475de35-91d2-4b32-9245-d74590283240)

권한이 없으면 권한이 없는대로 일단 진행하고, 각 API에서 401이나 403을 뱉는게 맞다고 판단해서 권한이 없어도 해당 filter는 통과하도록 수정했습니다.


## ⭐️ Review Request

> 리뷰어에게 전달하고 싶은 내용을 적어주세요.
